### PR TITLE
feat: signal domain type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (market/limit/stop-loss/best-limit), with exact Decimal fill accounting. (#8)
 - `Fill` and `Position` — net exposure rebuilt from an ordered fill sequence
   (flips, fee-aware realised PnL). (#9)
+- `Signal` — venue-neutral strategy target (fractional exposure or explicit
+  target quantity) with `delta_to(position)`. (#10)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,22 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Signal: two-mode venue-neutral target (PR #10)
+
+**Decision.** `domain/signal.py` expresses a strategy target in one of two
+validated modes — fractional exposure in `[-1, 1]` or an explicit signed target
+quantity (named constructors `Signal.exposure` / `Signal.target_qty`).
+`delta_to(position, reference_qty=None)` returns the signed change to reach the
+target; fractional mode **requires** a positive `reference_qty` (max position
+size) to scale the exposure into a quantity. This unifies the legacy `signal`
+(cumulative target) and `delta_signal` (per-step change) vocabulary.
+
+**Why.** Strategies think in normalised exposure; execution needs concrete
+quantities. Carrying both modes (with explicit scaling) lets one `Signal` feed the
+order router and the PnL layer without a divergent vocabulary.
+
+---
+
 ### 2026-06-20 Position PnL & flip convention from fills (PR #9)
 
 **Decision.** `Position.from_fills` folds an **ordered** fill sequence: realised

--- a/doc/dev/plans/domain-core/00-plan.md
+++ b/doc/dev/plans/domain-core/00-plan.md
@@ -30,7 +30,7 @@ no imports from `transport`/`brokers`/`storage`. The pre-2026 tree
 - [x] 01 primitives — feat/domain-primitives — medium
 - [x] 02 order — feat/domain-order — high (depends on 01)
 - [x] 03 fill-position — feat/domain-fill-position — medium (depends on 02)
-- [ ] 04 signal — feat/domain-signal — low (depends on 01)
+- [x] 04 signal — feat/domain-signal — low (depends on 01)
 - [ ] 05 performance — feat/domain-performance — high (depends on 03)
 
 ## Dependencies

--- a/doc/dev/plans/domain-core/04-signal.md
+++ b/doc/dev/plans/domain-core/04-signal.md
@@ -1,7 +1,7 @@
 ---
 plan: domain-core/04-signal
 kind: leaf
-status: planned
+status: done
 complexity: low
 depends: [01]
 parallel: false

--- a/doc/dev/plans/domain-core/04-signal.md
+++ b/doc/dev/plans/domain-core/04-signal.md
@@ -6,7 +6,7 @@ complexity: low
 depends: [01]
 parallel: false
 branch: feat/domain-signal
-pr: ""
+pr: "#10"
 ---
 
 # Signal (venue-neutral strategy target)

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -19,6 +19,9 @@ Public surface:
 * fill — the immutable :class:`~trading_bot.domain.fill.Fill` execution record;
 * position — the :class:`~trading_bot.domain.position.Position` net exposure
   rebuilt from fills;
+* signal — the venue-neutral :class:`~trading_bot.domain.signal.Signal` strategy
+  target (:class:`~trading_bot.domain.signal.SignalMode`) and its delta to a
+  position;
 * errors — the :class:`~trading_bot.domain.errors.TradingBotError` hierarchy.
 """
 
@@ -32,6 +35,7 @@ from trading_bot.domain.errors import (
     OrderError,
     OrderStatusError,
     RiskLimitBreached,
+    SignalError,
     TradingBotError,
 )
 from trading_bot.domain.fill import Fill
@@ -58,6 +62,7 @@ from trading_bot.domain.order import (
     OrderType,
 )
 from trading_bot.domain.position import Position
+from trading_bot.domain.signal import Signal, SignalMode
 
 __all__ = [
     # money
@@ -83,6 +88,9 @@ __all__ = [
     "Fill",
     # position
     "Position",
+    # signal
+    "Signal",
+    "SignalMode",
     # errors
     "TradingBotError",
     "OrderError",
@@ -92,4 +100,5 @@ __all__ = [
     "InsufficientFunds",
     "RiskLimitBreached",
     "NoCapability",
+    "SignalError",
 ]

--- a/trading_bot/domain/errors.py
+++ b/trading_bot/domain/errors.py
@@ -24,6 +24,7 @@ __all__ = [
     "InsufficientFunds",
     "RiskLimitBreached",
     "NoCapability",
+    "SignalError",
 ]
 
 
@@ -152,6 +153,25 @@ class RiskLimitBreached(TradingBotError):
         super().__init__(
             f"risk limit {limit!r} breached: {value} exceeds {threshold}"
         )
+
+
+class SignalError(TradingBotError):
+    """A strategy signal is invalid (bad target, missing scale, ...).
+
+    Raised when constructing or resolving a
+    :class:`~trading_bot.domain.signal.Signal`: an out-of-range fractional
+    exposure, an ambiguous/double-specified target, or a fractional signal
+    resolved without the ``reference_qty`` scale it requires.
+
+    Parameters
+    ----------
+    msg : str
+        Human-readable detail of why the signal is invalid.
+
+    """
+
+    def __init__(self, msg: str) -> None:
+        super().__init__(msg)
 
 
 class NoCapability(TradingBotError):

--- a/trading_bot/domain/signal.py
+++ b/trading_bot/domain/signal.py
@@ -1,0 +1,320 @@
+"""The :class:`Signal` value object — a strategy's venue-neutral target.
+
+A :class:`Signal` is what a strategy *wants* an instrument's exposure to be, said
+once, venue-neutrally, before any broker or order type is involved. A future
+``StrategyRunner`` turns a signal plus the current
+:class:`~trading_bot.domain.position.Position` into an order; this module owns
+the arithmetic of "where I am vs. where I want to be".
+
+Two target modes
+----------------
+A strategy can express its target in one of **two** mutually-exclusive ways, and
+a signal is exactly one of them (constructing both, or neither, is rejected):
+
+* **fractional exposure** — a normalised number in ``[-1, 1]`` where ``-1`` is
+  fully short, ``0`` is flat and ``+1`` is fully long. This is the natural
+  output of most strategies (a sign / a confidence in ``[-1, 1]``). It is a
+  *fraction of a reference size*, so it cannot be turned into a quantity on its
+  own: resolving it needs a ``reference_qty`` (the max position size, in base
+  units) supplied at :meth:`Signal.delta_to` time.
+
+* **explicit target quantity** — a signed :class:`~decimal.Decimal` (``+`` long,
+  ``-`` short, ``0`` flat) that *is* the desired net position in base units. It
+  carries its own scale, so :meth:`Signal.delta_to` needs no ``reference_qty``.
+
+The two are built with named constructors :meth:`Signal.exposure` and
+:meth:`Signal.target_qty`; the private ``__init__`` is not meant to be called
+directly. :attr:`Signal.mode` (a :class:`SignalMode`) tags which one a given
+signal is.
+
+The delta to a position
+------------------------
+:meth:`Signal.delta_to` returns the signed :class:`~decimal.Decimal` change the
+router must apply to reach the target from a current position::
+
+    delta = target_net_qty - position.net_qty
+
+For an explicit-qty signal ``target_net_qty`` is the target directly. For a
+fractional signal ``target_net_qty = exposure * reference_qty`` — hence the
+required ``reference_qty``. A positive delta means *buy that much base*, a
+negative delta means *sell*, zero means *already on target*. A flat target
+(``0``) against an open position yields ``-position.net_qty`` — a full close.
+
+Legacy mapping
+--------------
+This unifies the vocabulary of the legacy ``legacy/performance.py`` PnL columns
+(referenced, never imported):
+
+* legacy ``signal`` (``cumsum(delta_signal) + pos_init``) is the **target net
+  position** — i.e. an explicit-qty :class:`Signal`'s target;
+* legacy ``delta_signal`` (the per-step ``+1``/``-1`` position change) is the
+  output of :meth:`Signal.delta_to` — the change to apply to the current
+  position.
+
+So PnL (leaf 05) and the runner share one type: ``signal`` is the target, the
+``delta_to`` a :class:`Position` is the ``delta_signal``.
+
+The module is pure: no I/O, no async, money/quantities as
+:class:`~decimal.Decimal`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+from trading_bot.domain.errors import SignalError
+from trading_bot.domain.instrument import Instrument
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.position import Position
+
+__all__ = [
+    "SignalMode",
+    "Signal",
+]
+
+_ONE: Money = money("1")
+_NEG_ONE: Money = money("-1")
+
+
+class SignalMode(Enum):
+    """How a :class:`Signal`'s ``target`` should be interpreted."""
+
+    #: ``target`` is a normalised exposure in ``[-1, 1]`` (short..long); it is a
+    #: fraction of a reference size and needs a ``reference_qty`` to resolve.
+    EXPOSURE = "exposure"
+    #: ``target`` is an explicit signed net position quantity in base units.
+    TARGET_QTY = "target_qty"
+
+
+@dataclass(frozen=True, slots=True)
+class Signal:
+    """A strategy's venue-neutral target exposure for one instrument.
+
+    Immutable. Build one with :meth:`Signal.exposure` (a normalised ``[-1, 1]``
+    exposure) or :meth:`Signal.target_qty` (an explicit signed net quantity) —
+    never via the raw constructor, which does not validate the mode/target
+    pairing on its own intent. :meth:`delta_to` then computes the signed change
+    from a current :class:`~trading_bot.domain.position.Position`.
+
+    Parameters
+    ----------
+    instrument : Instrument
+        The instrument the target applies to.
+    mode : SignalMode
+        Whether :attr:`target` is a fractional exposure or an explicit quantity.
+    target : Decimal
+        In :data:`SignalMode.EXPOSURE` mode, a normalised exposure in
+        ``[-1, 1]``. In :data:`SignalMode.TARGET_QTY` mode, the signed desired
+        net position in base units.
+    ts : int
+        Timestamp the signal was produced, as **milliseconds since the Unix
+        epoch (UTC)** — the same unit as :attr:`~trading_bot.domain.fill.Fill.ts`.
+        Must be non-negative.
+    strength : Decimal or None, optional
+        Optional strategy confidence / conviction in ``[0, 1]`` (``None`` if the
+        strategy does not express one). Advisory metadata only: it does **not**
+        scale :meth:`delta_to`. Must be in ``[0, 1]`` when given.
+
+    Examples
+    --------
+    >>> from trading_bot.domain.instrument import Instrument, Symbol
+    >>> from trading_bot.domain.money import money
+    >>> inst = Instrument(Symbol("BTC", "USD"))
+    >>> Signal.exposure(inst, money("1"), ts=1).mode
+    <SignalMode.EXPOSURE: 'exposure'>
+    >>> Signal.target_qty(inst, money("2.5"), ts=1).target
+    Decimal('2.5')
+
+    """
+
+    instrument: Instrument
+    mode: SignalMode
+    target: Money
+    ts: int
+    strength: Money | None = None
+
+    def __post_init__(self) -> None:
+        """Validate the target against its mode, ``ts`` and ``strength``."""
+        if self.ts < 0:
+            raise SignalError(f"signal ts must be non-negative, got {self.ts}")
+
+        if self.mode is SignalMode.EXPOSURE:
+            if not (_NEG_ONE <= self.target <= _ONE):
+                raise SignalError(
+                    "exposure target must be in [-1, 1], got "
+                    f"{self.target}"
+                )
+        # TARGET_QTY accepts any signed Decimal (incl. 0 = flat); no bound.
+
+        if self.strength is not None and not (0 <= self.strength <= 1):
+            raise SignalError(
+                f"strength must be in [0, 1], got {self.strength}"
+            )
+
+    # --- named constructors ------------------------------------------------ #
+
+    @classmethod
+    def exposure(
+        cls,
+        instrument: Instrument,
+        target: Money,
+        *,
+        ts: int,
+        strength: Money | None = None,
+    ) -> Signal:
+        """Build a fractional-exposure signal (``target`` in ``[-1, 1]``).
+
+        Parameters
+        ----------
+        instrument : Instrument
+            The instrument the target applies to.
+        target : Decimal
+            Normalised exposure in ``[-1, 1]`` (``-1`` short, ``0`` flat, ``+1``
+            long).
+        ts : int
+            Timestamp in milliseconds since the Unix epoch (UTC).
+        strength : Decimal or None, optional
+            Optional confidence in ``[0, 1]`` (advisory only).
+
+        Returns
+        -------
+        Signal
+            A signal in :data:`SignalMode.EXPOSURE` mode.
+
+        Raises
+        ------
+        SignalError
+            If ``target`` is outside ``[-1, 1]`` (or ``strength``/``ts`` invalid).
+
+        """
+        return cls(
+            instrument=instrument,
+            mode=SignalMode.EXPOSURE,
+            target=target,
+            ts=ts,
+            strength=strength,
+        )
+
+    @classmethod
+    def target_qty(
+        cls,
+        instrument: Instrument,
+        target: Money,
+        *,
+        ts: int,
+        strength: Money | None = None,
+    ) -> Signal:
+        """Build an explicit target-quantity signal (signed net position).
+
+        Parameters
+        ----------
+        instrument : Instrument
+            The instrument the target applies to.
+        target : Decimal
+            The desired signed net position in base units (``+`` long, ``-``
+            short, ``0`` flat). Any magnitude is allowed.
+        ts : int
+            Timestamp in milliseconds since the Unix epoch (UTC).
+        strength : Decimal or None, optional
+            Optional confidence in ``[0, 1]`` (advisory only).
+
+        Returns
+        -------
+        Signal
+            A signal in :data:`SignalMode.TARGET_QTY` mode.
+
+        Raises
+        ------
+        SignalError
+            If ``strength``/``ts`` are invalid.
+
+        """
+        return cls(
+            instrument=instrument,
+            mode=SignalMode.TARGET_QTY,
+            target=target,
+            ts=ts,
+            strength=strength,
+        )
+
+    # --- views ------------------------------------------------------------- #
+
+    def target_net_qty(self, reference_qty: Money | None = None) -> Money:
+        """The desired *absolute* net position in base units.
+
+        For an explicit-qty signal this is :attr:`target` directly. For a
+        fractional signal it is ``target * reference_qty``, so ``reference_qty``
+        (the max position size in base units) is required.
+
+        Parameters
+        ----------
+        reference_qty : Decimal or None, optional
+            The reference size (max position, in base units) a fractional
+            exposure is a fraction of. Required for
+            :data:`SignalMode.EXPOSURE` signals; ignored for
+            :data:`SignalMode.TARGET_QTY` signals.
+
+        Returns
+        -------
+        Decimal
+            The signed target net quantity in base units.
+
+        Raises
+        ------
+        SignalError
+            If this is a fractional signal and ``reference_qty`` is ``None`` or
+            not strictly positive.
+
+        """
+        if self.mode is SignalMode.TARGET_QTY:
+            return self.target
+        # EXPOSURE: needs a positive scale to become a quantity.
+        if reference_qty is None:
+            raise SignalError(
+                "a fractional-exposure signal needs a reference_qty to resolve "
+                "into a target quantity"
+            )
+        if reference_qty <= 0:
+            raise SignalError(
+                f"reference_qty must be positive, got {reference_qty}"
+            )
+        return self.target * reference_qty
+
+    def delta_to(
+        self, position: Position, reference_qty: Money | None = None
+    ) -> Money:
+        """The signed position change to reach this target from ``position``.
+
+        ``delta = target_net_qty - position.net_qty``. A positive result means
+        *buy* that many base units, a negative result means *sell*, and ``0``
+        means the position is already on target. A flat target (``0``) against
+        an open position returns ``-position.net_qty`` — a full close.
+
+        Parameters
+        ----------
+        position : Position
+            The current net exposure for the instrument.
+        reference_qty : Decimal or None, optional
+            The reference size a fractional exposure is a fraction of (in base
+            units). **Required** for :data:`SignalMode.EXPOSURE` signals;
+            ignored for :data:`SignalMode.TARGET_QTY` signals.
+
+        Returns
+        -------
+        Decimal
+            The signed quantity change to apply (the router's order size/side).
+
+        Raises
+        ------
+        SignalError
+            If this is a fractional signal and ``reference_qty`` is missing or
+            not positive.
+
+        Notes
+        -----
+        This is the modern equivalent of the legacy ``delta_signal`` column,
+        while :meth:`target_net_qty` is the legacy ``signal`` (target position).
+
+        """
+        return self.target_net_qty(reference_qty) - position.net_qty

--- a/trading_bot/tests/domain/test_signal.py
+++ b/trading_bot/tests/domain/test_signal.py
@@ -1,0 +1,233 @@
+"""Tests for the Signal venue-neutral strategy target and its delta-to-position."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from trading_bot.domain.errors import SignalError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.order import OrderSide
+from trading_bot.domain.position import Position
+from trading_bot.domain.signal import Signal, SignalMode
+
+BTCUSD = Instrument(Symbol("BTC", "USD"), price_precision=1, qty_precision=8)
+
+
+def position_with(net_qty: str, *, entry: str = "30000") -> Position:
+    """Build a Position with a given signed net quantity via a single fill."""
+    qty = money(net_qty)
+    if qty == 0:
+        # A flat position: open then fully close.
+        buy = Fill("T1", "cid", BTCUSD, OrderSide.BUY, money("1"), money(entry),
+                   money("0"), 1)
+        sell = Fill("T2", "cid", BTCUSD, OrderSide.SELL, money("1"), money(entry),
+                    money("0"), 2)
+        return Position.from_fills([buy, sell])
+    side = OrderSide.BUY if qty > 0 else OrderSide.SELL
+    fill = Fill("T1", "cid", BTCUSD, side, abs(qty), money(entry), money("0"), 1)
+    return Position.from_fills([fill])
+
+
+class TestConstruction:
+    def test_exposure_mode_tag(self) -> None:
+        s = Signal.exposure(BTCUSD, money("1"), ts=1)
+        assert s.mode is SignalMode.EXPOSURE
+        assert s.target == money("1")
+
+    def test_target_qty_mode_tag(self) -> None:
+        s = Signal.target_qty(BTCUSD, money("2.5"), ts=1)
+        assert s.mode is SignalMode.TARGET_QTY
+        assert s.target == money("2.5")
+
+    def test_frozen_immutable(self) -> None:
+        s = Signal.exposure(BTCUSD, money("0.5"), ts=1)
+        with pytest.raises(AttributeError):
+            s.target = money("0.1")  # type: ignore[misc]
+
+    def test_optional_strength_default_none(self) -> None:
+        assert Signal.exposure(BTCUSD, money("0.5"), ts=1).strength is None
+
+    def test_strength_accepted_in_range(self) -> None:
+        s = Signal.exposure(BTCUSD, money("0.5"), ts=1, strength=money("0.8"))
+        assert s.strength == money("0.8")
+
+    def test_negative_ts_rejected(self) -> None:
+        with pytest.raises(SignalError, match="ts"):
+            Signal.target_qty(BTCUSD, money("1"), ts=-1)
+
+
+class TestTargetValidation:
+    def test_exposure_above_one_rejected(self) -> None:
+        with pytest.raises(SignalError, match=r"\[-1, 1\]"):
+            Signal.exposure(BTCUSD, money("1.5"), ts=1)
+
+    def test_exposure_below_minus_one_rejected(self) -> None:
+        with pytest.raises(SignalError, match=r"\[-1, 1\]"):
+            Signal.exposure(BTCUSD, money("-1.5"), ts=1)
+
+    def test_exposure_bounds_inclusive(self) -> None:
+        # The exact bounds are valid.
+        assert Signal.exposure(BTCUSD, money("1"), ts=1).target == money("1")
+        assert Signal.exposure(BTCUSD, money("-1"), ts=1).target == money("-1")
+        assert Signal.exposure(BTCUSD, money("0"), ts=1).target == money("0")
+
+    def test_target_qty_allows_magnitude_above_one(self) -> None:
+        # An explicit quantity is not bounded by [-1, 1].
+        s = Signal.target_qty(BTCUSD, money("12.5"), ts=1)
+        assert s.target == money("12.5")
+
+    def test_strength_above_one_rejected(self) -> None:
+        with pytest.raises(SignalError, match="strength"):
+            Signal.exposure(BTCUSD, money("0.5"), ts=1, strength=money("1.5"))
+
+    def test_strength_negative_rejected(self) -> None:
+        with pytest.raises(SignalError, match="strength"):
+            Signal.target_qty(BTCUSD, money("1"), ts=1, strength=money("-0.1"))
+
+
+class TestDeltaToExplicitQty:
+    def test_long_target_from_flat(self) -> None:
+        s = Signal.target_qty(BTCUSD, money("2"), ts=1)
+        assert s.delta_to(position_with("0")) == money("2")
+
+    def test_increase_long(self) -> None:
+        # Hold 1.5, want 4 -> buy 2.5.
+        s = Signal.target_qty(BTCUSD, money("4"), ts=1)
+        assert s.delta_to(position_with("1.5")) == money("2.5")
+
+    def test_reduce_long(self) -> None:
+        # Hold 4, want 1 -> sell 3.
+        s = Signal.target_qty(BTCUSD, money("1"), ts=1)
+        assert s.delta_to(position_with("4")) == money("-3")
+
+    def test_flip_long_to_short(self) -> None:
+        # Hold +2, want -1 -> delta -3.
+        s = Signal.target_qty(BTCUSD, money("-1"), ts=1)
+        assert s.delta_to(position_with("2")) == money("-3")
+
+    def test_flat_target_from_long_full_close(self) -> None:
+        s = Signal.target_qty(BTCUSD, money("0"), ts=1)
+        assert s.delta_to(position_with("3")) == money("-3")
+
+    def test_flat_target_from_short_full_close(self) -> None:
+        s = Signal.target_qty(BTCUSD, money("0"), ts=1)
+        assert s.delta_to(position_with("-2")) == money("2")
+
+    def test_already_on_target_zero_delta(self) -> None:
+        s = Signal.target_qty(BTCUSD, money("2"), ts=1)
+        assert s.delta_to(position_with("2")) == money("0")
+
+
+class TestDeltaToExposure:
+    REF = money("10")  # reference_qty: max position of 10 base units.
+
+    def test_full_long_from_flat(self) -> None:
+        # exposure +1 * 10 = target +10, from flat -> buy 10.
+        s = Signal.exposure(BTCUSD, money("1"), ts=1)
+        assert s.delta_to(position_with("0"), self.REF) == money("10")
+
+    def test_half_long_from_flat(self) -> None:
+        s = Signal.exposure(BTCUSD, money("0.5"), ts=1)
+        assert s.delta_to(position_with("0"), self.REF) == money("5")
+
+    def test_full_short_from_flat(self) -> None:
+        s = Signal.exposure(BTCUSD, money("-1"), ts=1)
+        assert s.delta_to(position_with("0"), self.REF) == money("-10")
+
+    def test_reduce_from_long(self) -> None:
+        # Hold +10, want exposure 0.3 -> target +3 -> sell 7.
+        s = Signal.exposure(BTCUSD, money("0.3"), ts=1)
+        assert s.delta_to(position_with("10"), self.REF) == money("-7")
+
+    def test_flat_exposure_from_long_full_close(self) -> None:
+        s = Signal.exposure(BTCUSD, money("0"), ts=1)
+        assert s.delta_to(position_with("6"), self.REF) == money("-6")
+
+    def test_flip_long_to_short_via_exposure(self) -> None:
+        # Hold +4, want exposure -1 -> target -10 -> delta -14.
+        s = Signal.exposure(BTCUSD, money("-1"), ts=1)
+        assert s.delta_to(position_with("4"), self.REF) == money("-14")
+
+    def test_missing_reference_qty_rejected(self) -> None:
+        s = Signal.exposure(BTCUSD, money("0.5"), ts=1)
+        with pytest.raises(SignalError, match="reference_qty"):
+            s.delta_to(position_with("0"))
+
+    def test_non_positive_reference_qty_rejected(self) -> None:
+        s = Signal.exposure(BTCUSD, money("0.5"), ts=1)
+        with pytest.raises(SignalError, match="reference_qty"):
+            s.delta_to(position_with("0"), money("0"))
+
+    def test_target_qty_ignores_reference_qty(self) -> None:
+        # reference_qty is irrelevant for explicit-qty signals.
+        s = Signal.target_qty(BTCUSD, money("3"), ts=1)
+        assert s.delta_to(position_with("1"), money("999")) == money("2")
+        assert s.target_net_qty() == money("3")
+
+
+class TestTargetNetQty:
+    def test_exposure_scaled(self) -> None:
+        s = Signal.exposure(BTCUSD, money("0.25"), ts=1)
+        assert s.target_net_qty(money("8")) == money("2.00")
+
+    def test_target_qty_direct(self) -> None:
+        s = Signal.target_qty(BTCUSD, money("5"), ts=1)
+        assert s.target_net_qty() == money("5")
+
+
+class TestRealDataSeries:
+    """A realistic signal series over a long/short/flat position series.
+
+    Mirrors the legacy ``signal``/``delta_signal`` vocabulary: ``target_net_qty``
+    is the legacy ``signal`` (target position), ``delta_to`` is ``delta_signal``
+    (the change to apply).
+    """
+
+    def test_explicit_qty_series(self) -> None:
+        # Position series and the target each step should drive toward.
+        steps: list[tuple[str, str, str]] = [
+            # (current net_qty, target_qty, expected delta)
+            ("0", "5", "5"),     # open long
+            ("5", "8", "3"),     # add to long
+            ("8", "-4", "-12"),  # flip to short
+            ("-4", "0", "4"),    # close to flat
+            ("0", "-3", "-3"),   # open short
+        ]
+        for cur, tgt, expected in steps:
+            sig = Signal.target_qty(BTCUSD, money(tgt), ts=1)
+            assert sig.delta_to(position_with(cur)) == money(expected)
+
+    def test_fractional_exposure_series(self) -> None:
+        ref = money("20")
+        steps: list[tuple[str, str, str]] = [
+            # (current net_qty, exposure, expected delta) with ref=20
+            ("0", "1", "20"),       # full long
+            ("20", "0.5", "-10"),   # halve exposure
+            ("10", "-1", "-30"),    # flip to full short
+            ("-20", "0", "20"),     # flat
+            ("0", "-0.25", "-5"),   # quarter short
+        ]
+        for cur, exp, expected in steps:
+            sig = Signal.exposure(BTCUSD, money(exp), ts=1)
+            assert sig.delta_to(position_with(cur), ref) == money(expected)
+
+    def test_deltas_sum_to_reach_target_invariant(self) -> None:
+        # Applying delta to a position lands exactly on the target (legacy
+        # invariant: position[t+1] == signal[t]).
+        ref: Money = money("10")
+        cur: Decimal = money("0")
+        for exp in ("0.5", "1", "-1", "0", "0.3"):
+            sig = Signal.exposure(BTCUSD, money(exp), ts=1)
+            pos = position_with(_qty_str(cur))
+            delta = sig.delta_to(pos, ref)
+            cur = pos.net_qty + delta
+            assert cur == sig.target_net_qty(ref)
+
+
+def _qty_str(d: Decimal) -> str:
+    """Render a Decimal net qty back to a plain string for position_with."""
+    return format(d, "f")


### PR DESCRIPTION
## Summary
- Fourth leaf of **E1 — Domain core**: `domain/signal.py`.
- `Signal` — venue-neutral strategy target in two validated modes (fractional exposure `[-1,1]` or explicit target qty) + `delta_to(position)`.

## Why
- Strategies think in normalised exposure; execution needs concrete quantities. One `Signal` feeds both the order router and PnL, unifying the legacy `signal`/`delta_signal` vocabulary. See `doc/dev/03-decisions.md`.

## Changes
- `domain/signal.py` (+ `SignalMode`, `SignalError`), exports; `tests/domain/test_signal.py` (36 tests, 100% coverage on signal.py).

## Changelog
Added under [Unreleased]:
- `Signal` — venue-neutral strategy target (fractional exposure or explicit target quantity) with `delta_to(position)`.

## Test plan
- [x] `pytest` (156 passed, 100% domain coverage)
- [x] `ruff check trading_bot/`
- [x] `mypy trading_bot/` (strict on domain)
- [ ] CI green