### PR TITLE
feat: fill and position from fills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   with Kraken normalisation, and the `errors` hierarchy. (#7)
 - `Order` aggregate + lifecycle state machine and order types
   (market/limit/stop-loss/best-limit), with exact Decimal fill accounting. (#8)
+- `Fill` and `Position` — net exposure rebuilt from an ordered fill sequence
+  (flips, fee-aware realised PnL). (#9)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,23 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Position PnL & flip convention from fills (PR #9)
+
+**Decision.** `Position.from_fills` folds an **ordered** fill sequence: realised
+PnL only on exposure-reducing fills — long reduce `(exit−entry)·closed`, short
+reduce `(entry−exit)·closed`. Every fill's `fee` accrues into `fees_paid` and is
+subtracted from realised PnL (fees count on opening fills too). A **flip** (a fill
+exceeding the open qty in the opposite direction) closes the whole position
+(realising PnL vs the old average), then re-opens the remainder at the flipping
+fill's price. `Fill.ts` is `int` milliseconds since the Unix epoch (UTC); fills are
+folded in caller-supplied order, not re-sorted.
+
+**Why.** Fills are the source of truth for PnL; a deterministic, explicit fold
+keeps positions reconstructable from history alone. ms-epoch ints keep the pure
+layer tz-free and match Kraken's granularity.
+
+---
+
 ### 2026-06-20 Order lifecycle as an explicit state machine (PR #8)
 
 **Decision.** `domain/order.py` models the order as a **mutable, stateful

--- a/doc/dev/plans/domain-core/00-plan.md
+++ b/doc/dev/plans/domain-core/00-plan.md
@@ -29,7 +29,7 @@ no imports from `transport`/`brokers`/`storage`. The pre-2026 tree
 
 - [x] 01 primitives — feat/domain-primitives — medium
 - [x] 02 order — feat/domain-order — high (depends on 01)
-- [ ] 03 fill-position — feat/domain-fill-position — medium (depends on 02)
+- [x] 03 fill-position — feat/domain-fill-position — medium (depends on 02)
 - [ ] 04 signal — feat/domain-signal — low (depends on 01)
 - [ ] 05 performance — feat/domain-performance — high (depends on 03)
 

--- a/doc/dev/plans/domain-core/03-fill-position.md
+++ b/doc/dev/plans/domain-core/03-fill-position.md
@@ -1,7 +1,7 @@
 ---
 plan: domain-core/03-fill-position
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: [02]
 parallel: false

--- a/doc/dev/plans/domain-core/03-fill-position.md
+++ b/doc/dev/plans/domain-core/03-fill-position.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: [02]
 parallel: false
 branch: feat/domain-fill-position
-pr: ""
+pr: "#9"
 ---
 
 # Fill + Position (net from fills)

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -16,12 +16,16 @@ Public surface:
   lifecycle state machine (:class:`~trading_bot.domain.order.OrderSide`,
   :class:`~trading_bot.domain.order.OrderType`,
   :class:`~trading_bot.domain.order.OrderStatus`);
+* fill — the immutable :class:`~trading_bot.domain.fill.Fill` execution record;
+* position — the :class:`~trading_bot.domain.position.Position` net exposure
+  rebuilt from fills;
 * errors — the :class:`~trading_bot.domain.errors.TradingBotError` hierarchy.
 """
 
 from __future__ import annotations
 
 from trading_bot.domain.errors import (
+    InstrumentMismatch,
     InsufficientFunds,
     MissingOrder,
     NoCapability,
@@ -30,6 +34,7 @@ from trading_bot.domain.errors import (
     RiskLimitBreached,
     TradingBotError,
 )
+from trading_bot.domain.fill import Fill
 from trading_bot.domain.instrument import (
     Instrument,
     Symbol,
@@ -52,6 +57,7 @@ from trading_bot.domain.order import (
     OrderStatus,
     OrderType,
 )
+from trading_bot.domain.position import Position
 
 __all__ = [
     # money
@@ -73,11 +79,16 @@ __all__ = [
     "OrderType",
     "OrderStatus",
     "DEFAULT_FILL_TOLERANCE",
+    # fill
+    "Fill",
+    # position
+    "Position",
     # errors
     "TradingBotError",
     "OrderError",
     "OrderStatusError",
     "MissingOrder",
+    "InstrumentMismatch",
     "InsufficientFunds",
     "RiskLimitBreached",
     "NoCapability",

--- a/trading_bot/domain/errors.py
+++ b/trading_bot/domain/errors.py
@@ -20,6 +20,7 @@ __all__ = [
     "OrderError",
     "OrderStatusError",
     "MissingOrder",
+    "InstrumentMismatch",
     "InsufficientFunds",
     "RiskLimitBreached",
     "NoCapability",
@@ -81,6 +82,30 @@ class MissingOrder(TradingBotError):
     def __init__(self, order_id: str) -> None:
         self.order_id = order_id
         super().__init__(f"order {order_id} is missing")
+
+
+class InstrumentMismatch(TradingBotError):
+    """Two domain objects that must share an instrument do not.
+
+    Raised, e.g., when folding fills into a single position and a fill names a
+    different instrument than the position is built on (a position is the net
+    exposure of *one* instrument).
+
+    Parameters
+    ----------
+    expected : str
+        The instrument the operation is bound to (its ``BASE/QUOTE`` string).
+    actual : str
+        The mismatching instrument that was supplied.
+
+    """
+
+    def __init__(self, expected: str, actual: str) -> None:
+        self.expected = expected
+        self.actual = actual
+        super().__init__(
+            f"instrument mismatch: expected {expected}, got {actual}"
+        )
 
 
 class InsufficientFunds(TradingBotError):

--- a/trading_bot/domain/fill.py
+++ b/trading_bot/domain/fill.py
@@ -1,0 +1,137 @@
+"""The :class:`Fill` value object — a broker-confirmed execution.
+
+A :class:`Fill` is the **source of truth for PnL**. Where an
+:class:`~trading_bot.domain.order.Order` is a stateful aggregate that *intends*
+to trade, a fill is an immutable record that a venue *did* trade a slice of it:
+``qty`` of an instrument at ``price``, costing ``fee``, on a given ``side``.
+Positions, realised PnL and fees are all rebuilt by folding an ordered sequence
+of fills (see :class:`~trading_bot.domain.position.Position`).
+
+Design choices (carried into the ADR / changelog):
+
+* **Immutable.** A fill is a fact, not a state machine — once the venue
+  confirms it, it never changes. The dataclass is ``frozen=True`` so a fill is
+  hashable and safe to share / store / replay.
+* **All amounts are :class:`~decimal.Decimal`.** ``qty``, ``price`` and ``fee``
+  never round-trip through ``float``.
+* **``ts`` is an ``int`` of milliseconds since the Unix epoch (UTC).** This is
+  the simplest fully-typed, timezone-free choice: it sorts and compares as a
+  plain integer, needs no ``datetime``/``tzinfo`` plumbing in the pure layer,
+  and matches the millisecond granularity Kraken reports. Callers that hold a
+  ``datetime`` convert at the boundary (``int(dt.timestamp() * 1000)``).
+* **``side`` reuses :class:`~trading_bot.domain.order.OrderSide`.** A fill is
+  ``BUY`` (adds to a long / reduces a short) or ``SELL`` (the inverse); there is
+  no separate fill-side enum.
+
+The module is pure: no I/O, no async, money as :class:`~decimal.Decimal`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from trading_bot.domain.errors import OrderError
+from trading_bot.domain.instrument import Instrument
+from trading_bot.domain.money import Money
+from trading_bot.domain.order import OrderSide
+
+__all__ = [
+    "Fill",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class Fill:
+    """A single broker-confirmed execution — immutable, the PnL source of truth.
+
+    Parameters
+    ----------
+    fill_id : str
+        The venue's identifier for this execution (Kraken trade id). Mandatory
+        and non-empty: it is the fill's identity and lets a replayed fill be
+        recognised as the same one.
+    client_order_id : str
+        The caller-assigned id of the order this fill belongs to. Mandatory and
+        non-empty. Ties the execution back to its originating order.
+    instrument : Instrument
+        The instrument that was traded.
+    side : OrderSide
+        ``BUY`` or ``SELL`` — the direction of the execution.
+    qty : Decimal
+        The executed quantity (in base units). Must be strictly positive.
+    price : Decimal
+        The execution price (in quote units per base unit). Must be strictly
+        positive.
+    fee : Decimal
+        The fee charged for this execution, in quote units. Must be
+        non-negative (zero is allowed for rebated / fee-free fills).
+    ts : int
+        Execution timestamp as **milliseconds since the Unix epoch (UTC)**. Must
+        be non-negative. Fills are folded in caller-supplied order; ``ts`` is
+        carried for record-keeping and tie-breaking, not used to re-sort.
+
+    Examples
+    --------
+    >>> from trading_bot.domain.instrument import Instrument, Symbol
+    >>> from trading_bot.domain.money import money
+    >>> Fill(
+    ...     fill_id="T1",
+    ...     client_order_id="cid-1",
+    ...     instrument=Instrument(Symbol("BTC", "USD")),
+    ...     side=OrderSide.BUY,
+    ...     qty=money("1"),
+    ...     price=money("30000"),
+    ...     fee=money("12"),
+    ...     ts=1_700_000_000_000,
+    ... ).qty
+    Decimal('1')
+
+    """
+
+    fill_id: str
+    client_order_id: str
+    instrument: Instrument
+    side: OrderSide
+    qty: Money
+    price: Money
+    fee: Money
+    ts: int
+
+    def __post_init__(self) -> None:
+        """Validate construction invariants (ids non-empty, amounts in range)."""
+        if not self.fill_id:
+            raise OrderError(
+                self.client_order_id, "fill_id is mandatory and non-empty"
+            )
+        if not self.client_order_id:
+            raise OrderError(
+                self.client_order_id, "client_order_id is mandatory and non-empty"
+            )
+        if self.qty <= 0:
+            raise OrderError(
+                self.client_order_id, f"fill qty must be positive, got {self.qty}"
+            )
+        if self.price <= 0:
+            raise OrderError(
+                self.client_order_id,
+                f"fill price must be positive, got {self.price}",
+            )
+        if self.fee < 0:
+            raise OrderError(
+                self.client_order_id,
+                f"fill fee must be non-negative, got {self.fee}",
+            )
+        if self.ts < 0:
+            raise OrderError(
+                self.client_order_id, f"fill ts must be non-negative, got {self.ts}"
+            )
+
+    @property
+    def signed_qty(self) -> Money:
+        """The execution quantity signed by side: ``+qty`` for BUY, ``-qty`` for SELL.
+
+        This is the contribution of the fill to a position's net quantity, the
+        natural unit for folding fills into a :class:`~trading_bot.domain.
+        position.Position`.
+        """
+        return self.qty if self.side is OrderSide.BUY else -self.qty

--- a/trading_bot/domain/position.py
+++ b/trading_bot/domain/position.py
@@ -1,0 +1,265 @@
+"""The :class:`Position` value object — net exposure rebuilt from fills.
+
+A :class:`Position` is the net result of folding an **ordered** sequence of
+:class:`~trading_bot.domain.fill.Fill` records for a *single* instrument. It
+tracks four things, all exact :class:`~decimal.Decimal`:
+
+* ``net_qty`` — signed net exposure: positive = long, negative = short, zero =
+  flat;
+* ``avg_entry_price`` — the quantity-weighted average entry price of the
+  currently-open exposure (``None`` when flat);
+* ``realised_pnl`` — cumulative profit/loss locked in by closing exposure,
+  **net of fees**;
+* ``fees_paid`` — cumulative fees across every folded fill.
+
+PnL sign convention
+-------------------
+PnL is realised only when exposure is *reduced* (a fill in the opposite
+direction of the open position) — opening or increasing exposure realises
+nothing. For the ``closed_qty`` (always a positive magnitude) that a reducing
+fill closes against an entry at ``avg_entry_price`` and an exit at the fill's
+``price``:
+
+* **long** position being reduced (a SELL)::
+
+      gross_pnl = (exit_price - avg_entry_price) * closed_qty
+
+* **short** position being reduced (a BUY)::
+
+      gross_pnl = (avg_entry_price - exit_price) * closed_qty
+
+i.e. a short's PnL is the long formula with the sign flipped. Fees are then
+subtracted: ``realised_pnl += gross_pnl`` and, separately, every fill's ``fee``
+is subtracted from ``realised_pnl`` and accrued into ``fees_paid`` — so fees
+always reduce realised PnL, on opening fills as well as closing ones.
+
+Flip handling
+-------------
+A **flip** is a fill that reverses the position's sign: a reducing fill whose
+``qty`` exceeds the open ``net_qty`` magnitude. It is handled in two stages:
+
+1. **close** the entire existing exposure — realise PnL on that closed part
+   against the old ``avg_entry_price`` and the flipping fill's ``price``;
+2. **open** the remainder (``fill.qty - |old net_qty|``) in the new direction at
+   the flipping fill's ``price`` — so the new ``avg_entry_price`` is exactly the
+   flipping fill's price.
+
+Increases in the same direction take the quantity-weighted average of the old
+and the added exposure.
+
+One instrument per position
+---------------------------
+A position is the exposure of exactly one instrument. :meth:`Position.from_fills`
+rejects a sequence whose fills name more than one instrument with
+:class:`~trading_bot.domain.errors.InstrumentMismatch`.
+
+The module is pure: no I/O, no async, money as :class:`~decimal.Decimal`,
+deterministic in fill order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+from trading_bot.domain.errors import InstrumentMismatch
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.order import OrderSide
+
+__all__ = [
+    "Position",
+]
+
+_ZERO: Money = money("0")
+
+
+@dataclass(frozen=True, slots=True)
+class Position:
+    """The net exposure of one instrument, folded from its fills.
+
+    Immutable: :meth:`from_fills` computes a final snapshot in one pass. ``long``
+    / ``short`` / ``is_flat`` are convenience views over the sign of
+    :attr:`net_qty`.
+
+    Parameters
+    ----------
+    instrument : Instrument
+        The single instrument this position is exposed to.
+    net_qty : Decimal
+        Signed net quantity: ``> 0`` long, ``< 0`` short, ``0`` flat.
+    avg_entry_price : Decimal or None
+        Quantity-weighted average entry price of the open exposure, or ``None``
+        when flat.
+    realised_pnl : Decimal
+        Cumulative realised PnL, net of fees (see the module-level sign
+        convention).
+    fees_paid : Decimal
+        Cumulative fees paid across all folded fills.
+
+    Examples
+    --------
+    >>> from trading_bot.domain.fill import Fill
+    >>> from trading_bot.domain.instrument import Instrument, Symbol
+    >>> from trading_bot.domain.money import money
+    >>> from trading_bot.domain.order import OrderSide
+    >>> inst = Instrument(Symbol("BTC", "USD"))
+    >>> f = Fill("T1", "cid-1", inst, OrderSide.BUY, money("2"), money("30000"),
+    ...          money("0"), 1)
+    >>> pos = Position.from_fills([f])
+    >>> pos.net_qty, pos.avg_entry_price
+    (Decimal('2'), Decimal('30000'))
+
+    """
+
+    instrument: Instrument
+    net_qty: Money
+    avg_entry_price: Money | None
+    realised_pnl: Money
+    fees_paid: Money
+
+    @property
+    def is_flat(self) -> bool:
+        """Whether the position holds no exposure (``net_qty == 0``)."""
+        return self.net_qty == 0
+
+    @property
+    def is_long(self) -> bool:
+        """Whether the position is net long (``net_qty > 0``)."""
+        return self.net_qty > 0
+
+    @property
+    def is_short(self) -> bool:
+        """Whether the position is net short (``net_qty < 0``)."""
+        return self.net_qty < 0
+
+    @classmethod
+    def from_fills(cls, fills: Iterable[Fill]) -> Position:
+        """Fold an **ordered** sequence of fills into a net :class:`Position`.
+
+        Handles increases (quantity-weighted average entry), partial closes and
+        full closes (realise PnL on the closed part), flips (close then re-open
+        at the flipping fill's price), and fee accrual. See the module docstring
+        for the PnL sign convention and flip handling.
+
+        Parameters
+        ----------
+        fills : Iterable[Fill]
+            The fills to fold, **in execution order**. Must be non-empty and all
+            name the same instrument.
+
+        Returns
+        -------
+        Position
+            The net position after all fills.
+
+        Raises
+        ------
+        ValueError
+            If ``fills`` is empty (an instrument cannot be inferred).
+        InstrumentMismatch
+            If the fills name more than one instrument.
+
+        """
+        ordered: Sequence[Fill] = tuple(fills)
+        if not ordered:
+            raise ValueError("from_fills requires at least one fill")
+
+        instrument: Instrument = ordered[0].instrument
+
+        net_qty: Money = _ZERO
+        # Average entry price of the *currently open* exposure. Only meaningful
+        # while net_qty != 0; kept as a plain Decimal (defaults to zero when
+        # flat) and exposed as None when flat in the final snapshot.
+        avg_entry: Money = _ZERO
+        realised_pnl: Money = _ZERO
+        fees_paid: Money = _ZERO
+
+        for fill in ordered:
+            if fill.instrument != instrument:
+                raise InstrumentMismatch(str(instrument), str(fill.instrument))
+
+            # Fees always accrue and always reduce realised PnL.
+            fees_paid += fill.fee
+            realised_pnl -= fill.fee
+
+            signed = fill.signed_qty  # +qty for BUY, -qty for SELL
+            price = fill.price
+
+            if net_qty == 0:
+                # Opening from flat: the fill becomes the whole exposure.
+                net_qty = signed
+                avg_entry = price
+                continue
+
+            same_direction = (net_qty > 0) == (fill.side is OrderSide.BUY)
+
+            if same_direction:
+                # Increasing exposure: quantity-weighted average of old + added.
+                # Work in magnitudes; both legs share the position's sign.
+                old_mag = abs(net_qty)
+                add_mag = fill.qty
+                total_mag = old_mag + add_mag
+                avg_entry = (avg_entry * old_mag + price * add_mag) / total_mag
+                net_qty += signed
+                continue
+
+            # Opposite direction: this fill reduces (and maybe flips) exposure.
+            open_mag = abs(net_qty)
+            closed_mag = min(open_mag, fill.qty)
+            realised_pnl += _close_pnl(
+                was_long=net_qty > 0,
+                entry=avg_entry,
+                exit_price=price,
+                closed_qty=closed_mag,
+            )
+
+            new_net = net_qty + signed
+            if new_net == 0:
+                # Exact close back to flat.
+                net_qty = _ZERO
+                avg_entry = _ZERO
+            elif (new_net > 0) == (net_qty > 0):
+                # Partial close: same sign, entry unchanged, qty reduced.
+                net_qty = new_net
+            else:
+                # Flip: old side fully closed above; remainder opens at the
+                # flipping fill's price, which becomes the new average entry.
+                net_qty = new_net
+                avg_entry = price
+
+        return cls(
+            instrument=instrument,
+            net_qty=net_qty,
+            avg_entry_price=None if net_qty == 0 else avg_entry,
+            realised_pnl=realised_pnl,
+            fees_paid=fees_paid,
+        )
+
+
+def _close_pnl(
+    *, was_long: bool, entry: Money, exit_price: Money, closed_qty: Money
+) -> Money:
+    """Gross PnL from closing ``closed_qty`` of exposure (sign convention above).
+
+    Parameters
+    ----------
+    was_long : bool
+        Whether the exposure being closed was long.
+    entry : Decimal
+        The average entry price of the closed exposure.
+    exit_price : Decimal
+        The price at which the exposure is closed.
+    closed_qty : Decimal
+        The (positive) magnitude of exposure closed.
+
+    Returns
+    -------
+    Decimal
+        ``(exit - entry) * closed_qty`` for a long, the negation for a short.
+
+    """
+    if was_long:
+        return (exit_price - entry) * closed_qty
+    return (entry - exit_price) * closed_qty

--- a/trading_bot/tests/domain/test_fill_position.py
+++ b/trading_bot/tests/domain/test_fill_position.py
@@ -1,0 +1,309 @@
+"""Tests for the Fill execution record and Position folded from fills."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from trading_bot.domain.errors import InstrumentMismatch, OrderError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.order import OrderSide
+from trading_bot.domain.position import Position
+
+BTCUSD = Instrument(Symbol("BTC", "USD"), price_precision=1, qty_precision=8)
+ETHUSD = Instrument(Symbol("ETH", "USD"), price_precision=2, qty_precision=8)
+
+
+def make_fill(
+    *,
+    side: OrderSide,
+    qty: str,
+    price: str,
+    fee: str = "0",
+    instrument: Instrument = BTCUSD,
+    fill_id: str = "T1",
+    client_order_id: str = "cid-1",
+    ts: int = 1_700_000_000_000,
+) -> Fill:
+    """Build a test fill with sensible defaults."""
+    return Fill(
+        fill_id=fill_id,
+        client_order_id=client_order_id,
+        instrument=instrument,
+        side=side,
+        qty=money(qty),
+        price=money(price),
+        fee=money(fee),
+        ts=ts,
+    )
+
+
+class TestFillConstruction:
+    def test_immutable_frozen(self) -> None:
+        f = make_fill(side=OrderSide.BUY, qty="1", price="30000")
+        with pytest.raises(AttributeError):
+            f.qty = money("2")  # type: ignore[misc]
+
+    def test_signed_qty_buy_is_positive(self) -> None:
+        f = make_fill(side=OrderSide.BUY, qty="1.5", price="30000")
+        assert f.signed_qty == money("1.5")
+
+    def test_signed_qty_sell_is_negative(self) -> None:
+        f = make_fill(side=OrderSide.SELL, qty="1.5", price="30000")
+        assert f.signed_qty == money("-1.5")
+
+    def test_empty_fill_id_rejected(self) -> None:
+        with pytest.raises(OrderError, match="fill_id"):
+            make_fill(side=OrderSide.BUY, qty="1", price="30000", fill_id="")
+
+    def test_empty_client_order_id_rejected(self) -> None:
+        with pytest.raises(OrderError, match="client_order_id"):
+            make_fill(
+                side=OrderSide.BUY, qty="1", price="30000", client_order_id=""
+            )
+
+    def test_non_positive_qty_rejected(self) -> None:
+        with pytest.raises(OrderError, match="qty"):
+            make_fill(side=OrderSide.BUY, qty="0", price="30000")
+
+    def test_non_positive_price_rejected(self) -> None:
+        with pytest.raises(OrderError, match="price"):
+            make_fill(side=OrderSide.BUY, qty="1", price="0")
+
+    def test_negative_fee_rejected(self) -> None:
+        with pytest.raises(OrderError, match="fee"):
+            make_fill(side=OrderSide.BUY, qty="1", price="30000", fee="-1")
+
+    def test_negative_ts_rejected(self) -> None:
+        with pytest.raises(OrderError, match="ts"):
+            make_fill(side=OrderSide.BUY, qty="1", price="30000", ts=-1)
+
+    def test_zero_fee_allowed(self) -> None:
+        f = make_fill(side=OrderSide.BUY, qty="1", price="30000", fee="0")
+        assert f.fee == money("0")
+
+
+class TestPositionBasics:
+    def test_empty_fills_raises(self) -> None:
+        with pytest.raises(ValueError, match="at least one fill"):
+            Position.from_fills([])
+
+    def test_single_buy(self) -> None:
+        pos = Position.from_fills(
+            [make_fill(side=OrderSide.BUY, qty="2", price="30000")]
+        )
+        assert pos.net_qty == money("2")
+        assert pos.avg_entry_price == money("30000")
+        assert pos.realised_pnl == money("0")
+        assert pos.fees_paid == money("0")
+        assert pos.is_long
+        assert not pos.is_flat
+
+    def test_single_sell_opens_short(self) -> None:
+        pos = Position.from_fills(
+            [make_fill(side=OrderSide.SELL, qty="2", price="30000")]
+        )
+        assert pos.net_qty == money("-2")
+        assert pos.avg_entry_price == money("30000")
+        assert pos.is_short
+
+    def test_increase_long_weighted_average(self) -> None:
+        # BUY 2 @ 30000, then BUY 1 @ 33000 -> avg = (60000+33000)/3 = 31000.
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.BUY, qty="2", price="30000"),
+                make_fill(side=OrderSide.BUY, qty="1", price="33000"),
+            ]
+        )
+        assert pos.net_qty == money("3")
+        assert pos.avg_entry_price == money("31000")
+        assert pos.realised_pnl == money("0")
+
+    def test_increase_short_weighted_average(self) -> None:
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.SELL, qty="2", price="30000"),
+                make_fill(side=OrderSide.SELL, qty="1", price="33000"),
+            ]
+        )
+        assert pos.net_qty == money("-3")
+        assert pos.avg_entry_price == money("31000")
+
+
+class TestPositionRealisedPnl:
+    def test_buy_then_partial_sell(self) -> None:
+        # BUY 3 @ 30000, then SELL 1 @ 35000.
+        # realised gross = (35000-30000)*1 = 5000; remainder 2 @ 30000.
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.BUY, qty="3", price="30000"),
+                make_fill(side=OrderSide.SELL, qty="1", price="35000"),
+            ]
+        )
+        assert pos.net_qty == money("2")
+        assert pos.avg_entry_price == money("30000")
+        assert pos.realised_pnl == money("5000")
+        assert pos.fees_paid == money("0")
+
+    def test_short_then_partial_buy_back(self) -> None:
+        # SELL 3 @ 35000, then BUY 1 @ 30000 -> short PnL = (35000-30000)*1.
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.SELL, qty="3", price="35000"),
+                make_fill(side=OrderSide.BUY, qty="1", price="30000"),
+            ]
+        )
+        assert pos.net_qty == money("-2")
+        assert pos.avg_entry_price == money("35000")
+        assert pos.realised_pnl == money("5000")
+
+    def test_full_close_to_flat(self) -> None:
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.BUY, qty="2", price="30000"),
+                make_fill(side=OrderSide.SELL, qty="2", price="31000"),
+            ]
+        )
+        assert pos.net_qty == money("0")
+        assert pos.avg_entry_price is None
+        assert pos.is_flat
+        assert pos.realised_pnl == money("2000")  # (31000-30000)*2
+
+    def test_loss_is_negative(self) -> None:
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.BUY, qty="1", price="30000"),
+                make_fill(side=OrderSide.SELL, qty="1", price="28000"),
+            ]
+        )
+        assert pos.realised_pnl == money("-2000")
+
+
+class TestPositionFlip:
+    def test_long_to_short_flip(self) -> None:
+        # BUY 2 @ 30000 (long 2), then SELL 5 @ 36000.
+        # Close 2 @ entry 30000: gross = (36000-30000)*2 = 12000.
+        # Remainder 3 opens short at the flipping fill's price 36000.
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.BUY, qty="2", price="30000"),
+                make_fill(side=OrderSide.SELL, qty="5", price="36000"),
+            ]
+        )
+        assert pos.net_qty == money("-3")
+        assert pos.avg_entry_price == money("36000")  # flipping fill's price
+        assert pos.realised_pnl == money("12000")
+        assert pos.is_short
+
+    def test_short_to_long_flip(self) -> None:
+        # SELL 2 @ 36000 (short 2), then BUY 5 @ 30000.
+        # Close 2 short @ entry 36000: gross = (36000-30000)*2 = 12000.
+        # Remainder 3 opens long at 30000.
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.SELL, qty="2", price="36000"),
+                make_fill(side=OrderSide.BUY, qty="5", price="30000"),
+            ]
+        )
+        assert pos.net_qty == money("3")
+        assert pos.avg_entry_price == money("30000")
+        assert pos.realised_pnl == money("12000")
+        assert pos.is_long
+
+
+class TestPositionFees:
+    def test_fees_accrue_and_reduce_pnl(self) -> None:
+        # BUY 1 @ 30000 fee 12; SELL 1 @ 31000 fee 6.
+        # gross close = 1000; realised = 1000 - 12 - 6 = 982; fees = 18.
+        pos = Position.from_fills(
+            [
+                make_fill(side=OrderSide.BUY, qty="1", price="30000", fee="12"),
+                make_fill(side=OrderSide.SELL, qty="1", price="31000", fee="6"),
+            ]
+        )
+        assert pos.fees_paid == money("18")
+        assert pos.realised_pnl == money("982")
+
+    def test_fee_on_opening_fill_only(self) -> None:
+        # A single opening BUY with a fee: no gross PnL yet, but the fee still
+        # accrues and reduces realised PnL.
+        pos = Position.from_fills(
+            [make_fill(side=OrderSide.BUY, qty="1", price="30000", fee="12")]
+        )
+        assert pos.fees_paid == money("12")
+        assert pos.realised_pnl == money("-12")
+        assert pos.net_qty == money("1")
+
+
+class TestPositionInstrument:
+    def test_mixed_instrument_raises(self) -> None:
+        with pytest.raises(InstrumentMismatch, match="BTC/USD"):
+            Position.from_fills(
+                [
+                    make_fill(side=OrderSide.BUY, qty="1", price="30000"),
+                    make_fill(
+                        side=OrderSide.BUY,
+                        qty="1",
+                        price="2000",
+                        instrument=ETHUSD,
+                    ),
+                ]
+            )
+
+    def test_position_carries_instrument(self) -> None:
+        pos = Position.from_fills(
+            [make_fill(side=OrderSide.BUY, qty="1", price="30000")]
+        )
+        assert pos.instrument == BTCUSD
+
+
+class TestRealDataFlipSequence:
+    """A realistic multi-fill BTC/USD sequence with an increase, partial close
+    and a flip, asserted against hand-computed Decimal expectations.
+
+    Sequence (in order):
+      F1 BUY  2 @ 30000 fee 12.0  -> long 2 @ 30000
+      F2 BUY  1 @ 33000 fee 6.6   -> long 3 @ 31000  (avg (60000+33000)/3)
+      F3 SELL 1 @ 35000 fee 7.0   -> long 2 @ 31000, close 1 -> gross +4000
+      F4 SELL 5 @ 36000 fee 36.0  -> FLIP: close 2 @ 31000 -> gross +10000,
+                                     open short 3 @ 36000
+
+    Hand-computed final:
+      net_qty         = 2 + 1 - 1 - 5 = -3
+      avg_entry_price = 36000 (the flipping fill's price)
+      fees_paid       = 12.0 + 6.6 + 7.0 + 36.0 = 61.6
+      gross realised  = 4000 + 10000 = 14000
+      realised_pnl    = 14000 - 61.6 = 13938.4
+    """
+
+    def test_realistic_flip_sequence(self) -> None:
+        fills = [
+            make_fill(
+                side=OrderSide.BUY, qty="2", price="30000", fee="12.0",
+                fill_id="T1", ts=1_700_000_000_000,
+            ),
+            make_fill(
+                side=OrderSide.BUY, qty="1", price="33000", fee="6.6",
+                fill_id="T2", ts=1_700_000_060_000,
+            ),
+            make_fill(
+                side=OrderSide.SELL, qty="1", price="35000", fee="7.0",
+                fill_id="T3", ts=1_700_000_120_000,
+            ),
+            make_fill(
+                side=OrderSide.SELL, qty="5", price="36000", fee="36.0",
+                fill_id="T4", ts=1_700_000_180_000,
+            ),
+        ]
+        pos = Position.from_fills(fills)
+
+        assert pos.net_qty == money("-3")
+        assert pos.avg_entry_price == money("36000")
+        assert pos.realised_pnl == money("13938.4")
+        assert pos.fees_paid == money("61.6")
+        # Exact-Decimal guarantee: no binary float contamination.
+        assert isinstance(pos.realised_pnl, Decimal)
+        assert pos.realised_pnl == Decimal("13938.4")


### PR DESCRIPTION
## Summary
- Third leaf of **E1 — Domain core**: `domain/fill.py` + `domain/position.py`.
- `Fill` (immutable broker-confirmed execution — the PnL source of truth) and `Position.from_fills` (net exposure: increases, partial closes, flips, fee-aware realised PnL).

## Why
- Positions must be reconstructable from fills alone (reconcile-don't-assume). Flip/fee/PnL conventions recorded in `doc/dev/03-decisions.md`.

## Changes
- `domain/fill.py`, `domain/position.py`, `InstrumentMismatch` error, exports; `tests/domain/test_fill_position.py` (28 tests, 100% coverage on both modules).

## Changelog
Added under [Unreleased]:
- `Fill` and `Position` — net exposure rebuilt from an ordered fill sequence (flips, fee-aware realised PnL).

## Test plan
- [x] `pytest` (123 passed, 100% domain coverage)
- [x] `ruff check trading_bot/`
- [x] `mypy trading_bot/` (strict on domain)
- [ ] CI green