### PR TITLE
docs: plan transport (E2)

### DIFF
--- a/doc/dev/plans/transport/00-plan.md
+++ b/doc/dev/plans/transport/00-plan.md
@@ -1,0 +1,46 @@
+---
+plan: transport
+kind: global
+status: planning
+roadmap: "- [ ] **E2 — Transport.** `AsyncHTTPClient` (httpx + retry/backoff), `WebSocketBase` (reconnect), `RateLimiter` (token-bucket / Kraken call-counter). Mirror dccd's transport."
+release_on_done: false
+---
+
+# E2 — Transport
+
+## Goal
+
+Build `trading_bot/transport/` — the async I/O primitives every broker adapter
+sits on, mirroring dccd's `transport/` layer
+(`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/transport/`): an
+`AsyncHTTPClient` (httpx wrapper with retry/backoff, GET **and POST** for order
+placement), a `WebSocketBase` with `stream_raw()` + exponential reconnect (for
+private order/fill streams), and a `RateLimiter` (token-bucket + a Kraken
+**call-counter** model). Async, fully type-annotated. No domain coupling beyond
+small transport-local errors. Auth/signing stays in the broker layer (E3) — transport
+is venue-neutral plumbing.
+
+## Decomposition
+
+1. **http** — `AsyncHTTPClient` (httpx): async CM, `get`/`post`, retry/backoff, timeouts, optional `RateLimiter`.
+2. **ws** — `WebSocketBase`: `stream_raw()` + exponential reconnect, `on_connect` hook, `send()`.
+3. **ratelimit** — `TokenBucket` + `RateLimiter` (per-exchange) + Kraken decaying call-counter.
+
+## Leaf checklist
+
+- [ ] 01 http — feat/transport-http — medium
+- [ ] 02 ws — feat/transport-ws — medium
+- [ ] 03 ratelimit — feat/transport-ratelimit — medium
+
+## Dependencies
+
+- None between the three leaves (independent; run serially in the main worktree —
+  the safe default). All assume E1 is merged (typing only).
+
+## Done criteria
+
+- `trading_bot/transport/` exposes `http`, `ws`, `ratelimit` with a clean `__init__`.
+- `ruff` + `mypy` + `pytest` green; transport tests run locally (httpx + websockets
+  installed, network reachable) and include a real public-endpoint smoke for http & ws.
+- `pytest-httpx` added to the `[dev]` extra in `pyproject.toml`.
+- Last leaf (03) removes the E2 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/transport/01-http.md
+++ b/doc/dev/plans/transport/01-http.md
@@ -1,0 +1,57 @@
+---
+plan: transport/01-http
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/transport-http
+pr: ""
+---
+
+# AsyncHTTPClient — httpx wrapper with retry/backoff
+
+## Goal
+
+`trading_bot/transport/http.py`: a thin async httpx wrapper with retry/backoff and
+timeouts, exposing `get` **and** `post` (order placement needs POST). Mirrors
+dccd's `AsyncHTTPClient` (`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/transport/http.py`),
+adapted for execution. Async, fully typed.
+
+## Files to change
+
+- `trading_bot/transport/__init__.py` — new; export `AsyncHTTPClient`, `HTTPError`.
+- `trading_bot/transport/http.py` — new.
+- `trading_bot/tests/transport/__init__.py` — new (empty).
+- `trading_bot/tests/transport/test_http.py` — new.
+- `pyproject.toml` — add `pytest-httpx` to the `[dev]` extra.
+
+## Steps
+
+1. Read dccd's `transport/http.py` for the pattern. Implement `AsyncHTTPClient`:
+   - `__init__(self, *, base_url=None, max_retries=3, backoff_base=0.5, timeout=10.0, headers=None, exchange=None, limiter=None)`.
+   - Async context manager (`__aenter__`/`__aexit__`) holding an `httpx.AsyncClient`; reference-count nested entry (`_depth`) like dccd.
+   - `async get(url, params=None) -> Any` and `async post(url, *, data=None, json=None, headers=None) -> Any` — both with retry/backoff on transient errors (5xx, `httpx` network errors) and `Retry-After` handling on 429; raise `HTTPError(status, url, body)` on non-retryable 4xx; return parsed JSON.
+   - If a `limiter` (E2-03) is set, `await limiter.acquire(exchange)` before each request (import lazily / type as a small Protocol to avoid a hard dep ordering).
+2. `HTTPError(Exception)` carrying `status`, `url`, `body`.
+3. Inject the sleep (an `asyncio.sleep`-compatible callable) as a constructor seam so retry timing is testable without real waits.
+
+## Tests
+
+- `pytest-httpx` mock: a 503 then 200 → retried, returns the 200 JSON; assert the injected sleep was called with backoff timing.
+- Non-retryable 400 → raises `HTTPError` with status/url/body.
+- `post` sends the body and parses JSON (mocked).
+- 429 with `Retry-After` → waits that long (via the seam) then retries.
+
+## Verification on real data
+
+Network is reachable. Do a **real GET** against Kraken's public API
+(`https://api.kraken.com/0/public/Time`) with a live `AsyncHTTPClient` and assert
+a sane JSON shape (`result.unixtime` present). Mark it `@pytest.mark.network`
+(opt-in) so the default suite stays offline. Demonstrate by running it.
+
+## Closeout
+
+- CHANGELOG (Added): "`transport.AsyncHTTPClient` — async httpx wrapper (get/post, retry/backoff, timeouts)."
+- ADR: short note if the retry/timeout policy or the limiter seam is non-obvious.
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/transport/02-ws.md
+++ b/doc/dev/plans/transport/02-ws.md
@@ -1,0 +1,62 @@
+---
+plan: transport/02-ws
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/transport-ws
+pr: ""
+---
+
+# WebSocketBase — stream_raw + exponential reconnect
+
+## Goal
+
+`trading_bot/transport/ws.py`: an async WebSocket base with `stream_raw()` and
+exponential reconnect, an `on_connect` hook (for subscribe/auth) and a `send()`
+(subscriptions, private auth). Mirrors dccd's `WebSocketBase`
+(`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/transport/ws.py`). Uses the
+`websockets` library (already installed). Async, fully typed.
+
+## Files to change
+
+- `trading_bot/transport/ws.py` — new.
+- `trading_bot/transport/__init__.py` — export `WebSocketBase`.
+- `trading_bot/tests/transport/test_ws.py` — new.
+
+## Steps
+
+1. Read dccd's `transport/ws.py`. Implement `WebSocketBase`:
+   - `__init__(self, url)`, `stop()` (sets a flag to end the stream).
+   - `async on_connect(self, ws) -> None` — overridable hook called after each
+     (re)connect (default no-op; subclasses subscribe/authenticate here).
+   - `async send(self, message) -> None` — send a frame on the live connection
+     (queue/await the active socket).
+   - `async stream_raw(self) -> AsyncIterator[str | bytes]` — connect, call
+     `on_connect`, yield frames; on disconnect/error reconnect with **exponential
+     backoff** (capped), until `stop()`.
+   - Optional `async stream(self) -> AsyncIterator[Any]` calling an overridable
+     `parse_message` (mirror dccd) — keep if cheap, else leave for the broker.
+2. Inject the connect function and sleep as seams so reconnect logic is testable
+   without a real server (a fake connection that raises then yields).
+
+## Tests
+
+- Fake connect (injected) raises once then yields two frames → `stream_raw`
+  reconnects (backoff via the sleep seam) and yields both; `stop()` ends it.
+- Backoff grows exponentially and is capped (assert the seam's sleep arguments).
+- `on_connect` is invoked on every (re)connect.
+
+## Verification on real data
+
+Network is reachable. Connect to Kraken's **public** WebSocket
+(`wss://ws.kraken.com/v2`, subscribe to a ticker for `BTC/USD`) and assert at least
+one real frame arrives, then `stop()`. Mark `@pytest.mark.network` (opt-in).
+Demonstrate by running it.
+
+## Closeout
+
+- CHANGELOG (Added): "`transport.WebSocketBase` — async WS base with stream_raw + exponential reconnect."
+- ADR: short note if the reconnect/backoff policy is non-obvious.
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/transport/03-ratelimit.md
+++ b/doc/dev/plans/transport/03-ratelimit.md
@@ -1,0 +1,64 @@
+---
+plan: transport/03-ratelimit
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/transport-ratelimit
+pr: ""
+---
+
+# RateLimiter — token-bucket + Kraken call-counter
+
+## Goal
+
+`trading_bot/transport/ratelimit.py`: a per-exchange `RateLimiter` over
+`TokenBucket`s (mirroring dccd's
+`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/transport/ratelimit.py`),
+**plus** a Kraken-style **decaying call-counter** model (mined from
+`trading_bot/legacy/tools/call_counters.py`). This is the last E2 leaf — it closes
+the E2 roadmap line.
+
+## Files to change
+
+- `trading_bot/transport/ratelimit.py` — new.
+- `trading_bot/transport/__init__.py` — export `RateLimiter`, `TokenBucket`, `KrakenCallCounter`.
+- `trading_bot/tests/transport/test_ratelimit.py` — new.
+- `doc/dev/07-roadmap.md` — remove the E2 line. `doc/dev/06-status.md` — mark E2 done.
+
+## Steps
+
+1. Read dccd's `transport/ratelimit.py` and `trading_bot/legacy/tools/call_counters.py`.
+2. `TokenBucket(rate, *, time_source=monotonic, sleep=asyncio.sleep)`: `async acquire()`
+   refills by elapsed×rate, waits when below one token. **time/sleep are seams** for
+   deterministic tests.
+3. `RateLimiter(rates=None, *, time_source, sleep)`: one bucket per exchange,
+   `async acquire(exchange)`; conservative default rates; fallback rate for unknown
+   venues.
+4. `KrakenCallCounter`: model Kraken's counter — each call adds a per-endpoint cost,
+   the counter **decays** at a fixed rate per second, and calls block when the cost
+   would exceed the tier limit. Port the constants/logic from
+   `legacy/tools/call_counters.py`. Expose `async acquire(cost)` (and a sync
+   `would_exceed`/inspection helper). Seam the clock.
+
+## Tests
+
+- `TokenBucket`: with a fake clock, N rapid `acquire()` calls are spaced to the
+  configured rate (assert the sleep seam's total wait); a slow caller never waits.
+- `RateLimiter`: distinct exchanges use independent buckets; unknown exchange uses
+  the fallback rate.
+- `KrakenCallCounter`: counter increments per call, decays over (faked) time, and
+  blocks/waits when the next call would exceed the limit; matches the legacy numbers.
+
+## Verification on real data
+
+Pure/deterministic timing layer — verified with a **fake clock** (no real sleeps):
+drive a realistic call pattern and assert the spacing/decay matches the configured
+rate and Kraken's counter limit. Demonstrate by running it.
+
+## Closeout
+
+- CHANGELOG (Added): "`transport.RateLimiter` — token-bucket + Kraken decaying call-counter."
+- ADR: note the Kraken call-counter model (decay rate, per-endpoint cost, tier limit) and where the constants came from.
+- Status/roadmap: **remove the E2 line** from `07-roadmap.md`; mark E2 done in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E2 — Transport** (mirrors dccd's `transport/`). Lands the durable
plan on `develop` before code.

## Goal
`trading_bot/transport/` — async I/O primitives every broker sits on: `AsyncHTTPClient`
(httpx; get/post, retry/backoff), `WebSocketBase` (stream_raw + exponential reconnect),
`RateLimiter` (token-bucket + Kraken decaying call-counter). Auth/signing stays in E3.

## Leaves
- [ ] 01 http — feat/transport-http — medium
- [ ] 02 ws — feat/transport-ws — medium
- [ ] 03 ratelimit — feat/transport-ratelimit — medium

Independent leaves; run serially. Real public-endpoint smokes (Kraken REST + WS,
`@pytest.mark.network`) now runnable — network is reachable, httpx + websockets installed.
After merge: `/execute-leaf transport next`.