### PR TITLE
docs: plan domain-core

### DIFF
--- a/doc/dev/plans/domain-core/00-plan.md
+++ b/doc/dev/plans/domain-core/00-plan.md
@@ -1,0 +1,52 @@
+---
+plan: domain-core
+kind: global
+status: planning
+roadmap: "- [ ] **E1 — Domain core.** `Order` (+ lifecycle state machine), `Position`, `Fill`, `Signal`, `Instrument`, `Money` (Decimal), pure PnL/KPI, errors."
+release_on_done: false
+---
+
+# E1 — Domain core
+
+## Goal
+
+Build `trading_bot/domain/` — the **pure, zero-I/O, mypy-strict** vocabulary every
+other layer speaks: exact-Decimal money, venue-neutral instruments, the `Order`
+aggregate + lifecycle state machine, broker-confirmed `Fill`s, `Position` rebuilt
+from fills, the strategy `Signal`, pure PnL/KPI, and the error hierarchy. No async,
+no imports from `transport`/`brokers`/`storage`. The pre-2026 tree
+(`trading_bot/legacy/`) is mined for domain knowledge, not copied.
+
+## Decomposition
+
+1. **primitives** — `Money` (Decimal), `Instrument`/`Symbol` (+ Kraken normalisation), `errors`.
+2. **order** — `Order` + lifecycle state machine + order types (market/limit/stop-loss/best-limit).
+3. **fill-position** — `Fill` (PnL source of truth) + `Position.from_fills`.
+4. **signal** — `Signal` (venue-neutral strategy target) + delta-to-position.
+5. **performance** — pure PnL/KPI functions, KPI delegated to fynance.
+
+## Leaf checklist
+
+- [ ] 01 primitives — feat/domain-primitives — medium
+- [ ] 02 order — feat/domain-order — high (depends on 01)
+- [ ] 03 fill-position — feat/domain-fill-position — medium (depends on 02)
+- [ ] 04 signal — feat/domain-signal — low (depends on 01)
+- [ ] 05 performance — feat/domain-performance — high (depends on 03)
+
+## Dependencies
+
+- 02 depends on 01
+- 03 depends on 02
+- 04 depends on 01 (independent of 02/03 — may run alongside, but serial is the safe default)
+- 05 depends on 03
+
+## Done criteria
+
+- `trading_bot/domain/` exposes `money`, `instrument`, `errors`, `order`, `fill`,
+  `position`, `signal`, `performance` with a clean public `__init__`.
+- `mypy trading_bot/` passes **strict** on `trading_bot.domain.*`.
+- `ruff` + `pytest` green; domain tests cover state-machine transitions, Decimal
+  exactness, position-from-fills (incl. a flip), and PnL/KPI vs an independent
+  computation.
+- **No** `domain/` module imports `transport`/`brokers`/`storage`.
+- Last leaf (05) removes the E1 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/domain-core/01-primitives.md
+++ b/doc/dev/plans/domain-core/01-primitives.md
@@ -1,0 +1,67 @@
+---
+plan: domain-core/01-primitives
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/domain-primitives
+pr: ""
+---
+
+# Domain primitives — Money, Instrument, errors
+
+## Goal
+
+The zero-dependency base of the domain: exact-Decimal money/quantities,
+venue-neutral `Instrument`/`Symbol` with Kraken-style normalisation, and the
+domain error hierarchy. Pure, typed strict.
+
+## Files to change
+
+- `trading_bot/domain/__init__.py` — new; re-export the public names (keep import-pure).
+- `trading_bot/domain/money.py` — new; `Decimal`-backed price/quantity helpers.
+- `trading_bot/domain/instrument.py` — new; `Symbol(base, quote)` + `Instrument` + asset normalisation.
+- `trading_bot/domain/errors.py` — new; error hierarchy rooted at `TradingBotError`.
+- `trading_bot/tests/domain/__init__.py` — new (empty).
+- `trading_bot/tests/domain/test_money.py`, `test_instrument.py`, `test_errors.py` — new.
+
+## Steps
+
+1. **money.py**: construction from `str`/`int`/`Decimal` only — **guard against
+   `float`** (raise/round explicitly) to avoid binary error. Provide arithmetic and
+   `quantize(precision)` to a tick/lot size. No float leakage in public API.
+2. **instrument.py**: frozen `Symbol(base, quote)` (hashable, `__str__` = `BASE/QUOTE`);
+   `Instrument` carrying optional `price_precision`/`qty_precision`. Implement
+   `normalise(asset)` — `XBT→BTC`, `XDG→DOGE`, strip leading `X`/`Z` on 4-char legacy
+   codes — mining the exact table from `trading_bot/legacy/exchanges/API_kraken.py`
+   and the dccd Kraken adapter (`../Download_Crypto_Currencies_Data`, altname mapping).
+   Add `to_venue_symbol(venue)` to render back the venue's code.
+3. **errors.py**: `TradingBotError(Exception)` root; port the meaningful legacy ones
+   (`OrderError`, `OrderStatusError`, `InsufficientFunds`, `MissingOrder`) from
+   `legacy/_exceptions.py`, modernised (drop exchange coupling); add
+   `RiskLimitBreached`, `NoCapability` (forward use).
+4. Export the public API from `domain/__init__.py`.
+
+## Tests
+
+- `test_money`: `Decimal('0.1')+Decimal('0.2') == Decimal('0.3')`; float construction
+  guarded; `quantize` to a realistic Kraken tick; no float in results.
+- `test_instrument`: `'XXBTZUSD'→BTC/USD`, `'XETHZEUR'→ETH/EUR`, `XDG→DOGE`; frozen
+  equality/hashing; `to_venue_symbol` round-trip.
+- `test_errors`: every error subclasses `TradingBotError`; message formatting.
+
+## Verification on real data
+
+Pure layer (no live I/O). Build `Instrument`s from **real Kraken pair strings**
+found in `trading_bot/legacy` (e.g. `XXBTZUSD`, `XETHZEUR`) and assert normalisation;
+`quantize` Money against realistic Kraken tick sizes. `pytest trading_bot/tests/domain -q`
+green and `mypy trading_bot/` clean (strict on domain).
+
+## Closeout
+
+- CHANGELOG (Added): "Domain primitives — Decimal `money`, venue-neutral
+  `instrument` with Kraken normalisation, `errors` hierarchy."
+- ADR: none (mechanical foundation; the Decimal-money invariant is already in
+  `03-decisions.md`).
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/domain-core/02-order.md
+++ b/doc/dev/plans/domain-core/02-order.md
@@ -1,0 +1,63 @@
+---
+plan: domain-core/02-order
+kind: leaf
+status: planned
+complexity: high
+depends: [01]
+parallel: false
+branch: feat/domain-order
+pr: ""
+---
+
+# Order aggregate + lifecycle state machine
+
+## Goal
+
+The `Order` aggregate with an **explicit lifecycle state machine** and the order
+types (market, limit, stop-loss, best-limit). Pure, Decimal, mypy-strict. Replaces
+the legacy `{None, 'open', 'canceled', 'closed'}` ad-hoc status with a typed
+machine.
+
+## Files to change
+
+- `trading_bot/domain/order.py` — new.
+- `trading_bot/domain/__init__.py` — export the new names.
+- `trading_bot/tests/domain/test_order.py` — new.
+
+## Steps
+
+1. Enums: `OrderSide{BUY,SELL}`, `OrderType{MARKET,LIMIT,STOP_LOSS,BEST_LIMIT}`,
+   `OrderStatus{NEW,SUBMITTED,OPEN,PARTIALLY_FILLED,FILLED,CANCELLED,REJECTED}`.
+2. `Order` dataclass: `client_order_id` (mandatory — idempotency invariant),
+   `instrument`, `side`, `qty`, `type`, `limit_price?`, `stop_price?`, `filled_qty`,
+   `avg_fill_price`, `status`, `venue_order_id?`. All amounts via `domain.money`.
+   Construction validation: LIMIT requires `limit_price`; STOP_LOSS requires `stop_price`.
+3. **State machine**: an allowed-transition table + methods `submit()`,
+   `open(venue_order_id)`, `apply_fill(qty, price)`, `cancel()`, `reject(reason)`.
+   `apply_fill` accumulates `filled_qty` and recomputes `avg_fill_price` (Decimal),
+   moving to `PARTIALLY_FILLED`/`FILLED`. Port the legacy `check_vol_exec` tolerance
+   ("fully filled within tol") from `legacy/orders.py`. Illegal transitions raise
+   `OrderStatusError` (from `domain.errors`).
+4. Keep pure: no I/O, no async.
+
+## Tests
+
+- Legal path `NEW→SUBMITTED→OPEN→PARTIALLY_FILLED→FILLED`; `cancel` from `OPEN`;
+  `reject` from `SUBMITTED`.
+- Illegal transitions raise `OrderStatusError` (e.g. `apply_fill` on a `CANCELLED`).
+- `apply_fill` accumulates qty + weighted avg price **exactly** (Decimal);
+  full-fill-within-tolerance closes to `FILLED`.
+- Construction validation for each `OrderType`.
+
+## Verification on real data
+
+Pure layer. Replay a realistic partial-fill sequence (several partials summing to
+the order qty, taken from the legacy semantics) and assert final `status==FILLED`
+and `avg_fill_price` exact to the Decimal. `pytest` green, `mypy` strict clean.
+
+## Closeout
+
+- CHANGELOG (Added): "Order aggregate + lifecycle state machine and order types."
+- ADR: short note — "explicit `OrderStatus` state machine replaces the legacy
+  `{None,open,canceled,closed}`; idempotent `client_order_id` mandatory."
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/domain-core/03-fill-position.md
+++ b/doc/dev/plans/domain-core/03-fill-position.md
@@ -1,0 +1,56 @@
+---
+plan: domain-core/03-fill-position
+kind: leaf
+status: planned
+complexity: medium
+depends: [02]
+parallel: false
+branch: feat/domain-fill-position
+pr: ""
+---
+
+# Fill + Position (net from fills)
+
+## Goal
+
+`Fill` — a broker-confirmed execution, the **source of truth for PnL** — and
+`Position`, the net exposure per instrument rebuilt from fills (handles increases,
+partial closes, flips, and fee accrual). Pure, Decimal, mypy-strict.
+
+## Files to change
+
+- `trading_bot/domain/fill.py` — new.
+- `trading_bot/domain/position.py` — new.
+- `trading_bot/domain/__init__.py` — export.
+- `trading_bot/tests/domain/test_fill_position.py` — new.
+
+## Steps
+
+1. **fill.py**: frozen `Fill(fill_id, client_order_id, instrument, side, qty, price,
+   fee, ts)` — all amounts Decimal; immutable.
+2. **position.py**: `Position(instrument, net_qty, avg_entry_price, realised_pnl,
+   fees_paid)` + classmethod `from_fills(fills)` that folds an ordered fill sequence:
+   weighted-average entry on size increases; realise PnL on decreases/flips; accrue
+   fees. One instrument per position (reject mixed-instrument fills).
+3. Keep pure; deterministic.
+
+## Tests
+
+- Single buy → `net_qty`/`avg_entry_price` correct.
+- Buy then partial sell → realised PnL on the sold part; remaining qty/avg correct.
+- **Flip** (sell more than held) → net flips sign, realised PnL on the closed part,
+  new avg = the flipping fill's price.
+- Fees reduce realised PnL / accrue in `fees_paid`.
+- Mixed-instrument fills raise.
+
+## Verification on real data
+
+Pure layer. Feed a **realistic multi-fill sequence including a flip** and assert
+`net_qty`, `avg_entry_price`, `realised_pnl`, `fees_paid` against hand-computed
+Decimal expectations. `pytest` green, `mypy` strict clean.
+
+## Closeout
+
+- CHANGELOG (Added): "Fill and Position (net exposure rebuilt from fills)."
+- ADR: none (fills-as-source-of-truth already in `03-decisions.md`).
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/domain-core/04-signal.md
+++ b/doc/dev/plans/domain-core/04-signal.md
@@ -1,0 +1,52 @@
+---
+plan: domain-core/04-signal
+kind: leaf
+status: planned
+complexity: low
+depends: [01]
+parallel: false
+branch: feat/domain-signal
+pr: ""
+---
+
+# Signal (venue-neutral strategy target)
+
+## Goal
+
+`Signal` — a strategy's target expressed venue-neutrally (a normalised target
+exposure, or an explicit target quantity), plus the diff against a current
+`Position`. This is the value a future `StrategyRunner` turns into orders. Pure,
+typed.
+
+## Files to change
+
+- `trading_bot/domain/signal.py` — new.
+- `trading_bot/domain/__init__.py` — export.
+- `trading_bot/tests/domain/test_signal.py` — new.
+
+## Steps
+
+1. Frozen `Signal(instrument, target, ts, strength?)` where `target` is a normalised
+   exposure in `[-1, 1]` (short..long) **or** an explicit target qty (one mode,
+   validated). Decimal.
+2. `delta_to(position)` → the desired position change (used later by the order
+   router). Pure.
+3. Map the legacy `signal`/`delta_signal` concept (`legacy/performance.py`) onto
+   this type so PnL (leaf 05) and the runner share one vocabulary.
+
+## Tests
+
+- Target validation (reject `|target| > 1` in fractional mode; reject double mode).
+- `delta_to` computes the correct desired change from a `Position`.
+- Flat target (`0`) from a long position → full-close delta.
+
+## Verification on real data
+
+Pure layer. Build a series of signals over a realistic `Position` series and assert
+the deltas. `pytest` green, `mypy` strict clean.
+
+## Closeout
+
+- CHANGELOG (Added): "Signal domain type (venue-neutral target + delta-to-position)."
+- ADR: none.
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/domain-core/05-performance.md
+++ b/doc/dev/plans/domain-core/05-performance.md
@@ -1,0 +1,66 @@
+---
+plan: domain-core/05-performance
+kind: leaf
+status: planned
+complexity: high
+depends: [03]
+parallel: false
+branch: feat/domain-performance
+pr: ""
+---
+
+# Pure PnL / KPI performance functions
+
+## Goal
+
+The modern, pure `performance.py`: PnL / cumulative PnL / equity curve from a
+fill+price sequence, and KPI (Sharpe, Sortino, max drawdown, Calmar) **delegated to
+fynance**. No I/O. Replaces the legacy `_PnLI`/`_PnLR`/`_FullPnL`. This is the **last
+leaf** — it closes the E1 roadmap line.
+
+## Files to change
+
+- `trading_bot/domain/performance.py` — new.
+- `trading_bot/domain/__init__.py` — export.
+- `trading_bot/tests/domain/test_performance.py` — new.
+- `doc/dev/07-roadmap.md` — remove the E1 line. `doc/dev/06-status.md` — mark E1 done.
+
+## Steps
+
+1. Port the legacy `_PnLI` column model (`['price','returns','volume',
+   'exchanged_volume','position','signal','delta_signal','fee','PnL','cumPnL',
+   'value']` from `legacy/performance.py`) into **typed functions** over Fills +
+   a price series: `returns`, `exchanged_volume`, `position_series`, `fee_series`,
+   `pnl`, `cum_pnl`, `equity_curve`. Mine `_get_PnL`/`_get_returns`/`_get_fee`/
+   `_get_pos`. Numeric core deterministic; Decimal at money boundaries, float arrays
+   acceptable for the KPI series.
+2. KPI wrappers calling **fynance** (`sharpe`, `sortino`, `mdd`/max-drawdown,
+   `calmar`). fynance is a `[triptych]` dep — guard the import.
+3. **mypy strict vs untyped fynance**: `domain.*` is strict (enables
+   `no-untyped-call`), but fynance is untyped. Resolve by **either** a thin typed
+   wrapper module isolating the fynance calls **or** a narrow
+   `[[tool.mypy.overrides]] module = ["trading_bot.domain.performance"]` relaxation.
+   Pick one and record it in the ADR (the wrapper is preferred — keeps the rest of
+   the module strict).
+
+## Tests
+
+- Known fill+price sequence → expected `cum_pnl`/`equity` (hand-computed Decimal/float).
+- KPI parity: a known returns series → wrappers match calling fynance directly.
+- Fee impact on PnL.
+
+## Verification on real data
+
+Reconstruct PnL/equity for a realistic trade sequence over a **real-ish price path**
+(a `trading_bot/legacy/.../data_base/example` fixture, or a synthetic-but-realistic
+path) and compare the equity endpoint + Sharpe to an **independent** computation.
+`pytest` green; `mypy trading_bot/` clean (strict on domain, per the chosen
+fynance-typing resolution).
+
+## Closeout
+
+- CHANGELOG (Added): "Pure PnL/KPI performance functions (fynance-backed KPI)."
+- ADR: "KPI delegated to fynance; domain stays pure — fynance's untyped calls
+  isolated behind a typed wrapper (or narrow mypy override)."
+- Status/roadmap: **remove the E1 line** from `07-roadmap.md`; mark E1 done and the
+  domain layer present in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E1 — Domain core** (first epic of the rewrite). Lands the durable
plan on `develop` before any code, so each leaf branch inherits it.

## Goal

Build `trading_bot/domain/` — the pure, zero-I/O, mypy-strict vocabulary every
other layer speaks: exact-Decimal money, venue-neutral instruments, the `Order`
aggregate + lifecycle state machine, broker-confirmed `Fill`s, `Position` from
fills, the strategy `Signal`, pure PnL/KPI, and the error hierarchy. The legacy
tree is mined for domain knowledge, not copied.

## Leaves

- [ ] 01 primitives — feat/domain-primitives — medium
- [ ] 02 order — feat/domain-order — high (depends on 01)
- [ ] 03 fill-position — feat/domain-fill-position — medium (depends on 02)
- [ ] 04 signal — feat/domain-signal — low (depends on 01)
- [ ] 05 performance — feat/domain-performance — high (depends on 03)

After merge: `/execute-leaf domain-core next` runs leaf 01.