### PR TITLE
docs: opus for everything (override complexity→model)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,14 +111,11 @@ checklist) → … per leaf … → last leaf removes the roadmap line → `/rel
 
 The full plan-tree format lives in [`doc/dev/plans/README.md`](doc/dev/plans/README.md).
 
-**Model per task** (advisory — set via `/model`, or a plan leaf's `complexity`
-derives it: `low→haiku`, `medium→sonnet`, `high→opus`):
-
-| Model | For |
-|-------|-----|
-| `opus` | judgement, design, decisions, planning, review |
-| `sonnet` | implementation — code, tests, docstrings |
-| `haiku` | mechanical fan-out (doc scans, checklists) — spawn explicitly as a subagent |
+**Model: `opus`, always.** Per the maintainer's standing preference, **all work on
+this repo runs on `opus`** — interactive sessions *and* every spawned subagent
+(including `/execute-leaf`), regardless of a leaf's `complexity`. The `complexity`
+tag still records effort/risk and orders the execution queue, but it **does not
+downgrade the model**: treat `low | medium | high` all as `opus`.
 
 ## Architecture (target — hexagonal, mirrors dccd)
 

--- a/doc/dev/plans/README.md
+++ b/doc/dev/plans/README.md
@@ -82,11 +82,16 @@ if a non-trivial decision was made; status/roadmap edits).
 
 ## Complexity → execution model
 
-| `complexity` | model | for |
-|--------------|--------|-----|
-| `low` | `haiku` | mechanical fan-out — doc scans, checklists, trivial edits |
-| `medium` | `sonnet` | straightforward implementation against a precise spec |
-| `high` | `opus` | judgement, design, cross-cutting changes |
+**This repo runs every leaf on `opus`** (maintainer preference — see `CLAUDE.md`).
+The `complexity` tag below records **effort/risk** and orders the queue, but the
+execution model is `opus` regardless — the model column is the upstream default,
+overridden here:
+
+| `complexity` | effort/risk | model |
+|--------------|-------------|-------|
+| `low` | mechanical fan-out — doc scans, checklists, trivial edits | ~~haiku~~ → **opus** |
+| `medium` | straightforward implementation against a precise spec | ~~sonnet~~ → **opus** |
+| `high` | judgement, design, cross-cutting changes | **opus** |
 
 ## Dependencies & parallelism
 


### PR DESCRIPTION
Maintainer preference: **use `opus` for all work** — interactive sessions and every spawned subagent (incl. `/execute-leaf`), regardless of a leaf's `complexity`.

- `CLAUDE.md` — "Model per task" → **"Model: opus, always"**.
- `doc/dev/plans/README.md` — the complexity→model table now notes the `opus` override (complexity = effort/risk + queue order only).

The `complexity` tag is kept (it orders the execution queue) but no longer selects the model.