### PR TITLE
feat: order aggregate + lifecycle state machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Git Flow (`develop` / `master`) with `CONTRIBUTING.md` and a `pre-push` hook.
 - Domain primitives — Decimal `money` (float-guarded), venue-neutral `instrument`
   with Kraken normalisation, and the `errors` hierarchy. (#7)
+- `Order` aggregate + lifecycle state machine and order types
+  (market/limit/stop-loss/best-limit), with exact Decimal fill accounting. (#8)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,24 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Order lifecycle as an explicit state machine (PR #8)
+
+**Decision.** `domain/order.py` models the order as a **mutable, stateful
+aggregate** with a typed `OrderStatus` machine (NEW→SUBMITTED→OPEN→
+PARTIALLY_FILLED→FILLED, plus CANCELLED/REJECTED) — replacing the legacy
+`{None,'open','canceled','closed'}`. State changes only through five guarded
+transitions; `apply_fill` accumulates an exact Decimal quantity-weighted average
+price and closes to FILLED when the unfilled fraction is below `fill_tolerance`
+(0.1%, ported from legacy `check_vol_exec`). Over-fills are rejected;
+`client_order_id` is mandatory (idempotency invariant).
+
+**Why.** An order has stable identity and a long fill-by-fill life; a mutable
+aggregate guarded by explicit transitions keeps the machine the single source of
+truth without copy-threading noise. The tolerance handles venues leaving sub-tick
+dust. **Rejected:** immutable copy-on-transition (noise without added safety).
+
+---
+
 ### 2026-06-20 Decimal-guarded Money & Kraken normalisation in `domain/` (PR #7)
 
 **Decision.** `domain/money.py` accepts only `str`/`int`/`Decimal`; a `float`

--- a/doc/dev/plans/domain-core/00-plan.md
+++ b/doc/dev/plans/domain-core/00-plan.md
@@ -28,7 +28,7 @@ no imports from `transport`/`brokers`/`storage`. The pre-2026 tree
 ## Leaf checklist
 
 - [x] 01 primitives — feat/domain-primitives — medium
-- [ ] 02 order — feat/domain-order — high (depends on 01)
+- [x] 02 order — feat/domain-order — high (depends on 01)
 - [ ] 03 fill-position — feat/domain-fill-position — medium (depends on 02)
 - [ ] 04 signal — feat/domain-signal — low (depends on 01)
 - [ ] 05 performance — feat/domain-performance — high (depends on 03)

--- a/doc/dev/plans/domain-core/02-order.md
+++ b/doc/dev/plans/domain-core/02-order.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [01]
 parallel: false
 branch: feat/domain-order
-pr: ""
+pr: "#8"
 ---
 
 # Order aggregate + lifecycle state machine

--- a/doc/dev/plans/domain-core/02-order.md
+++ b/doc/dev/plans/domain-core/02-order.md
@@ -1,7 +1,7 @@
 ---
 plan: domain-core/02-order
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01]
 parallel: false

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -12,6 +12,10 @@ Public surface:
   :func:`~trading_bot.domain.money.quantize`, ...);
 * instrument — venue-neutral :class:`~trading_bot.domain.instrument.Symbol` /
   :class:`~trading_bot.domain.instrument.Instrument` with Kraken normalisation;
+* order — the :class:`~trading_bot.domain.order.Order` aggregate and its
+  lifecycle state machine (:class:`~trading_bot.domain.order.OrderSide`,
+  :class:`~trading_bot.domain.order.OrderType`,
+  :class:`~trading_bot.domain.order.OrderStatus`);
 * errors — the :class:`~trading_bot.domain.errors.TradingBotError` hierarchy.
 """
 
@@ -41,6 +45,13 @@ from trading_bot.domain.money import (
     quantize,
     sub,
 )
+from trading_bot.domain.order import (
+    DEFAULT_FILL_TOLERANCE,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+)
 
 __all__ = [
     # money
@@ -56,6 +67,12 @@ __all__ = [
     "Instrument",
     "normalise",
     "parse_kraken_pair",
+    # order
+    "Order",
+    "OrderSide",
+    "OrderType",
+    "OrderStatus",
+    "DEFAULT_FILL_TOLERANCE",
     # errors
     "TradingBotError",
     "OrderError",

--- a/trading_bot/domain/order.py
+++ b/trading_bot/domain/order.py
@@ -1,0 +1,407 @@
+"""The :class:`Order` aggregate and its explicit lifecycle state machine.
+
+This module replaces the legacy ad-hoc status ``{None, 'open', 'canceled',
+'closed'}`` (see ``trading_bot/legacy/orders.py``) with a typed, validated
+state machine. An :class:`Order` is a **stateful aggregate**: it has identity
+(its mandatory ``client_order_id``) and mutates through explicit, guarded
+transitions — :meth:`Order.submit`, :meth:`Order.open`,
+:meth:`Order.apply_fill`, :meth:`Order.cancel`, :meth:`Order.reject`. Any
+transition the machine forbids raises :class:`~trading_bot.domain.errors.
+OrderStatusError`.
+
+Design choices (carried into the ADR):
+
+* **Mutable, not immutable-with-copy.** An order has a stable identity and a
+  long, fill-by-fill life; threading a fresh copy through every partial fill
+  would add noise without buying safety. State only ever changes via the five
+  guarded methods, never by reaching into the fields, so the machine stays the
+  single source of truth.
+* **Tolerance rule (ported from legacy ``check_vol_exec``).** The default
+  tolerance is ``0.1%`` (legacy ``tol=0.001``). After a fill, if the *unfilled*
+  fraction ``(qty - filled_qty) / qty`` is strictly below ``tol``, the order is
+  treated as fully :data:`OrderStatus.FILLED` even though a dust amount is
+  technically outstanding — venues routinely leave sub-tick remainders. An
+  exact fill (``filled_qty == qty``) always closes to ``FILLED``. Over-filling
+  (``filled_qty > qty``) is rejected with
+  :class:`~trading_bot.domain.errors.OrderError`.
+* **Order-type price invariants.** ``MARKET`` forbids both prices. ``LIMIT``
+  requires ``limit_price`` and forbids ``stop_price``. ``STOP_LOSS`` requires
+  ``stop_price`` and forbids ``limit_price`` (a stop *limit* is out of scope
+  here). ``BEST_LIMIT`` is a limit whose price is discovered at runtime, so
+  ``limit_price`` is *optional* at construction; ``stop_price`` is forbidden.
+
+The module is pure: no I/O, no async, money as :class:`~decimal.Decimal`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from trading_bot.domain.errors import OrderError, OrderStatusError
+from trading_bot.domain.instrument import Instrument
+from trading_bot.domain.money import Money, money
+
+__all__ = [
+    "OrderSide",
+    "OrderType",
+    "OrderStatus",
+    "Order",
+    "DEFAULT_FILL_TOLERANCE",
+]
+
+#: Default unfilled-fraction tolerance below which an order is treated as fully
+#: filled. Ported from the legacy ``_BasisOrder.tol`` default of ``0.001``
+#: (0.1%). See :meth:`Order.apply_fill`.
+DEFAULT_FILL_TOLERANCE: Money = money("0.001")
+
+
+class OrderSide(Enum):
+    """Which way the order trades."""
+
+    BUY = "buy"
+    SELL = "sell"
+
+
+class OrderType(Enum):
+    """How the order is priced / routed."""
+
+    MARKET = "market"
+    LIMIT = "limit"
+    STOP_LOSS = "stop_loss"
+    BEST_LIMIT = "best_limit"
+
+
+class OrderStatus(Enum):
+    """The order's position in its lifecycle.
+
+    The legal flow is::
+
+        NEW -> SUBMITTED -> OPEN -> PARTIALLY_FILLED -> FILLED
+                  |          |            |
+                  v          v            v
+               REJECTED   CANCELLED    CANCELLED
+
+    ``FILLED``, ``CANCELLED`` and ``REJECTED`` are terminal.
+    """
+
+    NEW = "new"
+    SUBMITTED = "submitted"
+    OPEN = "open"
+    PARTIALLY_FILLED = "partially_filled"
+    FILLED = "filled"
+    CANCELLED = "cancelled"
+    REJECTED = "rejected"
+
+
+# Allowed status transitions. A status missing from a value set forbids that
+# move; ``apply_fill`` resolves its own PARTIALLY_FILLED-vs-FILLED target and is
+# only gated on the *source* status here.
+_TRANSITIONS: dict[OrderStatus, frozenset[OrderStatus]] = {
+    OrderStatus.NEW: frozenset({OrderStatus.SUBMITTED}),
+    OrderStatus.SUBMITTED: frozenset(
+        {OrderStatus.OPEN, OrderStatus.REJECTED, OrderStatus.CANCELLED}
+    ),
+    OrderStatus.OPEN: frozenset(
+        {
+            OrderStatus.PARTIALLY_FILLED,
+            OrderStatus.FILLED,
+            OrderStatus.CANCELLED,
+        }
+    ),
+    OrderStatus.PARTIALLY_FILLED: frozenset(
+        {
+            OrderStatus.PARTIALLY_FILLED,
+            OrderStatus.FILLED,
+            OrderStatus.CANCELLED,
+        }
+    ),
+    OrderStatus.FILLED: frozenset(),
+    OrderStatus.CANCELLED: frozenset(),
+    OrderStatus.REJECTED: frozenset(),
+}
+
+# Statuses from which a fill may be applied (the order is live on the venue).
+_FILLABLE: frozenset[OrderStatus] = frozenset(
+    {OrderStatus.OPEN, OrderStatus.PARTIALLY_FILLED}
+)
+
+
+@dataclass(slots=True)
+class Order:
+    """A trading order with an explicit, guarded lifecycle.
+
+    The order is a *stateful aggregate*: create it, then drive it through its
+    lifecycle with :meth:`submit`, :meth:`open`, :meth:`apply_fill`,
+    :meth:`cancel` and :meth:`reject`. Status, fills and the average fill price
+    only ever change through those methods.
+
+    Parameters
+    ----------
+    client_order_id : str
+        Caller-assigned idempotency key. Mandatory: it is the order's identity
+        and lets a retry be recognised as the same order. Must be non-empty.
+    instrument : Instrument
+        The instrument being traded.
+    side : OrderSide
+        ``BUY`` or ``SELL``.
+    qty : Decimal
+        The order's total quantity. Must be strictly positive.
+    type : OrderType
+        Pricing / routing type (see :class:`OrderType`).
+    limit_price : Decimal, optional
+        Required for ``LIMIT``; optional for ``BEST_LIMIT`` (discovered at
+        runtime); forbidden for ``MARKET`` and ``STOP_LOSS``.
+    stop_price : Decimal, optional
+        Required for ``STOP_LOSS``; forbidden otherwise.
+    fill_tolerance : Decimal, optional
+        Unfilled-fraction threshold below which the order closes to ``FILLED``.
+        Defaults to :data:`DEFAULT_FILL_TOLERANCE` (0.1%).
+
+    Attributes
+    ----------
+    filled_qty : Decimal
+        Cumulative executed quantity. Starts at ``0``.
+    avg_fill_price : Decimal or None
+        Quantity-weighted average price across all fills, exact in
+        :class:`~decimal.Decimal`. ``None`` until the first fill.
+    status : OrderStatus
+        Current lifecycle status. Starts at :data:`OrderStatus.NEW`.
+    venue_order_id : str or None
+        The venue's order id, set by :meth:`open`. ``None`` until then.
+    reject_reason : str or None
+        Why the order was rejected, set by :meth:`reject`. ``None`` otherwise.
+
+    Examples
+    --------
+    >>> from trading_bot.domain.instrument import Instrument, Symbol
+    >>> from trading_bot.domain.money import money
+    >>> o = Order(
+    ...     client_order_id="cid-1",
+    ...     instrument=Instrument(Symbol("BTC", "USD")),
+    ...     side=OrderSide.BUY,
+    ...     qty=money("2"),
+    ...     type=OrderType.LIMIT,
+    ...     limit_price=money("30000"),
+    ... )
+    >>> o.submit(); o.open("VID-1")
+    >>> o.apply_fill(money("1"), money("30000"))
+    >>> o.status
+    <OrderStatus.PARTIALLY_FILLED: 'partially_filled'>
+    >>> o.apply_fill(money("1"), money("30100"))
+    >>> o.status, o.avg_fill_price
+    (<OrderStatus.FILLED: 'filled'>, Decimal('30050'))
+
+    """
+
+    client_order_id: str
+    instrument: Instrument
+    side: OrderSide
+    qty: Money
+    type: OrderType
+    limit_price: Money | None = None
+    stop_price: Money | None = None
+    fill_tolerance: Money = DEFAULT_FILL_TOLERANCE
+
+    filled_qty: Money = field(default_factory=lambda: money("0"))
+    avg_fill_price: Money | None = None
+    status: OrderStatus = OrderStatus.NEW
+    venue_order_id: str | None = None
+    reject_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate construction invariants (identity, qty, price/type rules)."""
+        if not self.client_order_id:
+            raise OrderError(
+                self.client_order_id, "client_order_id is mandatory and non-empty"
+            )
+        if self.qty <= 0:
+            raise OrderError(
+                self.client_order_id, f"qty must be positive, got {self.qty}"
+            )
+        if self.fill_tolerance < 0:
+            raise OrderError(
+                self.client_order_id,
+                f"fill_tolerance must be non-negative, got {self.fill_tolerance}",
+            )
+        self._validate_prices()
+
+    def _validate_prices(self) -> None:
+        """Enforce the per-:class:`OrderType` price invariants."""
+        otype = self.type
+        if otype is OrderType.MARKET:
+            if self.limit_price is not None or self.stop_price is not None:
+                raise OrderError(
+                    self.client_order_id,
+                    "MARKET order forbids limit_price and stop_price",
+                )
+        elif otype is OrderType.LIMIT:
+            if self.limit_price is None:
+                raise OrderError(
+                    self.client_order_id, "LIMIT order requires limit_price"
+                )
+            if self.stop_price is not None:
+                raise OrderError(
+                    self.client_order_id, "LIMIT order forbids stop_price"
+                )
+        elif otype is OrderType.STOP_LOSS:
+            if self.stop_price is None:
+                raise OrderError(
+                    self.client_order_id, "STOP_LOSS order requires stop_price"
+                )
+            if self.limit_price is not None:
+                raise OrderError(
+                    self.client_order_id, "STOP_LOSS order forbids limit_price"
+                )
+        else:  # OrderType.BEST_LIMIT
+            # BEST_LIMIT discovers its price at runtime, so limit_price is
+            # optional; a stop price is meaningless for it.
+            if self.stop_price is not None:
+                raise OrderError(
+                    self.client_order_id, "BEST_LIMIT order forbids stop_price"
+                )
+
+    # --- lifecycle transitions --------------------------------------------- #
+
+    def _require_transition(self, target: OrderStatus, action: str) -> None:
+        """Raise :class:`OrderStatusError` if ``target`` is not reachable now."""
+        if target not in _TRANSITIONS[self.status]:
+            raise OrderStatusError(self.client_order_id, self.status.value, action)
+
+    def submit(self) -> None:
+        """Mark the order as sent to the venue (``NEW -> SUBMITTED``)."""
+        self._require_transition(OrderStatus.SUBMITTED, "submit")
+        self.status = OrderStatus.SUBMITTED
+
+    def open(self, venue_order_id: str) -> None:
+        """Acknowledge the venue accepted the order (``SUBMITTED -> OPEN``).
+
+        Parameters
+        ----------
+        venue_order_id : str
+            The venue's identifier for the live order. Must be non-empty.
+
+        """
+        self._require_transition(OrderStatus.OPEN, "open")
+        if not venue_order_id:
+            raise OrderError(
+                self.client_order_id, "venue_order_id must be non-empty to open"
+            )
+        self.venue_order_id = venue_order_id
+        self.status = OrderStatus.OPEN
+
+    def apply_fill(self, qty: Money, price: Money) -> None:
+        """Apply an execution of ``qty`` at ``price``, updating the average.
+
+        Accumulates :attr:`filled_qty` and recomputes :attr:`avg_fill_price` as
+        the exact quantity-weighted average across all fills so far. The status
+        moves to :data:`OrderStatus.PARTIALLY_FILLED`, or to
+        :data:`OrderStatus.FILLED` once the order is filled within tolerance
+        (see :data:`DEFAULT_FILL_TOLERANCE`).
+
+        Parameters
+        ----------
+        qty : Decimal
+            The executed quantity for this fill. Must be strictly positive.
+        price : Decimal
+            The execution price for this fill. Must be strictly positive.
+
+        Raises
+        ------
+        OrderStatusError
+            If the order is not live (must be ``OPEN`` or ``PARTIALLY_FILLED``).
+        OrderError
+            If ``qty``/``price`` are not positive, or the fill would push
+            :attr:`filled_qty` beyond :attr:`qty` (over-fill).
+
+        """
+        if self.status not in _FILLABLE:
+            raise OrderStatusError(
+                self.client_order_id, self.status.value, "apply_fill"
+            )
+        if qty <= 0:
+            raise OrderError(
+                self.client_order_id, f"fill qty must be positive, got {qty}"
+            )
+        if price <= 0:
+            raise OrderError(
+                self.client_order_id, f"fill price must be positive, got {price}"
+            )
+
+        new_filled = self.filled_qty + qty
+        if new_filled > self.qty:
+            raise OrderError(
+                self.client_order_id,
+                f"over-fill: {new_filled} exceeds order qty {self.qty}",
+            )
+
+        # Exact quantity-weighted average: (sum of qty*price) / sum of qty.
+        prior_notional = (
+            self.avg_fill_price * self.filled_qty
+            if self.avg_fill_price is not None
+            else money("0")
+        )
+        notional = prior_notional + qty * price
+        self.filled_qty = new_filled
+        self.avg_fill_price = notional / new_filled
+
+        if self._is_filled_within_tolerance():
+            self.status = OrderStatus.FILLED
+        else:
+            self.status = OrderStatus.PARTIALLY_FILLED
+
+    def _is_filled_within_tolerance(self) -> bool:
+        """Whether the unfilled fraction is within :attr:`fill_tolerance`.
+
+        Ported from legacy ``check_vol_exec``: an exact fill always counts; a
+        residual unfilled fraction strictly below ``fill_tolerance`` is treated
+        as a full fill (venues leave sub-tick dust).
+        """
+        if self.filled_qty >= self.qty:
+            return True
+        unfilled_fraction = (self.qty - self.filled_qty) / self.qty
+        return unfilled_fraction < self.fill_tolerance
+
+    def cancel(self) -> None:
+        """Cancel a live order (from ``SUBMITTED``, ``OPEN`` or partially filled).
+
+        Raises
+        ------
+        OrderStatusError
+            If the current status forbids cancellation (terminal or ``NEW``).
+
+        """
+        self._require_transition(OrderStatus.CANCELLED, "cancel")
+        self.status = OrderStatus.CANCELLED
+
+    def reject(self, reason: str) -> None:
+        """Reject the order (``SUBMITTED -> REJECTED``), recording ``reason``.
+
+        Parameters
+        ----------
+        reason : str
+            Human-readable rejection reason (e.g. the venue error). Stored on
+            :attr:`reject_reason`.
+
+        Raises
+        ------
+        OrderStatusError
+            If the current status forbids rejection.
+
+        """
+        self._require_transition(OrderStatus.REJECTED, "reject")
+        self.reject_reason = reason
+        self.status = OrderStatus.REJECTED
+
+    # --- derived views ----------------------------------------------------- #
+
+    @property
+    def remaining_qty(self) -> Money:
+        """Quantity not yet filled (``qty - filled_qty``, never negative)."""
+        remaining = self.qty - self.filled_qty
+        return remaining if remaining > 0 else money("0")
+
+    @property
+    def is_terminal(self) -> bool:
+        """Whether the order has reached a terminal status (no transitions left)."""
+        return not _TRANSITIONS[self.status]

--- a/trading_bot/tests/domain/test_order.py
+++ b/trading_bot/tests/domain/test_order.py
@@ -1,0 +1,386 @@
+"""Tests for the Order aggregate and its lifecycle state machine."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from trading_bot.domain.errors import OrderError, OrderStatusError
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.order import (
+    DEFAULT_FILL_TOLERANCE,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+)
+
+INSTRUMENT = Instrument(Symbol("BTC", "USD"), price_precision=1, qty_precision=8)
+
+
+def make_order(
+    *,
+    qty: str = "2",
+    otype: OrderType = OrderType.LIMIT,
+    limit_price: str | None = "30000",
+    stop_price: str | None = None,
+    fill_tolerance: str | None = None,
+) -> Order:
+    """Build a test order with sensible defaults."""
+    kwargs: dict[str, object] = {
+        "client_order_id": "cid-1",
+        "instrument": INSTRUMENT,
+        "side": OrderSide.BUY,
+        "qty": money(qty),
+        "type": otype,
+        "limit_price": money(limit_price) if limit_price is not None else None,
+        "stop_price": money(stop_price) if stop_price is not None else None,
+    }
+    if fill_tolerance is not None:
+        kwargs["fill_tolerance"] = money(fill_tolerance)
+    return Order(**kwargs)  # type: ignore[arg-type]
+
+
+class TestConstructionValidation:
+    def test_market_forbids_prices(self) -> None:
+        # No prices: fine.
+        Order(
+            client_order_id="cid",
+            instrument=INSTRUMENT,
+            side=OrderSide.SELL,
+            qty=money("1"),
+            type=OrderType.MARKET,
+        )
+        with pytest.raises(OrderError, match="MARKET"):
+            make_order(otype=OrderType.MARKET, limit_price="30000")
+        with pytest.raises(OrderError, match="MARKET"):
+            make_order(
+                otype=OrderType.MARKET, limit_price=None, stop_price="29000"
+            )
+
+    def test_limit_requires_limit_price(self) -> None:
+        make_order(otype=OrderType.LIMIT, limit_price="30000")
+        with pytest.raises(OrderError, match="LIMIT order requires limit_price"):
+            make_order(otype=OrderType.LIMIT, limit_price=None)
+
+    def test_limit_forbids_stop_price(self) -> None:
+        with pytest.raises(OrderError, match="LIMIT order forbids stop_price"):
+            make_order(
+                otype=OrderType.LIMIT, limit_price="30000", stop_price="29000"
+            )
+
+    def test_stop_loss_requires_stop_price(self) -> None:
+        make_order(otype=OrderType.STOP_LOSS, limit_price=None, stop_price="29000")
+        with pytest.raises(OrderError, match="STOP_LOSS order requires stop_price"):
+            make_order(otype=OrderType.STOP_LOSS, limit_price=None, stop_price=None)
+
+    def test_stop_loss_forbids_limit_price(self) -> None:
+        with pytest.raises(OrderError, match="STOP_LOSS order forbids limit_price"):
+            make_order(
+                otype=OrderType.STOP_LOSS,
+                limit_price="30000",
+                stop_price="29000",
+            )
+
+    def test_best_limit_price_optional(self) -> None:
+        # BEST_LIMIT discovers its price at runtime: no limit_price is allowed.
+        make_order(otype=OrderType.BEST_LIMIT, limit_price=None)
+        # But it may carry an initial limit price.
+        make_order(otype=OrderType.BEST_LIMIT, limit_price="30000")
+
+    def test_best_limit_forbids_stop_price(self) -> None:
+        with pytest.raises(OrderError, match="BEST_LIMIT order forbids stop_price"):
+            make_order(
+                otype=OrderType.BEST_LIMIT,
+                limit_price=None,
+                stop_price="29000",
+            )
+
+    def test_qty_must_be_positive(self) -> None:
+        with pytest.raises(OrderError, match="qty must be positive"):
+            make_order(qty="0")
+        with pytest.raises(OrderError, match="qty must be positive"):
+            make_order(qty="-1")
+
+    def test_fill_tolerance_must_be_non_negative(self) -> None:
+        with pytest.raises(OrderError, match="fill_tolerance must be non-negative"):
+            make_order(fill_tolerance="-0.001")
+
+    def test_client_order_id_mandatory(self) -> None:
+        with pytest.raises(OrderError, match="client_order_id is mandatory"):
+            Order(
+                client_order_id="",
+                instrument=INSTRUMENT,
+                side=OrderSide.BUY,
+                qty=money("1"),
+                type=OrderType.MARKET,
+            )
+
+    def test_initial_state(self) -> None:
+        o = make_order()
+        assert o.status is OrderStatus.NEW
+        assert o.filled_qty == money("0")
+        assert o.avg_fill_price is None
+        assert o.venue_order_id is None
+        assert o.reject_reason is None
+        assert o.fill_tolerance == DEFAULT_FILL_TOLERANCE
+
+
+class TestLegalLifecycle:
+    def test_full_legal_path(self) -> None:
+        # NEW -> SUBMITTED -> OPEN -> PARTIALLY_FILLED -> FILLED
+        o = make_order(qty="2")
+        assert o.status is OrderStatus.NEW
+
+        o.submit()
+        assert o.status is OrderStatus.SUBMITTED
+
+        o.open("VID-42")
+        assert o.status is OrderStatus.OPEN
+        assert o.venue_order_id == "VID-42"
+
+        o.apply_fill(money("1"), money("30000"))
+        assert o.status is OrderStatus.PARTIALLY_FILLED
+        assert o.filled_qty == money("1")
+        assert o.remaining_qty == money("1")
+
+        o.apply_fill(money("1"), money("30100"))
+        assert o.status is OrderStatus.FILLED
+        assert o.filled_qty == money("2")
+        assert o.remaining_qty == money("0")
+        assert o.is_terminal
+
+    def test_cancel_from_open(self) -> None:
+        o = make_order()
+        o.submit()
+        o.open("VID-1")
+        o.cancel()
+        assert o.status is OrderStatus.CANCELLED
+        assert o.is_terminal
+
+    def test_cancel_from_submitted(self) -> None:
+        o = make_order()
+        o.submit()
+        o.cancel()
+        assert o.status is OrderStatus.CANCELLED
+
+    def test_cancel_from_partially_filled(self) -> None:
+        o = make_order(qty="2")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("1"), money("30000"))
+        o.cancel()
+        assert o.status is OrderStatus.CANCELLED
+        # Partial fill is preserved on cancellation.
+        assert o.filled_qty == money("1")
+
+    def test_reject_from_submitted(self) -> None:
+        o = make_order()
+        o.submit()
+        o.reject("insufficient funds")
+        assert o.status is OrderStatus.REJECTED
+        assert o.reject_reason == "insufficient funds"
+        assert o.is_terminal
+
+
+class TestIllegalTransitions:
+    def test_open_before_submit(self) -> None:
+        o = make_order()
+        with pytest.raises(OrderStatusError, match="cannot open"):
+            o.open("VID-1")
+
+    def test_double_submit(self) -> None:
+        o = make_order()
+        o.submit()
+        with pytest.raises(OrderStatusError, match="cannot submit"):
+            o.submit()
+
+    def test_apply_fill_on_new(self) -> None:
+        o = make_order()
+        with pytest.raises(OrderStatusError, match="cannot apply_fill"):
+            o.apply_fill(money("1"), money("30000"))
+
+    def test_apply_fill_on_cancelled(self) -> None:
+        o = make_order()
+        o.submit()
+        o.open("VID-1")
+        o.cancel()
+        with pytest.raises(OrderStatusError, match="cannot apply_fill"):
+            o.apply_fill(money("1"), money("30000"))
+
+    def test_apply_fill_on_filled(self) -> None:
+        o = make_order(qty="1")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("1"), money("30000"))
+        assert o.status is OrderStatus.FILLED
+        with pytest.raises(OrderStatusError, match="cannot apply_fill"):
+            o.apply_fill(money("0.1"), money("30000"))
+
+    def test_cancel_from_new(self) -> None:
+        o = make_order()
+        with pytest.raises(OrderStatusError, match="cannot cancel"):
+            o.cancel()
+
+    def test_cancel_terminal(self) -> None:
+        o = make_order(qty="1")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("1"), money("30000"))
+        with pytest.raises(OrderStatusError, match="cannot cancel"):
+            o.cancel()
+
+    def test_reject_from_open(self) -> None:
+        o = make_order()
+        o.submit()
+        o.open("VID-1")
+        with pytest.raises(OrderStatusError, match="cannot reject"):
+            o.reject("too late")
+
+    def test_open_with_empty_venue_id(self) -> None:
+        o = make_order()
+        o.submit()
+        with pytest.raises(OrderError, match="venue_order_id must be non-empty"):
+            o.open("")
+        # Status unchanged after the failed open.
+        assert o.status is OrderStatus.SUBMITTED
+
+
+class TestApplyFillAccounting:
+    def test_weighted_average_is_exact(self) -> None:
+        # Two equal-qty fills -> arithmetic mean.
+        o = make_order(qty="2")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("1"), money("30000"))
+        o.apply_fill(money("1"), money("30100"))
+        assert o.avg_fill_price == Decimal("30050")
+
+    def test_weighted_average_unequal_quantities(self) -> None:
+        # 3 @ 100 then 1 @ 200 -> (300 + 200) / 4 = 125, exactly.
+        o = make_order(qty="4", limit_price="150")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("3"), money("100"))
+        assert o.avg_fill_price == Decimal("100")
+        o.apply_fill(money("1"), money("200"))
+        assert o.avg_fill_price == Decimal("125")
+        assert o.status is OrderStatus.FILLED
+
+    def test_avg_price_is_decimal_not_float(self) -> None:
+        # A third that would lose precision as a float stays exact as Decimal.
+        o = make_order(qty="3", limit_price="10")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("1"), money("10"))
+        o.apply_fill(money("2"), money("10"))
+        assert isinstance(o.avg_fill_price, Decimal)
+        assert o.avg_fill_price == Decimal("10")
+
+    def test_over_fill_rejected(self) -> None:
+        o = make_order(qty="2")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("1.5"), money("30000"))
+        with pytest.raises(OrderError, match="over-fill"):
+            o.apply_fill(money("1"), money("30000"))
+        # State unchanged after the rejected over-fill.
+        assert o.filled_qty == money("1.5")
+        assert o.status is OrderStatus.PARTIALLY_FILLED
+
+    def test_non_positive_fill_qty_rejected(self) -> None:
+        o = make_order(qty="2")
+        o.submit()
+        o.open("VID-1")
+        with pytest.raises(OrderError, match="fill qty must be positive"):
+            o.apply_fill(money("0"), money("30000"))
+
+    def test_non_positive_fill_price_rejected(self) -> None:
+        o = make_order(qty="2")
+        o.submit()
+        o.open("VID-1")
+        with pytest.raises(OrderError, match="fill price must be positive"):
+            o.apply_fill(money("1"), money("0"))
+
+
+class TestFillTolerance:
+    def test_exact_fill_closes(self) -> None:
+        o = make_order(qty="1")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("1"), money("30000"))
+        assert o.status is OrderStatus.FILLED
+
+    def test_dust_within_tolerance_closes_to_filled(self) -> None:
+        # Default tol is 0.1%. Leave 0.05% unfilled -> treated as FILLED.
+        o = make_order(qty="1000")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("999.5"), money("30000"))
+        unfilled_fraction = (money("1000") - money("999.5")) / money("1000")
+        assert unfilled_fraction < DEFAULT_FILL_TOLERANCE
+        assert o.status is OrderStatus.FILLED
+        # filled_qty reflects what actually executed, not the rounded-up qty.
+        assert o.filled_qty == money("999.5")
+
+    def test_unfilled_above_tolerance_stays_partial(self) -> None:
+        # Leave 1% unfilled -> well above the 0.1% tolerance.
+        o = make_order(qty="1000")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("990"), money("30000"))
+        assert o.status is OrderStatus.PARTIALLY_FILLED
+
+    def test_tolerance_boundary_is_strict(self) -> None:
+        # Exactly at tolerance (unfilled == tol) is NOT within tolerance.
+        o = make_order(qty="1000", fill_tolerance="0.001")
+        o.submit()
+        o.open("VID-1")
+        # Unfilled fraction == 0.001 exactly -> not strictly below tol.
+        o.apply_fill(money("999"), money("30000"))
+        assert o.status is OrderStatus.PARTIALLY_FILLED
+
+    def test_zero_tolerance_requires_exact_fill(self) -> None:
+        o = make_order(qty="1000", fill_tolerance="0")
+        o.submit()
+        o.open("VID-1")
+        o.apply_fill(money("999.99"), money("30000"))
+        assert o.status is OrderStatus.PARTIALLY_FILLED
+
+
+class TestRealisticPartialFillReplay:
+    def test_partial_fills_sum_to_qty_exact_weighted_average(self) -> None:
+        # A realistic ladder of partial fills at different prices summing to the
+        # order quantity. Assert final status FILLED and the avg price equal to
+        # the exact Decimal quantity-weighted average.
+        o = Order(
+            client_order_id="replay-1",
+            instrument=INSTRUMENT,
+            side=OrderSide.BUY,
+            qty=money("1.5"),
+            type=OrderType.LIMIT,
+            limit_price=money("30100"),
+        )
+        o.submit()
+        o.open("KRAKEN-OXXXX")
+
+        fills = [
+            (money("0.3"), money("30000.0")),
+            (money("0.45"), money("30025.5")),
+            (money("0.25"), money("30050.0")),
+            (money("0.5"), money("30099.9")),
+        ]
+        for q, p in fills:
+            o.apply_fill(q, p)
+
+        total_qty = sum((q for q, _ in fills), money("0"))
+        notional = sum((q * p for q, p in fills), money("0"))
+        expected_avg = notional / total_qty
+
+        assert total_qty == money("1.5")
+        assert o.filled_qty == money("1.5")
+        assert o.status is OrderStatus.FILLED
+        assert o.avg_fill_price == expected_avg
+        assert o.remaining_qty == money("0")


### PR DESCRIPTION
## Summary
- Second leaf of **E1 — Domain core**: `trading_bot/domain/order.py`.
- `Order` aggregate + typed `OrderStatus` state machine + order types (market/limit/stop-loss/best-limit), with exact Decimal fill accounting.

## Why
- Replaces the legacy `{None,'open','canceled','closed'}` ad-hoc status with a guarded, typed machine; `client_order_id` mandatory (idempotency). See `doc/dev/03-decisions.md`.

## Changes
- `domain/order.py` + exports; `tests/domain/test_order.py` (23 tests; 100% coverage on order.py). Mutable aggregate, five guarded transitions, fill tolerance ported from legacy `check_vol_exec`.

## Changelog
Added under [Unreleased]:
- `Order` aggregate + lifecycle state machine and order types, with exact Decimal fill accounting.

## Test plan
- [x] `pytest` passes (97 passed, 100% domain coverage)
- [x] `ruff check trading_bot/` passes
- [x] `mypy trading_bot/` clean (strict on domain)
- [ ] CI green