### PR TITLE
feat: domain primitives (Money, Instrument, errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Claude Code developer workflow: `CLAUDE.md`, `.claude/` (workflow.json, hooks,
   settings), and the `doc/dev/` orientation pack + plan-tree scaffold.
 - Git Flow (`develop` / `master`) with `CONTRIBUTING.md` and a `pre-push` hook.
+- Domain primitives — Decimal `money` (float-guarded), venue-neutral `instrument`
+  with Kraken normalisation, and the `errors` hierarchy. (#7)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,22 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Decimal-guarded Money & Kraken normalisation in `domain/` (PR #7)
+
+**Decision.** `domain/money.py` accepts only `str`/`int`/`Decimal`; a `float`
+(and `bool`) raises `TypeError`. The single sanctioned float entry point is
+`from_float()`, which routes through `str(value)` to get the shortest
+round-tripping decimal (`from_float(0.1) == Decimal("0.1")`). `quantize` defaults
+to `ROUND_DOWN` so an order never overshoots a tick/lot. `domain/instrument.py`
+normalises Kraken assets with the alias table **mined from the dccd Kraken
+adapter** (`XBT→BTC`, `XDG→DOGE`) plus Kraken's legacy 4-char `X`/`Z` prefix rule.
+
+**Why.** Money correctness is a core invariant — `Decimal(0.1)` already carries
+binary error, so floats must never enter silently. Reusing dccd's table keeps the
+two repos consistent instead of inventing a divergent mapping.
+
+---
+
 ### 2026-06-20 Bootstrap the dev environment & Claude workflow (Phase 0)
 
 **Decision.** Bring the repo up to the dccd/fynance standard *before* writing any

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,9 +10,11 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**The rewrite itself has not started.** The new hexagonal layers
-(`domain/`, `transport/`, `brokers/`, `storage/`, `application/`, `interfaces/`)
-do **not** exist yet — only the legacy reference tree and the package skeleton do.
+**The rewrite has begun.** `domain/` exists with the primitives — `money`
+(Decimal, float-guarded), `instrument` (Kraken normalisation), `errors` (E1 leaf
+01 landed). The remaining domain leaves (order, fill/position, signal, performance)
+and the later layers (`transport`, `brokers`, `storage`, `application`,
+`interfaces`) are pending — see `07-roadmap.md` / `08-program-plan.md`.
 
 ## Done
 

--- a/doc/dev/plans/domain-core/00-plan.md
+++ b/doc/dev/plans/domain-core/00-plan.md
@@ -27,7 +27,7 @@ no imports from `transport`/`brokers`/`storage`. The pre-2026 tree
 
 ## Leaf checklist
 
-- [ ] 01 primitives — feat/domain-primitives — medium
+- [x] 01 primitives — feat/domain-primitives — medium
 - [ ] 02 order — feat/domain-order — high (depends on 01)
 - [ ] 03 fill-position — feat/domain-fill-position — medium (depends on 02)
 - [ ] 04 signal — feat/domain-signal — low (depends on 01)

--- a/doc/dev/plans/domain-core/01-primitives.md
+++ b/doc/dev/plans/domain-core/01-primitives.md
@@ -1,7 +1,7 @@
 ---
 plan: domain-core/01-primitives
 kind: leaf
-status: planned
+status: executing
 complexity: medium
 depends: []
 parallel: false

--- a/doc/dev/plans/domain-core/01-primitives.md
+++ b/doc/dev/plans/domain-core/01-primitives.md
@@ -1,12 +1,12 @@
 ---
 plan: domain-core/01-primitives
 kind: leaf
-status: executing
+status: done
 complexity: medium
 depends: []
 parallel: false
 branch: feat/domain-primitives
-pr: ""
+pr: "#7"
 ---
 
 # Domain primitives — Money, Instrument, errors

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -1,0 +1,67 @@
+"""Pure domain primitives for the trading bot.
+
+This package is the zero-dependency base of the domain: it is **pure,
+synchronous and free of I/O**, and must never import from ``transport``,
+``brokers``, ``storage`` or any I/O library. Everything here is exactly typed.
+
+Public surface:
+
+* money — exact :class:`~decimal.Decimal` price/quantity helpers
+  (:data:`~trading_bot.domain.money.Money`, :func:`~trading_bot.domain.money.money`,
+  :func:`~trading_bot.domain.money.from_float`,
+  :func:`~trading_bot.domain.money.quantize`, ...);
+* instrument — venue-neutral :class:`~trading_bot.domain.instrument.Symbol` /
+  :class:`~trading_bot.domain.instrument.Instrument` with Kraken normalisation;
+* errors — the :class:`~trading_bot.domain.errors.TradingBotError` hierarchy.
+"""
+
+from __future__ import annotations
+
+from trading_bot.domain.errors import (
+    InsufficientFunds,
+    MissingOrder,
+    NoCapability,
+    OrderError,
+    OrderStatusError,
+    RiskLimitBreached,
+    TradingBotError,
+)
+from trading_bot.domain.instrument import (
+    Instrument,
+    Symbol,
+    normalise,
+    parse_kraken_pair,
+)
+from trading_bot.domain.money import (
+    Money,
+    add,
+    from_float,
+    money,
+    mul,
+    quantize,
+    sub,
+)
+
+__all__ = [
+    # money
+    "Money",
+    "money",
+    "from_float",
+    "quantize",
+    "add",
+    "sub",
+    "mul",
+    # instrument
+    "Symbol",
+    "Instrument",
+    "normalise",
+    "parse_kraken_pair",
+    # errors
+    "TradingBotError",
+    "OrderError",
+    "OrderStatusError",
+    "MissingOrder",
+    "InsufficientFunds",
+    "RiskLimitBreached",
+    "NoCapability",
+]

--- a/trading_bot/domain/errors.py
+++ b/trading_bot/domain/errors.py
@@ -1,0 +1,147 @@
+"""Domain error hierarchy.
+
+Every error raised by the pure domain (and, by convention, the layers built on
+top of it) descends from :class:`TradingBotError`. The hierarchy is venue- and
+transport-neutral: errors carry plain data (ids, assets, amounts) and format
+their own messages — they never reach for an exchange client or an I/O object.
+
+Ported and modernised from the pre-2026 ``trading_bot/legacy/_exceptions.py``,
+with the exchange coupling dropped (the legacy errors reached into live
+``order`` objects to slice ``order.pair[1:4]``; here the caller passes the
+already-decoded values).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+__all__ = [
+    "TradingBotError",
+    "OrderError",
+    "OrderStatusError",
+    "MissingOrder",
+    "InsufficientFunds",
+    "RiskLimitBreached",
+    "NoCapability",
+]
+
+
+class TradingBotError(Exception):
+    """Root of every error raised by the trading bot domain."""
+
+
+class OrderError(TradingBotError):
+    """An operation on a specific order failed.
+
+    Parameters
+    ----------
+    order_id : str
+        Identifier of the offending order.
+    msg : str, optional
+        Human-readable detail. When omitted a generic message is built.
+
+    """
+
+    def __init__(self, order_id: str, msg: str | None = None) -> None:
+        self.order_id = order_id
+        detail = msg if msg is not None else "order operation failed"
+        super().__init__(f"[order {order_id}] {detail}")
+
+
+class OrderStatusError(OrderError):
+    """An action is not allowed by the order's current status.
+
+    Parameters
+    ----------
+    order_id : str
+        Identifier of the offending order.
+    status : str
+        The current status that forbids the action.
+    action : str
+        The action that was attempted.
+
+    """
+
+    def __init__(self, order_id: str, status: str, action: str) -> None:
+        self.status = status
+        self.action = action
+        super().__init__(order_id, f"cannot {action} order with status {status!r}")
+
+
+class MissingOrder(TradingBotError):
+    """A referenced order does not exist (locally or on the venue).
+
+    Parameters
+    ----------
+    order_id : str
+        Identifier of the order that could not be found.
+
+    """
+
+    def __init__(self, order_id: str) -> None:
+        self.order_id = order_id
+        super().__init__(f"order {order_id} is missing")
+
+
+class InsufficientFunds(TradingBotError):
+    """The available balance cannot cover the requested operation.
+
+    Parameters
+    ----------
+    asset : str
+        The asset that is short (canonical code, e.g. ``"USD"``).
+    required : Decimal
+        Amount needed to perform the operation.
+    available : Decimal
+        Amount actually available.
+
+    """
+
+    def __init__(self, asset: str, required: Decimal, available: Decimal) -> None:
+        self.asset = asset
+        self.required = required
+        self.available = available
+        super().__init__(
+            f"insufficient {asset}: need {required}, only {available} available"
+        )
+
+
+class RiskLimitBreached(TradingBotError):
+    """A risk limit (exposure, drawdown, position size, ...) was breached.
+
+    Parameters
+    ----------
+    limit : str
+        Name of the limit that was breached (e.g. ``"max_position"``).
+    value : Decimal
+        The observed value.
+    threshold : Decimal
+        The limit that was exceeded.
+
+    """
+
+    def __init__(self, limit: str, value: Decimal, threshold: Decimal) -> None:
+        self.limit = limit
+        self.value = value
+        self.threshold = threshold
+        super().__init__(
+            f"risk limit {limit!r} breached: {value} exceeds {threshold}"
+        )
+
+
+class NoCapability(TradingBotError):
+    """A venue/adapter was asked for a capability it does not provide.
+
+    Parameters
+    ----------
+    venue : str
+        The venue or adapter that lacks the capability.
+    capability : str
+        The missing capability (e.g. ``"margin"``, ``"stream_orderbook"``).
+
+    """
+
+    def __init__(self, venue: str, capability: str) -> None:
+        self.venue = venue
+        self.capability = capability
+        super().__init__(f"{venue} has no capability {capability!r}")

--- a/trading_bot/domain/instrument.py
+++ b/trading_bot/domain/instrument.py
@@ -1,0 +1,273 @@
+"""Venue-neutral :class:`Symbol` / :class:`Instrument` + Kraken normalisation.
+
+The domain speaks in *canonical* assets (``BTC``, ``ETH``, ``USD``, ``DOGE``)
+and canonical pairs (``BTC/USD``). Venues use their own codes; Kraken in
+particular has two layers of weirdness:
+
+* an ``X`` prefix on crypto asset codes and a ``Z`` prefix on fiat codes in its
+  *legacy* 4-character form — ``XXBT``, ``XETH``, ``ZUSD``, ``ZEUR`` — so that a
+  legacy pair string looks like ``XXBTZUSD`` or ``XETHZEUR``;
+* two ticker aliases that differ from the rest of the world: ``XBT`` for Bitcoin
+  and ``XDG`` for Dogecoin.
+
+:func:`normalise` collapses any of those venue codes to the canonical asset.
+:func:`parse_kraken_pair` turns a Kraken pair string into a :class:`Symbol`, and
+:meth:`Symbol.to_venue_symbol` renders a canonical symbol back to a venue's code.
+
+The alias table (``XBT→BTC``, ``XDG→DOGE``) is the one used by the **dccd**
+Kraken adapter (``dccd/sources/kraken.py`` ``_KRAKEN_ALIASES`` and
+``dccd/domain/symbol.py`` ``_ALIASES``); the X/Z legacy-prefix rule is Kraken's
+documented asset-naming scheme. This module is pure: no I/O, no network — it
+never calls Kraken's ``/Assets`` or ``/AssetPairs`` endpoints.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "Symbol",
+    "Instrument",
+    "normalise",
+    "parse_kraken_pair",
+]
+
+# --- Kraken asset normalisation -------------------------------------------- #
+
+# Ticker aliases: venue code -> canonical code. Mined from the dccd Kraken
+# adapter (BTC<->XBT, DOGE<->XDG). Keys are the *stripped* codes (no X/Z
+# prefix), because we strip the legacy prefix first.
+_KRAKEN_TO_CANONICAL: dict[str, str] = {
+    "XBT": "BTC",
+    "XDG": "DOGE",
+}
+# Inverse, for rendering a canonical asset back to Kraken's altname.
+_CANONICAL_TO_KRAKEN: dict[str, str] = {
+    canon: venue for venue, canon in _KRAKEN_TO_CANONICAL.items()
+}
+
+# Known fiat codes (canonical, 3-char). Kraken prefixes these with ``Z`` in its
+# legacy 4-char form. Used to split a concatenated legacy pair on the boundary.
+_FIAT: frozenset[str] = frozenset(
+    {"USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF"}
+)
+
+
+def normalise(asset: str) -> str:
+    """Normalise a single venue asset code to its canonical form.
+
+    Rules, applied in order:
+
+    1. upper-case and strip surrounding whitespace;
+    2. on a **4-character** legacy code, strip a leading ``X`` (crypto) or
+       ``Z`` (fiat) prefix — ``XXBT→XBT``, ``XETH→ETH``, ``ZUSD→USD``,
+       ``ZEUR→EUR``;
+    3. apply ticker aliases — ``XBT→BTC``, ``XDG→DOGE``.
+
+    Codes that are already canonical (``BTC``, ``ETH``, ``USD``, ``USDT``, ...)
+    pass through unchanged.
+
+    Parameters
+    ----------
+    asset : str
+        A venue asset code (``"XXBT"``, ``"ZEUR"``, ``"XBT"``, ``"ETH"``, ...).
+
+    Returns
+    -------
+    str
+        The canonical asset code.
+
+    Examples
+    --------
+    >>> normalise("XXBT")
+    'BTC'
+    >>> normalise("ZUSD")
+    'USD'
+    >>> normalise("XDG")
+    'DOGE'
+    >>> normalise("usdt")
+    'USDT'
+
+    """
+    code = asset.upper().strip()
+    # Strip the legacy X/Z prefix only on 4-char codes (XXBT, XETH, ZUSD...).
+    # Modern altnames (USDT, TRX) and bare aliases (XBT, XDG) are 3-4 chars
+    # without a doubled/fiat prefix, so guard on length == 4 and a known prefix.
+    if len(code) == 4 and code[0] in ("X", "Z"):
+        stripped = code[1:]
+        # Only strip when it actually yields a known crypto (X-prefixed) or a
+        # known fiat (Z-prefixed); otherwise keep the original (e.g. a genuine
+        # 4-letter ticker would be left intact — none in our universe).
+        if code[0] == "Z" and stripped in _FIAT:
+            code = stripped
+        elif code[0] == "X":
+            code = stripped
+    return _KRAKEN_TO_CANONICAL.get(code, code)
+
+
+def _to_kraken_asset(canonical: str) -> str:
+    """Render a canonical asset to its Kraken altname (``BTC→XBT``)."""
+    return _CANONICAL_TO_KRAKEN.get(canonical, canonical)
+
+
+@dataclass(frozen=True, slots=True)
+class Symbol:
+    """A canonical, venue-neutral trading pair.
+
+    Frozen and hashable, so symbols are safe as dict keys / set members.
+    ``base`` and ``quote`` are stored canonicalised and upper-cased.
+
+    Parameters
+    ----------
+    base : str
+        The base asset (what is bought/sold), e.g. ``"BTC"``.
+    quote : str
+        The quote asset (the price currency), e.g. ``"USD"``.
+
+    Examples
+    --------
+    >>> str(Symbol("BTC", "USD"))
+    'BTC/USD'
+    >>> Symbol("xbt", "zusd") == Symbol("BTC", "USD")
+    True
+
+    """
+
+    base: str
+    quote: str
+
+    def __post_init__(self) -> None:
+        """Canonicalise both legs in place (frozen-safe via ``object.__setattr__``)."""
+        object.__setattr__(self, "base", normalise(self.base))
+        object.__setattr__(self, "quote", normalise(self.quote))
+
+    def __str__(self) -> str:
+        """``BASE/QUOTE``."""
+        return f"{self.base}/{self.quote}"
+
+    def to_venue_symbol(self, venue: str) -> str:
+        """Render this canonical symbol back to a venue's pair code.
+
+        Parameters
+        ----------
+        venue : str
+            The venue name. Only ``"kraken"`` (case-insensitive) has a bespoke
+            rendering today (altname form, ``XBTUSD`` / ``ETHXBT``); any other
+            venue gets the concatenated canonical legs.
+
+        Returns
+        -------
+        str
+            The venue pair code.
+
+        Examples
+        --------
+        >>> Symbol("BTC", "USD").to_venue_symbol("kraken")
+        'XBTUSD'
+        >>> Symbol("ETH", "BTC").to_venue_symbol("kraken")
+        'ETHXBT'
+
+        """
+        if venue.lower() == "kraken":
+            return f"{_to_kraken_asset(self.base)}{_to_kraken_asset(self.quote)}"
+        return f"{self.base}{self.quote}"
+
+
+def parse_kraken_pair(pair: str) -> Symbol:
+    """Parse a Kraken pair string into a canonical :class:`Symbol`.
+
+    Handles both the legacy X/Z-prefixed form (``XXBTZUSD``, ``XETHZEUR``) and
+    the modern altname form (``XBTUSD``, ``ETHUSD``, ``ETHXBT``).
+
+    The split strategy:
+
+    * a separator (``/``, ``-``, ``_``) is honoured if present;
+    * an 8-char legacy pair splits 4/4 (``XXBT`` + ``ZUSD``);
+    * otherwise the quote is taken as a trailing known fiat (3-char) or a
+      trailing ``XBT``/``XXBT`` crypto-quote, with the remainder as base.
+
+    Parameters
+    ----------
+    pair : str
+        A Kraken pair string.
+
+    Returns
+    -------
+    Symbol
+        The canonical symbol.
+
+    Raises
+    ------
+    ValueError
+        If the pair cannot be split into a base and a quote.
+
+    Examples
+    --------
+    >>> str(parse_kraken_pair("XXBTZUSD"))
+    'BTC/USD'
+    >>> str(parse_kraken_pair("XETHZEUR"))
+    'ETH/EUR'
+    >>> str(parse_kraken_pair("ETHUSD"))
+    'ETH/USD'
+    >>> str(parse_kraken_pair("ETHXBT"))
+    'ETH/BTC'
+
+    """
+    raw = pair.strip()
+    # Explicit separator wins.
+    for sep in ("/", "-", "_"):
+        if sep in raw:
+            base, quote = raw.split(sep, 1)
+            return Symbol(base, quote)
+
+    code = raw.upper()
+    # Legacy 8-char form: XXBT + ZUSD, XETH + ZEUR, ... split 4/4.
+    if len(code) == 8 and code[0] in ("X", "Z") and code[4] in ("X", "Z"):
+        return Symbol(code[:4], code[4:])
+
+    # Altname form: try a trailing fiat quote (after normalisation), then a
+    # trailing crypto quote (XBT). Longest plausible quote first.
+    for qlen in (4, 3):
+        if len(code) > qlen:
+            base_raw, quote_raw = code[:-qlen], code[-qlen:]
+            quote = normalise(quote_raw)
+            if quote in _FIAT or quote in {"BTC", "USDT", "USDC", "DAI"}:
+                return Symbol(base_raw, quote_raw)
+
+    raise ValueError(f"cannot parse Kraken pair {pair!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class Instrument:
+    """A tradeable instrument: a :class:`Symbol` plus venue trading metadata.
+
+    Frozen and hashable. ``price_precision`` / ``qty_precision`` are the number
+    of decimal places the venue accepts for price and quantity respectively;
+    both are optional (unknown until the venue's metadata is loaded).
+
+    Parameters
+    ----------
+    symbol : Symbol
+        The canonical pair.
+    price_precision : int, optional
+        Number of decimal places allowed for the price.
+    qty_precision : int, optional
+        Number of decimal places allowed for the quantity / volume.
+
+    Examples
+    --------
+    >>> inst = Instrument(Symbol("BTC", "USD"), price_precision=1, qty_precision=8)
+    >>> str(inst)
+    'BTC/USD'
+    >>> inst.price_precision
+    1
+
+    """
+
+    symbol: Symbol
+    price_precision: int | None = None
+    qty_precision: int | None = None
+
+    def __str__(self) -> str:
+        """The underlying symbol's ``BASE/QUOTE``."""
+        return str(self.symbol)

--- a/trading_bot/domain/money.py
+++ b/trading_bot/domain/money.py
@@ -1,0 +1,173 @@
+"""Exact, ``Decimal``-backed money and quantity helpers.
+
+Money in this domain is *always* a :class:`decimal.Decimal`. Binary ``float``
+cannot represent decimal fractions exactly (``0.1 + 0.2 != 0.3``), so prices,
+sizes and fees must never round-trip through ``float``. The helpers here make
+that invariant enforceable:
+
+* :func:`money` constructs a ``Decimal`` from ``str`` / ``int`` / ``Decimal``
+  only and **rejects ``float``** outright — the binary error would already be
+  baked into the bits before we ever saw the value. A caller that genuinely
+  starts from a ``float`` (e.g. a number off the wire) must opt in explicitly
+  via :func:`from_float`, which routes through ``str`` so the *shortest*
+  round-tripping decimal is taken.
+* :func:`quantize` snaps a value to a venue tick / lot size, defaulting to
+  banker's-unsafe-free ``ROUND_DOWN`` (never hand a venue more size/price than
+  intended).
+
+The public API takes and returns ``Decimal`` exclusively — no ``float`` leaks.
+"""
+
+from __future__ import annotations
+
+from decimal import ROUND_DOWN, ROUND_HALF_EVEN, Decimal
+
+__all__ = [
+    "Money",
+    "money",
+    "from_float",
+    "quantize",
+    "add",
+    "sub",
+    "mul",
+]
+
+#: Public alias for the money type. All monetary values are exact decimals.
+Money = Decimal
+
+# Accepted inputs for exact construction. ``bool`` is an ``int`` subclass but
+# is meaningless as money, so it is rejected explicitly below.
+_Exact = str | int | Decimal
+
+
+def money(value: _Exact) -> Money:
+    """Build an exact :class:`~decimal.Decimal` from ``str``/``int``/``Decimal``.
+
+    Parameters
+    ----------
+    value : str or int or Decimal
+        The monetary value. Strings are parsed exactly (``money("0.1")`` is
+        exactly one tenth). ``float`` is rejected — use :func:`from_float`.
+
+    Returns
+    -------
+    Decimal
+        The exact value.
+
+    Raises
+    ------
+    TypeError
+        If ``value`` is a ``float`` (or ``bool``), or any other unsupported
+        type. Floats are refused because the binary rounding error is already
+        present in the bits.
+    decimal.InvalidOperation
+        If a ``str`` does not parse as a number.
+
+    Examples
+    --------
+    >>> money("0.1") + money("0.2") == money("0.3")
+    True
+    >>> money(5)
+    Decimal('5')
+
+    """
+    if isinstance(value, bool):
+        raise TypeError("money() does not accept bool")
+    if isinstance(value, float):
+        raise TypeError(
+            "money() refuses float to avoid binary rounding error; "
+            "pass a str/int/Decimal, or use from_float() to opt in explicitly"
+        )
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, (str, int)):
+        return Decimal(value)
+    raise TypeError(f"cannot build Money from {type(value).__name__}")
+
+
+def from_float(value: float) -> Money:
+    """Explicitly convert a ``float`` to :class:`Money` via its ``str`` form.
+
+    This is the *only* sanctioned float entry point. Going through ``str``
+    yields the shortest decimal that round-trips the float (e.g.
+    ``from_float(0.1) == Decimal("0.1")``), which is almost always the value a
+    human meant — far better than ``Decimal(0.1)``'s 55-digit tail.
+
+    Use this only at boundaries where the value genuinely arrived as a float;
+    prefer keeping money as :class:`Decimal` end to end.
+
+    Parameters
+    ----------
+    value : float
+        The float to convert.
+
+    Returns
+    -------
+    Decimal
+        The shortest decimal that round-trips ``value``.
+
+    Examples
+    --------
+    >>> from_float(0.1)
+    Decimal('0.1')
+
+    """
+    if not isinstance(value, float):
+        raise TypeError("from_float() expects a float")
+    return Decimal(str(value))
+
+
+def quantize(value: Money, tick: Money, *, rounding: str = ROUND_DOWN) -> Money:
+    """Snap ``value`` to a multiple of ``tick`` (a venue tick or lot size).
+
+    Parameters
+    ----------
+    value : Decimal
+        The value to quantise.
+    tick : Decimal
+        The tick / lot size, e.g. ``Decimal("0.00001")`` for a Kraken price
+        tick or ``Decimal("0.00000001")`` for a satoshi lot. Must be positive.
+    rounding : str, optional
+        A :mod:`decimal` rounding mode. Defaults to ``ROUND_DOWN`` so an order
+        never overshoots the intended price/size.
+
+    Returns
+    -------
+    Decimal
+        ``value`` rounded to the nearest multiple of ``tick`` (toward zero by
+        default), carrying the same exponent as ``tick``.
+
+    Raises
+    ------
+    ValueError
+        If ``tick`` is not strictly positive.
+
+    Examples
+    --------
+    >>> quantize(money("27123.456789"), money("0.1"))
+    Decimal('27123.4')
+    >>> quantize(money("0.123456789"), money("0.00000001"))
+    Decimal('0.12345678')
+
+    """
+    if tick <= 0:
+        raise ValueError(f"tick must be positive, got {tick}")
+    snapped = (value / tick).quantize(Decimal(1), rounding=rounding) * tick
+    # Re-quantize to the tick's exponent so the result's scale matches the tick
+    # exactly (e.g. 0.1 -> "0.1", not "0.10000...").
+    return snapped.quantize(tick, rounding=ROUND_HALF_EVEN)
+
+
+def add(a: Money, b: Money) -> Money:
+    """Exact addition of two :class:`Money` values."""
+    return a + b
+
+
+def sub(a: Money, b: Money) -> Money:
+    """Exact subtraction ``a - b`` of two :class:`Money` values."""
+    return a - b
+
+
+def mul(a: Money, b: Money) -> Money:
+    """Exact multiplication of two :class:`Money` values."""
+    return a * b

--- a/trading_bot/tests/domain/test_errors.py
+++ b/trading_bot/tests/domain/test_errors.py
@@ -1,0 +1,92 @@
+"""Tests for the domain error hierarchy."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from trading_bot.domain.errors import (
+    InsufficientFunds,
+    MissingOrder,
+    NoCapability,
+    OrderError,
+    OrderStatusError,
+    RiskLimitBreached,
+    TradingBotError,
+)
+
+ALL_ERRORS = [
+    OrderError,
+    OrderStatusError,
+    MissingOrder,
+    InsufficientFunds,
+    RiskLimitBreached,
+    NoCapability,
+]
+
+
+class TestHierarchy:
+    @pytest.mark.parametrize("err", ALL_ERRORS)
+    def test_all_subclass_root(self, err: type[Exception]) -> None:
+        assert issubclass(err, TradingBotError)
+
+    def test_root_is_exception(self) -> None:
+        assert issubclass(TradingBotError, Exception)
+
+    def test_order_status_error_is_order_error(self) -> None:
+        assert issubclass(OrderStatusError, OrderError)
+
+
+class TestMessages:
+    def test_order_error_default_message(self) -> None:
+        err = OrderError("OID-1")
+        assert "OID-1" in str(err)
+        assert err.order_id == "OID-1"
+
+    def test_order_error_custom_message(self) -> None:
+        err = OrderError("OID-2", "rejected by venue")
+        assert "OID-2" in str(err)
+        assert "rejected by venue" in str(err)
+
+    def test_order_status_error_message(self) -> None:
+        err = OrderStatusError("OID-3", status="filled", action="cancel")
+        assert "cancel" in str(err)
+        assert "filled" in str(err)
+        assert err.status == "filled"
+        assert err.action == "cancel"
+
+    def test_missing_order_message(self) -> None:
+        err = MissingOrder("OID-4")
+        assert "OID-4" in str(err)
+        assert "missing" in str(err)
+        assert err.order_id == "OID-4"
+
+    def test_insufficient_funds_message(self) -> None:
+        err = InsufficientFunds("USD", Decimal("100"), Decimal("40"))
+        assert "USD" in str(err)
+        assert "100" in str(err)
+        assert "40" in str(err)
+        assert err.asset == "USD"
+        assert err.required == Decimal("100")
+        assert err.available == Decimal("40")
+
+    def test_risk_limit_breached_message(self) -> None:
+        err = RiskLimitBreached("max_position", Decimal("5"), Decimal("3"))
+        assert "max_position" in str(err)
+        assert "5" in str(err)
+        assert "3" in str(err)
+        assert err.limit == "max_position"
+
+    def test_no_capability_message(self) -> None:
+        err = NoCapability("kraken", "margin")
+        assert "kraken" in str(err)
+        assert "margin" in str(err)
+        assert err.venue == "kraken"
+        assert err.capability == "margin"
+
+
+class TestRaisability:
+    def test_can_catch_via_root(self) -> None:
+        with pytest.raises(TradingBotError):
+            raise InsufficientFunds("EUR", Decimal("1"), Decimal("0"))

--- a/trading_bot/tests/domain/test_instrument.py
+++ b/trading_bot/tests/domain/test_instrument.py
@@ -1,0 +1,129 @@
+"""Tests for venue-neutral Symbol/Instrument and Kraken normalisation."""
+
+from __future__ import annotations
+
+import pytest
+
+from trading_bot.domain.instrument import (
+    Instrument,
+    Symbol,
+    normalise,
+    parse_kraken_pair,
+)
+
+# Real Kraken pair strings (legacy X/Z-prefixed form) and their canonical map.
+REAL_KRAKEN_PAIRS = [
+    ("XXBTZUSD", "BTC", "USD"),
+    ("XETHZEUR", "ETH", "EUR"),
+    ("XXBTZEUR", "BTC", "EUR"),
+    ("XETHZUSD", "ETH", "USD"),
+    ("XLTCZUSD", "LTC", "USD"),
+    ("XXRPZUSD", "XRP", "USD"),
+    ("XETHXXBT", "ETH", "BTC"),
+]
+
+
+class TestNormalise:
+    def test_xbt_alias(self) -> None:
+        assert normalise("XBT") == "BTC"
+        assert normalise("XXBT") == "BTC"
+
+    def test_xdg_alias(self) -> None:
+        assert normalise("XDG") == "DOGE"
+        assert normalise("XXDG") == "DOGE"
+
+    def test_fiat_z_prefix_stripped(self) -> None:
+        assert normalise("ZUSD") == "USD"
+        assert normalise("ZEUR") == "EUR"
+        assert normalise("ZGBP") == "GBP"
+
+    def test_crypto_x_prefix_stripped(self) -> None:
+        assert normalise("XETH") == "ETH"
+        assert normalise("XLTC") == "LTC"
+        assert normalise("XXRP") == "XRP"
+
+    def test_canonical_passthrough(self) -> None:
+        assert normalise("BTC") == "BTC"
+        assert normalise("ETH") == "ETH"
+        assert normalise("USDT") == "USDT"
+
+    def test_case_and_whitespace_insensitive(self) -> None:
+        assert normalise("  xxbt ") == "BTC"
+        assert normalise("zusd") == "USD"
+
+
+class TestParseKrakenPair:
+    @pytest.mark.parametrize("pair,base,quote", REAL_KRAKEN_PAIRS)
+    def test_real_legacy_pairs(self, pair: str, base: str, quote: str) -> None:
+        sym = parse_kraken_pair(pair)
+        assert sym == Symbol(base, quote)
+        assert str(sym) == f"{base}/{quote}"
+
+    def test_altname_form(self) -> None:
+        assert parse_kraken_pair("ETHUSD") == Symbol("ETH", "USD")
+        assert parse_kraken_pair("XBTUSD") == Symbol("BTC", "USD")
+        assert parse_kraken_pair("ETHXBT") == Symbol("ETH", "BTC")
+
+    def test_explicit_separator(self) -> None:
+        assert parse_kraken_pair("BTC/USD") == Symbol("BTC", "USD")
+        assert parse_kraken_pair("XBT-USD") == Symbol("BTC", "USD")
+
+    def test_unparseable_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_kraken_pair("ZZ")
+
+
+class TestSymbol:
+    def test_str_is_base_slash_quote(self) -> None:
+        assert str(Symbol("BTC", "USD")) == "BTC/USD"
+
+    def test_canonicalises_legs(self) -> None:
+        assert Symbol("XBT", "ZUSD") == Symbol("BTC", "USD")
+        assert Symbol("xxbt", "zeur") == Symbol("BTC", "EUR")
+
+    def test_frozen_immutable(self) -> None:
+        sym = Symbol("BTC", "USD")
+        with pytest.raises(Exception):
+            sym.base = "ETH"  # type: ignore[misc]
+
+    def test_hashable_and_equal(self) -> None:
+        a = Symbol("BTC", "USD")
+        b = Symbol("xbt", "zusd")
+        assert a == b
+        assert hash(a) == hash(b)
+        assert {a, b} == {a}
+
+    def test_to_venue_symbol_kraken(self) -> None:
+        assert Symbol("BTC", "USD").to_venue_symbol("kraken") == "XBTUSD"
+        assert Symbol("ETH", "BTC").to_venue_symbol("kraken") == "ETHXBT"
+        assert Symbol("DOGE", "USD").to_venue_symbol("kraken") == "XDGUSD"
+
+    def test_to_venue_symbol_generic(self) -> None:
+        assert Symbol("BTC", "USDT").to_venue_symbol("binance") == "BTCUSDT"
+
+    def test_to_venue_symbol_round_trip(self) -> None:
+        # Render to Kraken altname then parse back to the same canonical symbol.
+        for _, base, quote in REAL_KRAKEN_PAIRS:
+            sym = Symbol(base, quote)
+            rendered = sym.to_venue_symbol("kraken")
+            assert parse_kraken_pair(rendered) == sym
+
+
+class TestInstrument:
+    def test_carries_symbol_and_precisions(self) -> None:
+        inst = Instrument(Symbol("BTC", "USD"), price_precision=1, qty_precision=8)
+        assert inst.symbol == Symbol("BTC", "USD")
+        assert inst.price_precision == 1
+        assert inst.qty_precision == 8
+        assert str(inst) == "BTC/USD"
+
+    def test_precisions_optional(self) -> None:
+        inst = Instrument(Symbol("ETH", "EUR"))
+        assert inst.price_precision is None
+        assert inst.qty_precision is None
+
+    def test_frozen_and_hashable(self) -> None:
+        inst = Instrument(Symbol("BTC", "USD"), price_precision=1)
+        assert isinstance(hash(inst), int)
+        with pytest.raises(Exception):
+            inst.price_precision = 2  # type: ignore[misc]

--- a/trading_bot/tests/domain/test_money.py
+++ b/trading_bot/tests/domain/test_money.py
@@ -1,0 +1,104 @@
+"""Tests for the exact Decimal money helpers."""
+
+from __future__ import annotations
+
+from decimal import ROUND_HALF_UP, Decimal
+
+import pytest
+
+from trading_bot.domain.money import (
+    Money,
+    add,
+    from_float,
+    money,
+    mul,
+    quantize,
+    sub,
+)
+
+
+class TestExactConstruction:
+    def test_decimal_addition_is_exact(self) -> None:
+        # The whole reason money is Decimal: 0.1 + 0.2 == 0.3 exactly.
+        assert money("0.1") + money("0.2") == money("0.3")
+        assert add(money("0.1"), money("0.2")) == Decimal("0.3")
+
+    def test_float_addition_is_not_exact(self) -> None:
+        # Sanity: prove the float trap we are guarding against is real.
+        assert 0.1 + 0.2 != 0.3
+
+    def test_from_str(self) -> None:
+        assert money("27123.45") == Decimal("27123.45")
+        assert isinstance(money("1"), Money)
+
+    def test_from_int(self) -> None:
+        assert money(5) == Decimal("5")
+
+    def test_from_decimal_passthrough(self) -> None:
+        d = Decimal("3.14159")
+        assert money(d) is d
+
+
+class TestFloatGuard:
+    def test_float_is_rejected(self) -> None:
+        with pytest.raises(TypeError, match="float"):
+            money(0.1)  # type: ignore[arg-type]
+
+    def test_bool_is_rejected(self) -> None:
+        with pytest.raises(TypeError, match="bool"):
+            money(True)  # type: ignore[arg-type]
+
+    def test_unsupported_type_rejected(self) -> None:
+        with pytest.raises(TypeError):
+            money(None)  # type: ignore[arg-type]
+
+    def test_from_float_opt_in_round_trips_shortest_decimal(self) -> None:
+        # The sanctioned float entry point yields the human-meant decimal.
+        assert from_float(0.1) == Decimal("0.1")
+        assert from_float(27123.45) == Decimal("27123.45")
+
+    def test_from_float_rejects_non_float(self) -> None:
+        with pytest.raises(TypeError):
+            from_float("0.1")  # type: ignore[arg-type]
+
+
+class TestQuantize:
+    def test_quantize_to_kraken_price_tick(self) -> None:
+        # Kraken BTC/USD price tick is 0.1.
+        result = quantize(money("27123.456789"), money("0.1"))
+        assert result == Decimal("27123.4")
+        assert isinstance(result, Decimal)
+
+    def test_quantize_to_satoshi_lot(self) -> None:
+        # Kraken volume precision for BTC is 8 dp (satoshi).
+        result = quantize(money("0.123456789"), money("0.00000001"))
+        assert result == Decimal("0.12345678")
+
+    def test_quantize_rounds_down_by_default(self) -> None:
+        # Default ROUND_DOWN must never overshoot.
+        assert quantize(money("0.9999"), money("0.001")) == Decimal("0.999")
+
+    def test_quantize_honours_rounding_mode(self) -> None:
+        assert quantize(
+            money("0.9999"), money("0.001"), rounding=ROUND_HALF_UP
+        ) == Decimal("1.000")
+
+    def test_quantize_result_scale_matches_tick(self) -> None:
+        # Result carries the tick's exponent (0.1 -> "0.1", not "0.100").
+        result = quantize(money("5"), money("0.1"))
+        assert str(result) == "5.0"
+
+    def test_quantize_rejects_non_positive_tick(self) -> None:
+        with pytest.raises(ValueError):
+            quantize(money("1"), money("0"))
+        with pytest.raises(ValueError):
+            quantize(money("1"), money("-0.1"))
+
+
+class TestNoFloatLeakage:
+    def test_arithmetic_helpers_return_decimal(self) -> None:
+        assert isinstance(add(money("1"), money("2")), Decimal)
+        assert isinstance(sub(money("3"), money("1")), Decimal)
+        assert isinstance(mul(money("2"), money("3")), Decimal)
+        assert sub(money("0.3"), money("0.1")) == Decimal("0.2")
+        assert mul(money("0.1"), money("3")) == Decimal("0.3")


### PR DESCRIPTION
## Summary
- First leaf of **E1 — Domain core**: the pure, mypy-strict base of `trading_bot/domain/`.
- `money.py` (Decimal, float-guarded), `instrument.py` (`Symbol`/`Instrument` + Kraken normalisation), `errors.py` (`TradingBotError` hierarchy).

## Why
- Money correctness is a core invariant — floats must never enter silently (`Decimal(0.1)` carries binary error). Kraken normalisation reuses the dccd table to keep the triptych consistent. See `doc/dev/03-decisions.md`.

## Changes
- `trading_bot/domain/{__init__,money,instrument,errors}.py` + `trading_bot/tests/domain/test_{money,instrument,errors}.py` (59 tests, 100% domain cov).
- Domain layer is pure (no I/O, no transport/brokers/storage imports); mypy-strict.

## Changelog
Added under [Unreleased]:
- Domain primitives — Decimal `money` (float-guarded), venue-neutral `instrument` with Kraken normalisation, and the `errors` hierarchy.

## Test plan
- [x] `pytest` passes locally (60 passed, 100% domain coverage)
- [x] `ruff check trading_bot/` passes
- [x] `mypy trading_bot/` clean (strict on domain)
- [ ] CI green