### PR TITLE
feat: pure PnL/KPI performance functions (closes E1 domain core)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (flips, fee-aware realised PnL). (#9)
 - `Signal` — venue-neutral strategy target (fractional exposure or explicit
   target quantity) with `delta_to(position)`. (#10)
+- Pure PnL/KPI performance functions — `pnl`/`cum_pnl`/`equity_curve` (Decimal),
+  with Sharpe/Sortino/max-drawdown/Calmar delegated to fynance. Completes the
+  **E1 domain core**. (#11)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,22 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Performance: pure PnL core, KPI delegated to fynance (PR #11)
+
+**Decision.** `domain/performance.py` keeps the PnL/cum-PnL/equity core pure
+(numpy/Decimal) and delegates KPI (Sharpe, Sortino, max-drawdown, Calmar) to
+**fynance**, imported **lazily** inside each wrapper (`PerformanceDependencyError`
+if absent). KPI tests are `pytest.importorskip("fynance")`-gated. mypy stays strict
+on the domain via a **typed wrapper** at the boundary (no `pyproject` override) —
+fynance results coerced through `float()`.
+
+**Why.** Reuse fynance's vetted metric implementations rather than reimplement
+them; the lazy import + skip-gate keep the module importable and the suite green
+where fynance (numba) isn't installed, while CI exercises the parity. Decimal money
+math stays in the pure core where exactness matters.
+
+---
+
 ### 2026-06-20 Signal: two-mode venue-neutral target (PR #10)
 
 **Decision.** `domain/signal.py` expresses a strategy target in one of two

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,11 +10,11 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**The rewrite has begun.** `domain/` exists with the primitives — `money`
-(Decimal, float-guarded), `instrument` (Kraken normalisation), `errors` (E1 leaf
-01 landed). The remaining domain leaves (order, fill/position, signal, performance)
-and the later layers (`transport`, `brokers`, `storage`, `application`,
-`interfaces`) are pending — see `07-roadmap.md` / `08-program-plan.md`.
+**E1 — Domain core is complete.** `trading_bot/domain/` exposes `money`,
+`instrument`, `errors`, `order`, `fill`, `position`, `signal`, `performance` —
+pure, mypy-strict, ~180 tests (KPI parity import-gated on fynance). The later
+layers (`transport`, `brokers`, `storage`, `application`, `interfaces`) are
+pending — next is **E2 (transport)**. See `07-roadmap.md` / `08-program-plan.md`.
 
 ## Done
 
@@ -22,10 +22,12 @@ and the later layers (`transport`, `brokers`, `storage`, `application`,
 - Modern packaging + tooling + CI + Git Flow.
 - Claude Code workflow wired (`/pick-task` … `/release` resolve against this repo).
 - Developer brief (`doc/dev/`) and rewrite roadmap.
+- **E1 — Domain core**: `domain/` (money, instrument, errors, order, fill,
+  position, signal, performance) — pure, mypy-strict, tested.
 
 ## Pending
 
-Everything in [`07-roadmap.md`](07-roadmap.md): the domain core, transport, the
+Everything remaining in [`07-roadmap.md`](07-roadmap.md): transport, the
 Kraken broker + paper broker, the order router, the strategy runner, performance/
 risk, the CLI, the orchestration layer, and (later) the UI and go-live hardening.
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,10 +12,6 @@ The single source *index* of open work. Each unchecked item is a candidate for
 
 ## Foundation
 
-- [ ] **E1 — Domain core.** `Order` (+ lifecycle state machine), `Position`,
-  `Fill`, `Signal`, `Instrument`, `Money` (Decimal), pure PnL/KPI, errors. Pure,
-  typed strict, unit-tested. Mine `legacy/orders.py` + `legacy/performance.py` for
-  spec.
 - [ ] **E2 — Transport.** `AsyncHTTPClient` (httpx + retry/backoff),
   `WebSocketBase` (reconnect), `RateLimiter` (token-bucket / Kraken call-counter).
   Mirror dccd's transport. _(depends on E1 for typing only)_

--- a/doc/dev/plans/domain-core/00-plan.md
+++ b/doc/dev/plans/domain-core/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: domain-core
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E1 — Domain core.** `Order` (+ lifecycle state machine), `Position`, `Fill`, `Signal`, `Instrument`, `Money` (Decimal), pure PnL/KPI, errors."
 release_on_done: false
 ---
@@ -31,7 +31,7 @@ no imports from `transport`/`brokers`/`storage`. The pre-2026 tree
 - [x] 02 order — feat/domain-order — high (depends on 01)
 - [x] 03 fill-position — feat/domain-fill-position — medium (depends on 02)
 - [x] 04 signal — feat/domain-signal — low (depends on 01)
-- [ ] 05 performance — feat/domain-performance — high (depends on 03)
+- [x] 05 performance — feat/domain-performance — high (depends on 03)
 
 ## Dependencies
 

--- a/doc/dev/plans/domain-core/05-performance.md
+++ b/doc/dev/plans/domain-core/05-performance.md
@@ -1,7 +1,7 @@
 ---
 plan: domain-core/05-performance
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [03]
 parallel: false

--- a/doc/dev/plans/domain-core/05-performance.md
+++ b/doc/dev/plans/domain-core/05-performance.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [03]
 parallel: false
 branch: feat/domain-performance
-pr: ""
+pr: "#11"
 ---
 
 # Pure PnL / KPI performance functions

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -61,6 +61,21 @@ from trading_bot.domain.order import (
     OrderStatus,
     OrderType,
 )
+from trading_bot.domain.performance import (
+    PerformanceDependencyError,
+    calmar,
+    cum_pnl,
+    equity_array,
+    equity_curve,
+    exchanged_volume,
+    fee_series,
+    max_drawdown,
+    pnl,
+    position_series,
+    returns,
+    sharpe,
+    sortino,
+)
 from trading_bot.domain.position import Position
 from trading_bot.domain.signal import Signal, SignalMode
 
@@ -91,6 +106,20 @@ __all__ = [
     # signal
     "Signal",
     "SignalMode",
+    # performance
+    "returns",
+    "exchanged_volume",
+    "position_series",
+    "fee_series",
+    "pnl",
+    "cum_pnl",
+    "equity_curve",
+    "equity_array",
+    "sharpe",
+    "sortino",
+    "max_drawdown",
+    "calmar",
+    "PerformanceDependencyError",
     # errors
     "TradingBotError",
     "OrderError",

--- a/trading_bot/domain/performance.py
+++ b/trading_bot/domain/performance.py
@@ -1,0 +1,561 @@
+"""Pure PnL / KPI performance functions over a fill + price sequence.
+
+This module is the modern, pure replacement for the legacy ``_PnLI`` /
+``_PnLR`` / ``_FullPnL`` objects (``trading_bot/legacy/performance.py``,
+referenced never imported). It rebuilds a strategy's profit-and-loss from the
+**source of truth** — an ordered sequence of :class:`~trading_bot.domain.fill.
+Fill` records — marked against a price series, and exposes the KPI ratios
+(Sharpe, Sortino, max drawdown, Calmar) by delegating to **fynance**.
+
+Two-tier design (money vs. series)
+----------------------------------
+The legacy ``_PnLI`` carried a single wide table whose columns were
+``['price', 'returns', 'volume', 'exchanged_volume', 'position', 'signal',
+'delta_signal', 'fee', 'PnL', 'cumPnL', 'value']``. Here that table is decomposed
+into small, individually-testable typed functions:
+
+* **money boundary — exact :class:`~decimal.Decimal`.** :func:`position_series`,
+  :func:`fee_series`, :func:`pnl`, :func:`cum_pnl` and :func:`equity_curve`
+  return tuples of ``Decimal``. Quantities, prices and fees never round-trip
+  through ``float`` — the PnL of a real book must reconcile to the cent.
+* **KPI series — ``float`` numpy.** The risk ratios are statistical estimators
+  over a returns/equity path where ``float64`` is both sufficient and what
+  fynance consumes. :func:`equity_array` bridges the two: it converts an exact
+  equity curve into a ``float64`` ``numpy`` array to feed the KPI wrappers.
+
+PnL convention (ported from legacy ``_get_PnL``)
+------------------------------------------------
+The legacy mark-to-market step was ``PnL_t = volume_t * returns_t * position_t
+- fee_t`` with ``returns_t = price_t - price_{t-1}`` (an **absolute** price
+change, not a percentage) and ``position_t`` the *signed* net exposure held
+*going into* step ``t``. We keep exactly that: at each mark, the open signed
+position earns the absolute price move since the previous mark, then the step's
+fee is subtracted. Concretely, for marks ``p_0 .. p_n`` and the signed net
+position ``q_{t-1}`` held over the interval ``(t-1, t]``::
+
+    pnl_t = q_{t-1} * (p_t - p_{t-1}) - fee_t          (t >= 1)
+    pnl_0 = -fee_0
+
+``cum_pnl`` is the running sum and ``equity = v0 + cum_pnl`` (legacy
+``value = cumPnL + v0``).
+
+The inputs
+----------
+The functions take an **ordered** ``Sequence[Fill]`` (one instrument; in
+execution order — the same contract as :meth:`~trading_bot.domain.position.
+Position.from_fills`) plus a **mark price series**: a ``Sequence[Money]`` of one
+price per fill, the price at which the book is marked when that fill lands. The
+price series and the fill series share one index, so ``returns[t]`` is the move
+from mark ``t-1`` to mark ``t``. Pass ``v0`` (initial capital) to anchor the
+equity curve; it defaults to ``money("0")`` so ``equity_curve`` is just the
+cumulative PnL when no starting capital is given.
+
+fynance, lazily
+---------------
+fynance is a heavy optional dependency (the ``[triptych]`` extra) and is **not
+importable in every environment**. The PnL core above is pure numpy/Decimal and
+never touches it. The KPI wrappers :func:`sharpe`, :func:`sortino`,
+:func:`max_drawdown` and :func:`calmar` import fynance **lazily, inside the
+function body**, so ``import trading_bot.domain.performance`` always succeeds.
+When fynance is absent the wrappers raise :class:`PerformanceDependencyError`
+(a :class:`~trading_bot.domain.errors.TradingBotError`).
+
+The module is pure: no I/O, no async, deterministic in fill order.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from trading_bot.domain.errors import TradingBotError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.money import Money, money
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+__all__ = [
+    "PerformanceDependencyError",
+    "returns",
+    "exchanged_volume",
+    "position_series",
+    "fee_series",
+    "pnl",
+    "cum_pnl",
+    "equity_curve",
+    "equity_array",
+    "sharpe",
+    "sortino",
+    "max_drawdown",
+    "calmar",
+]
+
+_ZERO: Money = money("0")
+
+
+class PerformanceDependencyError(TradingBotError):
+    """A KPI wrapper needs fynance but it is not importable.
+
+    The PnL core of :mod:`trading_bot.domain.performance` is pure numpy/Decimal,
+    but the KPI ratios (Sharpe, Sortino, max drawdown, Calmar) delegate to
+    fynance — an optional ``[triptych]`` dependency. This is raised when one of
+    those wrappers is called in an environment where ``import fynance`` fails.
+
+    Parameters
+    ----------
+    func : str
+        Name of the KPI function that required fynance.
+
+    """
+
+    def __init__(self, func: str) -> None:
+        self.func = func
+        super().__init__(
+            f"{func}() requires the optional 'fynance' dependency "
+            "(install the 'triptych' extra: pip install trading_bot[triptych])"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Input validation
+# --------------------------------------------------------------------------- #
+
+
+def _check_aligned(fills: Sequence[Fill], prices: Sequence[Money]) -> None:
+    """Require a non-empty fill series and a price series of equal length."""
+    if len(fills) != len(prices):
+        raise ValueError(
+            f"prices and fills must have equal length, "
+            f"got {len(prices)} prices for {len(fills)} fills"
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Pure PnL core — exact Decimal at the money boundary
+# --------------------------------------------------------------------------- #
+
+
+def returns(prices: Sequence[Money]) -> tuple[Money, ...]:
+    """Per-step **absolute** price changes (legacy ``_get_returns``).
+
+    Ported from ``_PnLI._get_returns``: ``returns[t] = price[t] - price[t-1]``
+    with ``returns[0] = 0``. These are absolute moves in quote units, *not*
+    percentage returns — they are multiplied by the held quantity to give a
+    mark-to-market PnL.
+
+    Parameters
+    ----------
+    prices : Sequence[Money]
+        The mark price series, one price per step, in chronological order.
+
+    Returns
+    -------
+    tuple of Decimal
+        The first-difference series, same length as ``prices`` (the first
+        element is ``0``). Empty input yields an empty tuple.
+
+    """
+    if not prices:
+        return ()
+    out = [_ZERO]
+    for prev, cur in zip(prices[:-1], prices[1:], strict=True):
+        out.append(cur - prev)
+    return tuple(out)
+
+
+def exchanged_volume(fills: Sequence[Fill]) -> tuple[Money, ...]:
+    """Per-step traded base volume (legacy ``exchanged_volume`` column).
+
+    The magnitude of base units that changed hands at each step — ``fill.qty``,
+    unsigned. Ported from ``_PnLI._get_exch_vol`` (the per-timestamp sum of
+    executed volume); with one fill per step this is simply each fill's ``qty``.
+
+    Parameters
+    ----------
+    fills : Sequence[Fill]
+        The ordered fills.
+
+    Returns
+    -------
+    tuple of Decimal
+        The exchanged base volume at each step.
+
+    """
+    return tuple(f.qty for f in fills)
+
+
+def position_series(fills: Sequence[Fill], *, initial: Money = _ZERO) -> tuple[Money, ...]:
+    """Signed net position held **going into** each step.
+
+    The exposure carried over the interval ending at step ``t`` — i.e. the net
+    position *after* folding fills ``0 .. t-1`` (legacy ``_get_pos``'s ``ex_pos``
+    snapshot taken before the step's own fill). ``position[0] == initial`` (the
+    legacy ``pos_init``), and ``position[t]`` accumulates each prior fill's
+    signed quantity. This is the quantity that earns step ``t``'s price move in
+    :func:`pnl`.
+
+    Parameters
+    ----------
+    fills : Sequence[Fill]
+        The ordered fills.
+    initial : Decimal, optional
+        The net position held before the first fill (legacy ``ex_pos[0]`` /
+        ``pos_init``). Defaults to flat (``0``).
+
+    Returns
+    -------
+    tuple of Decimal
+        The signed net position before each step, same length as ``fills``.
+
+    """
+    out: list[Money] = []
+    held = initial
+    for f in fills:
+        out.append(held)
+        held = held + f.signed_qty
+    return tuple(out)
+
+
+def fee_series(fills: Sequence[Fill]) -> tuple[Money, ...]:
+    """Per-step fee charged, in quote units (legacy ``_get_fee``).
+
+    Each fill's ``fee`` directly (already in quote units in the modern
+    :class:`~trading_bot.domain.fill.Fill`, like the legacy real-mode
+    ``_PnLR._get_fee`` which summed the venue-reported ``fee`` column — as
+    opposed to ``_PnLI`` which derived it from a percentage).
+
+    Parameters
+    ----------
+    fills : Sequence[Fill]
+        The ordered fills.
+
+    Returns
+    -------
+    tuple of Decimal
+        The fee paid at each step.
+
+    """
+    return tuple(f.fee for f in fills)
+
+
+def pnl(
+    fills: Sequence[Fill],
+    prices: Sequence[Money],
+    *,
+    initial_position: Money = _ZERO,
+) -> tuple[Money, ...]:
+    """Per-step mark-to-market PnL (legacy ``_get_PnL``).
+
+    At each step the signed net position held *going into* the step earns the
+    absolute price move since the previous mark, then the step's fee is
+    subtracted::
+
+        pnl_t = position_t * returns_t - fee_t
+
+    where ``position_t`` is :func:`position_series` (the exposure carried over
+    the interval ``(t-1, t]``), ``returns_t`` is :func:`returns` (the absolute
+    move ``price_t - price_{t-1}``, zero at ``t == 0``) and ``fee_t`` is
+    :func:`fee_series`. This is exactly the legacy ``volume * returns * position
+    - fee`` with ``volume * position`` collapsed into the signed held quantity.
+
+    Parameters
+    ----------
+    fills : Sequence[Fill]
+        The ordered fills (one instrument, execution order).
+    prices : Sequence[Money]
+        The mark price series, one price per fill, same length as ``fills``.
+    initial_position : Decimal, optional
+        Net position held before the first fill. Defaults to flat.
+
+    Returns
+    -------
+    tuple of Decimal
+        The per-step PnL, same length as ``fills``.
+
+    Raises
+    ------
+    ValueError
+        If ``prices`` and ``fills`` differ in length.
+
+    """
+    _check_aligned(fills, prices)
+    pos = position_series(fills, initial=initial_position)
+    rets = returns(prices)
+    fees = fee_series(fills)
+    return tuple(
+        p * r - fee for p, r, fee in zip(pos, rets, fees, strict=True)
+    )
+
+
+def cum_pnl(
+    fills: Sequence[Fill],
+    prices: Sequence[Money],
+    *,
+    initial_position: Money = _ZERO,
+) -> tuple[Money, ...]:
+    """Cumulative (running-sum) PnL (legacy ``cumPnL = cumsum(PnL)``).
+
+    Parameters
+    ----------
+    fills : Sequence[Fill]
+        The ordered fills.
+    prices : Sequence[Money]
+        The mark price series aligned to ``fills``.
+    initial_position : Decimal, optional
+        Net position held before the first fill. Defaults to flat.
+
+    Returns
+    -------
+    tuple of Decimal
+        The running cumulative PnL, same length as ``fills``.
+
+    Raises
+    ------
+    ValueError
+        If ``prices`` and ``fills`` differ in length.
+
+    """
+    steps = pnl(fills, prices, initial_position=initial_position)
+    out: list[Money] = []
+    running = _ZERO
+    for step in steps:
+        running = running + step
+        out.append(running)
+    return tuple(out)
+
+
+def equity_curve(
+    fills: Sequence[Fill],
+    prices: Sequence[Money],
+    *,
+    v0: Money = _ZERO,
+    initial_position: Money = _ZERO,
+) -> tuple[Money, ...]:
+    """The equity (account value) curve (legacy ``value = cumPnL + v0``).
+
+    The initial capital ``v0`` plus the cumulative PnL at each step.
+
+    Parameters
+    ----------
+    fills : Sequence[Fill]
+        The ordered fills.
+    prices : Sequence[Money]
+        The mark price series aligned to ``fills``.
+    v0 : Decimal, optional
+        Initial capital available to the strategy. Defaults to ``0`` (so the
+        curve is the bare cumulative PnL).
+    initial_position : Decimal, optional
+        Net position held before the first fill. Defaults to flat.
+
+    Returns
+    -------
+    tuple of Decimal
+        The equity at each step, same length as ``fills``.
+
+    Raises
+    ------
+    ValueError
+        If ``prices`` and ``fills`` differ in length.
+
+    """
+    return tuple(
+        v0 + c
+        for c in cum_pnl(fills, prices, initial_position=initial_position)
+    )
+
+
+def equity_array(equity: Sequence[Money]) -> NDArray[np.float64]:
+    """Convert an exact equity curve to a ``float64`` array for the KPI wrappers.
+
+    The KPI ratios are statistical estimators where ``float64`` is sufficient
+    and is what fynance consumes; this is the single, explicit money→float
+    boundary. Each :class:`~decimal.Decimal` is converted via ``float()``.
+
+    Parameters
+    ----------
+    equity : Sequence[Money]
+        An equity (or any value) curve as exact decimals.
+
+    Returns
+    -------
+    numpy.ndarray
+        A 1-D ``float64`` array of the same values.
+
+    """
+    return np.array([float(v) for v in equity], dtype=np.float64)
+
+
+# --------------------------------------------------------------------------- #
+# KPI wrappers — lazily delegate to fynance
+# --------------------------------------------------------------------------- #
+
+
+def _as_float_array(equity: Sequence[Money] | NDArray[np.float64]) -> NDArray[np.float64]:
+    """Coerce an equity curve (Decimal sequence or float array) to ``float64``."""
+    if isinstance(equity, np.ndarray):
+        return equity.astype(np.float64)
+    return equity_array(equity)
+
+
+def sharpe(
+    equity: Sequence[Money] | NDArray[np.float64],
+    *,
+    rf: float = 0.0,
+    period: int = 252,
+    log: bool = False,
+) -> float:
+    """Annualised Sharpe ratio of an equity curve, via ``fynance.metrics.sharpe``.
+
+    Delegates to fynance's :func:`fynance.metrics.sharpe`
+    (signature ``sharpe(X, rf=0, period=252, log=False, axis=0, dtype=None,
+    ddof=0)``): annualised excess return over annualised volatility.
+
+    Parameters
+    ----------
+    equity : Sequence[Money] or numpy.ndarray
+        The equity / value curve (exact decimals or a ``float64`` array).
+    rf : float, optional
+        Annualised risk-free rate. Default ``0``.
+    period : int, optional
+        Periods per year for annualisation. Default ``252`` (trading days).
+    log : bool, optional
+        Use log-returns instead of simple returns. Default ``False``.
+
+    Returns
+    -------
+    float
+        The Sharpe ratio.
+
+    Raises
+    ------
+    PerformanceDependencyError
+        If fynance is not importable.
+
+    """
+    try:
+        import fynance.metrics as fy_metrics
+    except ImportError as exc:
+        raise PerformanceDependencyError("sharpe") from exc
+    x = _as_float_array(equity)
+    return float(fy_metrics.sharpe(x, rf=rf, period=period, log=log))
+
+
+def sortino(
+    equity: Sequence[Money] | NDArray[np.float64],
+    *,
+    rf: float = 0.0,
+    period: int = 252,
+    log: bool = False,
+) -> float:
+    """Annualised Sortino ratio of an equity curve, via ``fynance.metrics.sortino``.
+
+    Delegates to fynance's :func:`fynance.metrics.sortino`
+    (signature ``sortino(X, rf=0, period=252, log=False, axis=0, dtype=None,
+    ddof=0)``): annualised excess return over *downside* deviation.
+
+    Parameters
+    ----------
+    equity : Sequence[Money] or numpy.ndarray
+        The equity / value curve.
+    rf : float, optional
+        Annualised risk-free rate. Default ``0``.
+    period : int, optional
+        Periods per year. Default ``252``.
+    log : bool, optional
+        Use log-returns. Default ``False``.
+
+    Returns
+    -------
+    float
+        The Sortino ratio.
+
+    Raises
+    ------
+    PerformanceDependencyError
+        If fynance is not importable.
+
+    """
+    try:
+        import fynance.metrics as fy_metrics
+    except ImportError as exc:
+        raise PerformanceDependencyError("sortino") from exc
+    x = _as_float_array(equity)
+    return float(fy_metrics.sortino(x, rf=rf, period=period, log=log))
+
+
+def max_drawdown(
+    equity: Sequence[Money] | NDArray[np.float64],
+    *,
+    raw: bool = False,
+) -> float:
+    """Maximum drawdown of an equity curve, via ``fynance.metrics.mdd``.
+
+    Delegates to fynance's :func:`fynance.metrics.mdd`
+    (signature ``mdd(X, raw=False, axis=0, dtype=None)``): the worst
+    peak-to-trough decline, as a fraction of the peak by default.
+
+    Parameters
+    ----------
+    equity : Sequence[Money] or numpy.ndarray
+        The equity / value curve (should be positive for the relative form).
+    raw : bool, optional
+        If ``True`` return the absolute decline; otherwise (default) the
+        fractional drawdown.
+
+    Returns
+    -------
+    float
+        The maximum drawdown.
+
+    Raises
+    ------
+    PerformanceDependencyError
+        If fynance is not importable.
+
+    """
+    try:
+        import fynance.metrics as fy_metrics
+    except ImportError as exc:
+        raise PerformanceDependencyError("max_drawdown") from exc
+    x = _as_float_array(equity)
+    return float(fy_metrics.mdd(x, raw=raw))
+
+
+def calmar(
+    equity: Sequence[Money] | NDArray[np.float64],
+    *,
+    period: int = 252,
+) -> float:
+    """Calmar ratio of an equity curve, via ``fynance.metrics.calmar``.
+
+    Delegates to fynance's :func:`fynance.metrics.calmar`
+    (signature ``calmar(X, period=252, axis=0, dtype=None, ddof=0)``):
+    the compounded annual return over the maximum drawdown.
+
+    Parameters
+    ----------
+    equity : Sequence[Money] or numpy.ndarray
+        The equity / value curve.
+    period : int, optional
+        Periods per year. Default ``252``.
+
+    Returns
+    -------
+    float
+        The Calmar ratio.
+
+    Raises
+    ------
+    PerformanceDependencyError
+        If fynance is not importable.
+
+    """
+    try:
+        import fynance.metrics as fy_metrics
+    except ImportError as exc:
+        raise PerformanceDependencyError("calmar") from exc
+    x = _as_float_array(equity)
+    return float(fy_metrics.calmar(x, period=period))

--- a/trading_bot/tests/domain/test_performance.py
+++ b/trading_bot/tests/domain/test_performance.py
@@ -1,0 +1,348 @@
+"""Tests for the pure PnL / KPI performance functions.
+
+The PnL core (returns / position / fee / pnl / cum_pnl / equity) is pure
+numpy/Decimal and is fully exercised here. The KPI wrappers delegate to fynance,
+an optional ``[triptych]`` dependency that is not importable in every
+environment; those tests are gated behind ``pytest.importorskip("fynance")`` so
+they **skip** where fynance is absent and **run** in CI / a dev box where it is
+installed.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import numpy as np
+import pytest
+
+from trading_bot.domain import performance as perf
+from trading_bot.domain.errors import TradingBotError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.order import OrderSide
+from trading_bot.domain.performance import PerformanceDependencyError
+
+BTCUSD = Instrument(Symbol("BTC", "USD"), price_precision=1, qty_precision=8)
+
+
+def make_fill(
+    *,
+    side: OrderSide,
+    qty: str,
+    price: str,
+    fee: str = "0",
+    fill_id: str = "T1",
+    ts: int = 1,
+) -> Fill:
+    """Build a test fill with sensible defaults."""
+    return Fill(
+        fill_id=fill_id,
+        client_order_id="cid-1",
+        instrument=BTCUSD,
+        side=side,
+        qty=money(qty),
+        price=money(price),
+        fee=money(fee),
+        ts=ts,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Pure PnL core
+# --------------------------------------------------------------------------- #
+
+
+class TestReturns:
+    def test_first_difference_with_zero_head(self) -> None:
+        prices = [money("100"), money("110"), money("120")]
+        assert perf.returns(prices) == (money("0"), money("10"), money("10"))
+
+    def test_negative_moves(self) -> None:
+        prices = [money("100"), money("90"), money("95")]
+        assert perf.returns(prices) == (money("0"), money("-10"), money("5"))
+
+    def test_empty(self) -> None:
+        assert perf.returns([]) == ()
+
+    def test_single(self) -> None:
+        assert perf.returns([money("100")]) == (money("0"),)
+
+    def test_returns_are_exact_decimal(self) -> None:
+        prices = [money("0.1"), money("0.3")]
+        # 0.3 - 0.1 == 0.2 exactly (would be 0.19999... in float).
+        assert perf.returns(prices)[1] == money("0.2")
+
+
+class TestExchangedVolume:
+    def test_unsigned_qty_per_step(self) -> None:
+        fills = [
+            make_fill(side=OrderSide.BUY, qty="2", price="100", fill_id="A"),
+            make_fill(side=OrderSide.SELL, qty="1.5", price="110", fill_id="B"),
+        ]
+        assert perf.exchanged_volume(fills) == (money("2"), money("1.5"))
+
+
+class TestPositionSeries:
+    def test_held_position_going_into_each_step(self) -> None:
+        fills = [
+            make_fill(side=OrderSide.BUY, qty="2", price="100", fill_id="A"),
+            make_fill(side=OrderSide.SELL, qty="1", price="110", fill_id="B"),
+            make_fill(side=OrderSide.SELL, qty="1", price="120", fill_id="C"),
+        ]
+        # Before each fill: flat, then +2, then +1.
+        assert perf.position_series(fills) == (money("0"), money("2"), money("1"))
+
+    def test_initial_position_is_the_head(self) -> None:
+        fills = [make_fill(side=OrderSide.BUY, qty="1", price="100")]
+        assert perf.position_series(fills, initial=money("3")) == (money("3"),)
+
+    def test_can_go_short(self) -> None:
+        fills = [
+            make_fill(side=OrderSide.SELL, qty="1", price="100", fill_id="A"),
+            make_fill(side=OrderSide.SELL, qty="1", price="110", fill_id="B"),
+        ]
+        assert perf.position_series(fills) == (money("0"), money("-1"))
+
+
+class TestFeeSeries:
+    def test_passes_through_fill_fee(self) -> None:
+        fills = [
+            make_fill(side=OrderSide.BUY, qty="1", price="100", fee="0.5", fill_id="A"),
+            make_fill(side=OrderSide.SELL, qty="1", price="110", fee="0.6", fill_id="B"),
+        ]
+        assert perf.fee_series(fills) == (money("0.5"), money("0.6"))
+
+
+class TestPnLAndEquity:
+    """The headline hand-computed scenario.
+
+    v0 = 10000, starting flat. Three fills marked at their own price:
+
+    ===  ====  ===  =====  ===   ====  ========  =======  ========  ======
+    step side  qty  price  fee   pos   returns   pnl      cum_pnl   equity
+    ===  ====  ===  =====  ===   ====  ========  =======  ========  ======
+    0    BUY   2    100    1     0     0          -1       -1       9999
+    1    SELL  1    110    2     2     10         18       17       10017
+    2    SELL  1    120    1     1     10         9        26       10026
+    ===  ====  ===  =====  ===   ====  ========  =======  ========  ======
+
+    pnl_t = position_t * returns_t - fee_t.
+    """
+
+    fills = [
+        make_fill(side=OrderSide.BUY, qty="2", price="100", fee="1", fill_id="A"),
+        make_fill(side=OrderSide.SELL, qty="1", price="110", fee="2", fill_id="B"),
+        make_fill(side=OrderSide.SELL, qty="1", price="120", fee="1", fill_id="C"),
+    ]
+    prices = [money("100"), money("110"), money("120")]
+
+    def test_pnl(self) -> None:
+        assert perf.pnl(self.fills, self.prices) == (
+            money("-1"),
+            money("18"),
+            money("9"),
+        )
+
+    def test_cum_pnl(self) -> None:
+        assert perf.cum_pnl(self.fills, self.prices) == (
+            money("-1"),
+            money("17"),
+            money("26"),
+        )
+
+    def test_equity_curve_with_v0(self) -> None:
+        assert perf.equity_curve(self.fills, self.prices, v0=money("10000")) == (
+            money("9999"),
+            money("10017"),
+            money("10026"),
+        )
+
+    def test_equity_endpoint(self) -> None:
+        equity = perf.equity_curve(self.fills, self.prices, v0=money("10000"))
+        assert equity[-1] == money("10026")
+
+    def test_equity_without_v0_is_cum_pnl(self) -> None:
+        assert perf.equity_curve(self.fills, self.prices) == perf.cum_pnl(
+            self.fills, self.prices
+        )
+
+    def test_equity_array_is_float64(self) -> None:
+        equity = perf.equity_curve(self.fills, self.prices, v0=money("10000"))
+        arr = perf.equity_array(equity)
+        assert arr.dtype == np.float64
+        assert arr.tolist() == [9999.0, 10017.0, 10026.0]
+
+
+class TestFeeImpact:
+    """A non-zero fee strictly reduces PnL by exactly the fee total."""
+
+    fills_template = [
+        (OrderSide.BUY, "2", "100"),
+        (OrderSide.SELL, "1", "110"),
+        (OrderSide.SELL, "1", "120"),
+    ]
+    prices = [money("100"), money("110"), money("120")]
+
+    def _build(self, fee: str) -> list[Fill]:
+        return [
+            make_fill(side=s, qty=q, price=p, fee=fee, fill_id=f"F{i}")
+            for i, (s, q, p) in enumerate(self.fills_template)
+        ]
+
+    def test_fee_reduces_each_step(self) -> None:
+        no_fee = perf.pnl(self._build("0"), self.prices)
+        with_fee = perf.pnl(self._build("3"), self.prices)
+        for clean, charged in zip(no_fee, with_fee, strict=True):
+            assert charged == clean - money("3")
+
+    def test_fee_reduces_terminal_equity_by_total_fees(self) -> None:
+        no_fee = perf.equity_curve(self._build("0"), self.prices, v0=money("10000"))
+        with_fee = perf.equity_curve(self._build("3"), self.prices, v0=money("10000"))
+        # Three fills, fee 3 each → 9 total off the endpoint.
+        assert with_fee[-1] == no_fee[-1] - money("9")
+
+
+class TestInitialPosition:
+    def test_carried_position_earns_first_move(self) -> None:
+        # Start already long 5; the position held into step 1 is 5 + the first
+        # fill's signed qty (here SELL 5 ⇒ flat). So step-1 PnL = 5 * (+10).
+        fills = [
+            make_fill(side=OrderSide.SELL, qty="5", price="100", fill_id="A"),
+            make_fill(side=OrderSide.BUY, qty="1", price="110", fill_id="B"),
+        ]
+        prices = [money("100"), money("110")]
+        steps = perf.pnl(fills, prices, initial_position=money("5"))
+        # pos series: [5, 0]; step 1 held 0 ⇒ pnl 0.
+        assert perf.position_series(fills, initial=money("5")) == (
+            money("5"),
+            money("0"),
+        )
+        assert steps[1] == money("0")
+
+    def test_initial_position_alone_earns_the_move(self) -> None:
+        # A single fill that does not change the carried exposure before its
+        # own step: the head position is the initial one, earning its move.
+        fills = [
+            make_fill(side=OrderSide.SELL, qty="2", price="120", fill_id="A"),
+        ]
+        prices = [money("120")]
+        # Only one step (returns[0] == 0), so PnL is just -fee (zero here).
+        assert perf.pnl(fills, prices, initial_position=money("5")) == (money("0"),)
+
+
+class TestValidation:
+    def test_length_mismatch_raises(self) -> None:
+        fills = [make_fill(side=OrderSide.BUY, qty="1", price="100")]
+        with pytest.raises(ValueError, match="equal length"):
+            perf.pnl(fills, [money("100"), money("110")])
+
+    def test_empty_inputs_are_empty(self) -> None:
+        assert perf.pnl([], []) == ()
+        assert perf.cum_pnl([], []) == ()
+        assert perf.equity_curve([], []) == ()
+
+
+class TestDeterminism:
+    def test_pure_decimal_no_float_drift(self) -> None:
+        # Tricky decimals that float would mangle.
+        fills = [
+            make_fill(side=OrderSide.BUY, qty="0.3", price="0.1", fill_id="A"),
+            make_fill(side=OrderSide.SELL, qty="0.1", price="0.3", fill_id="B"),
+        ]
+        prices = [money("0.1"), money("0.3")]
+        # pos at step 1 = 0.3; move = 0.3 - 0.1 = 0.2 → pnl 0.06 exactly.
+        result = perf.pnl(fills, prices)
+        assert result[1] == money("0.06")
+        assert isinstance(result[1], Decimal)
+
+
+# --------------------------------------------------------------------------- #
+# KPI wrappers — require fynance (skip cleanly where absent)
+# --------------------------------------------------------------------------- #
+
+
+class TestKPIParity:
+    """KPI wrappers must match calling fynance directly on the same float array.
+
+    Gated behind ``importorskip`` so this whole class skips when fynance is not
+    installed (e.g. the sandbox without numba) and runs in CI / a dev box.
+    """
+
+    # A known equity path with both gains and a drawdown.
+    equity = [
+        money("100"),
+        money("110"),
+        money("105"),
+        money("120"),
+        money("160"),
+        money("108"),
+    ]
+
+    def test_sharpe_parity(self) -> None:
+        fy = pytest.importorskip("fynance")
+        x = perf.equity_array(self.equity)
+        assert perf.sharpe(self.equity, period=12) == pytest.approx(
+            float(fy.metrics.sharpe(x, rf=0, period=12, log=False))
+        )
+
+    def test_sortino_parity(self) -> None:
+        fy = pytest.importorskip("fynance")
+        x = perf.equity_array(self.equity)
+        assert perf.sortino(self.equity, period=12) == pytest.approx(
+            float(fy.metrics.sortino(x, rf=0, period=12, log=False))
+        )
+
+    def test_max_drawdown_parity(self) -> None:
+        fy = pytest.importorskip("fynance")
+        x = perf.equity_array(self.equity)
+        assert perf.max_drawdown(self.equity) == pytest.approx(
+            float(fy.metrics.mdd(x, raw=False))
+        )
+
+    def test_calmar_parity(self) -> None:
+        fy = pytest.importorskip("fynance")
+        x = perf.equity_array(self.equity)
+        assert perf.calmar(self.equity, period=12) == pytest.approx(
+            float(fy.metrics.calmar(x, period=12))
+        )
+
+    def test_accepts_float_array_directly(self) -> None:
+        pytest.importorskip("fynance")
+        arr = perf.equity_array(self.equity)
+        assert perf.sharpe(arr, period=12) == perf.sharpe(self.equity, period=12)
+
+    def test_max_drawdown_value(self) -> None:
+        pytest.importorskip("fynance")
+        # Peak 160 → trough 108 ⇒ mdd = 1 - 108/160 = 0.325.
+        assert perf.max_drawdown(self.equity) == pytest.approx(0.325)
+
+
+class TestKPIMissingDependency:
+    """When fynance is absent the wrappers raise a clear domain error."""
+
+    def test_raises_performance_dependency_error_without_fynance(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Simulate the dependency being unavailable regardless of the env by
+        # making ``import fynance.metrics`` fail.
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name: str, *args: object, **kwargs: object) -> object:
+            if name.startswith("fynance"):
+                raise ImportError("no fynance in this environment")
+            return real_import(name, *args, **kwargs)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        equity = [money("100"), money("110"), money("120")]
+        with pytest.raises(PerformanceDependencyError, match="sharpe"):
+            perf.sharpe(equity)
+        with pytest.raises(TradingBotError):
+            perf.sortino(equity)
+        with pytest.raises(PerformanceDependencyError, match="max_drawdown"):
+            perf.max_drawdown(equity)
+        with pytest.raises(PerformanceDependencyError, match="calmar"):
+            perf.calmar(equity)


### PR DESCRIPTION
## Summary
- **Final leaf of E1 — Domain core**: `domain/performance.py`.
- Pure PnL / cum-PnL / equity-curve core (Decimal); KPI (Sharpe/Sortino/max-drawdown/Calmar) delegated to **fynance** via lazy, typed wrappers.
- Closes the E1 epic — `07-roadmap.md` E1 line removed, `06-status.md` marks the domain core complete.

## Why
- Reuse fynance's vetted metrics rather than reimplement; lazy import + `importorskip`-gated KPI tests keep the module importable and the suite green where fynance (numba) isn't installed, while CI exercises the parity. See `doc/dev/03-decisions.md`.

## Changes
- `domain/performance.py` (12 functions + `PerformanceDependencyError`), exports; `tests/domain/test_performance.py` (30 tests). Pure core 100%-covered; KPI wrappers covered by import-gated tests.

## Changelog
Added under [Unreleased]:
- Pure PnL/KPI performance functions — `pnl`/`cum_pnl`/`equity_curve` (Decimal), Sharpe/Sortino/max-drawdown/Calmar delegated to fynance.

## Test plan
- [x] `pytest` (180 passed, 6 skipped = fynance KPI parity, import-gated)
- [x] `ruff check trading_bot/`
- [x] `mypy trading_bot/` clean (strict on domain; typed fynance wrapper)
- [x] real-data PnL/equity reconstruction cross-checked vs `Position.from_fills`
- [ ] CI green (runs the fynance KPI parity)