### PR TITLE
feat: transport AsyncHTTPClient (httpx, retry/backoff)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pure PnL/KPI performance functions — `pnl`/`cum_pnl`/`equity_curve` (Decimal),
   with Sharpe/Sortino/max-drawdown/Calmar delegated to fynance. Completes the
   **E1 domain core**. (#11)
+- `transport.AsyncHTTPClient` — async httpx wrapper (get/post, retry with
+  increasing exponential backoff, `Retry-After` on 429, timeouts). (#13)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,23 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Transport HTTP: increasing backoff + Protocol limiter seam (PR #13)
+
+**Decision.** `transport.AsyncHTTPClient` retries transient failures (5xx, network
+errors, 429) with **monotonically increasing** exponential backoff
+(`backoff_base * 2**attempt`, capped at 60s) — review caught and fixed an initial
+`base**attempt` form that *decreased* with `base=0.5`. 429 honours `Retry-After`.
+The optional rate limiter is typed as a `Protocol` (awaited before each request),
+so transport doesn't hard-depend on the not-yet-built `ratelimit` module; `sleep`
+is an injected seam for deterministic retry-timing tests. `HTTPError` stays a plain
+`Exception` (transport decoupled from `domain.errors`).
+
+**Why.** Backoff must lengthen under a sustained outage, never shorten — a
+shortening backoff hammers the venue and risks a ban. The Protocol seam keeps the
+leaf order (http before ratelimit) dependency-free.
+
+---
+
 ### 2026-06-20 Performance: pure PnL core, KPI delegated to fynance (PR #11)
 
 **Decision.** `domain/performance.py` keeps the PnL/cum-PnL/equity core pure

--- a/doc/dev/plans/transport/00-plan.md
+++ b/doc/dev/plans/transport/00-plan.md
@@ -28,7 +28,7 @@ is venue-neutral plumbing.
 
 ## Leaf checklist
 
-- [ ] 01 http — feat/transport-http — medium
+- [x] 01 http — feat/transport-http — medium
 - [ ] 02 ws — feat/transport-ws — medium
 - [ ] 03 ratelimit — feat/transport-ratelimit — medium
 

--- a/doc/dev/plans/transport/01-http.md
+++ b/doc/dev/plans/transport/01-http.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/transport-http
-pr: ""
+pr: "#13"
 ---
 
 # AsyncHTTPClient — httpx wrapper with retry/backoff

--- a/doc/dev/plans/transport/01-http.md
+++ b/doc/dev/plans/transport/01-http.md
@@ -1,7 +1,7 @@
 ---
 plan: transport/01-http
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "pytest>=7.4",
     "pytest-asyncio>=0.23",
     "pytest-cov>=4.1",
+    "pytest-httpx>=0.30",
     "ruff>=0.4",
     "mypy>=1.0",
     "interrogate>=1.5",

--- a/trading_bot/tests/transport/test_http.py
+++ b/trading_bot/tests/transport/test_http.py
@@ -1,0 +1,166 @@
+"""Tests for :mod:`trading_bot.transport.http`.
+
+Offline tests use ``pytest-httpx``'s ``httpx_mock`` fixture and a recording
+fake sleep injected via the ``sleep`` seam, so retry timing is asserted without
+real waits. The opt-in network test (``-m network``) hits Kraken's public API.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from trading_bot.transport import AsyncHTTPClient, HTTPError
+
+
+class RecordingSleep:
+    """Async ``asyncio.sleep`` stand-in that records every requested delay."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, delay: float) -> None:
+        self.calls.append(delay)
+
+
+async def test_retries_503_then_returns_200_json(httpx_mock) -> None:
+    httpx_mock.add_response(status_code=503)
+    httpx_mock.add_response(status_code=200, json={"ok": True})
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(backoff_base=0.5, sleep=sleep) as client:
+        result = await client.get("https://example.test/data")
+
+    assert result == {"ok": True}
+    # One transient 503 → exactly one backoff sleep, at backoff_base * 2**0 == 0.5.
+    assert sleep.calls == [pytest.approx(0.5)]
+
+
+async def test_non_retryable_400_raises_http_error(httpx_mock) -> None:
+    httpx_mock.add_response(status_code=400, text="bad request body")
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(sleep=sleep) as client:
+        with pytest.raises(HTTPError) as exc_info:
+            await client.get("https://example.test/oops")
+
+    err = exc_info.value
+    assert err.status == 400
+    assert err.url == "https://example.test/oops"
+    assert err.body == "bad request body"
+    # 4xx is not retried: the sleep seam was never awaited.
+    assert sleep.calls == []
+
+
+async def test_post_sends_body_and_parses_json(httpx_mock) -> None:
+    httpx_mock.add_response(status_code=200, json={"txid": ["OABC-123"]})
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(sleep=sleep) as client:
+        result = await client.post(
+            "https://example.test/AddOrder",
+            data={"pair": "XBTUSD", "type": "buy"},
+        )
+
+    assert result == {"txid": ["OABC-123"]}
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.method == "POST"
+    # Form body is sent and url-encoded.
+    body = request.content.decode()
+    assert "pair=XBTUSD" in body
+    assert "type=buy" in body
+
+
+async def test_post_sends_json_body(httpx_mock) -> None:
+    httpx_mock.add_response(status_code=200, json={"accepted": True})
+
+    async with AsyncHTTPClient() as client:
+        result = await client.post(
+            "https://example.test/json", json={"a": 1, "b": [2, 3]}
+        )
+
+    assert result == {"accepted": True}
+    request = httpx_mock.get_request()
+    assert request is not None
+    import json as _json
+
+    assert _json.loads(request.content) == {"a": 1, "b": [2, 3]}
+
+
+async def test_429_retry_after_waits_then_retries(httpx_mock) -> None:
+    httpx_mock.add_response(status_code=429, headers={"Retry-After": "3"})
+    httpx_mock.add_response(status_code=200, json={"ok": 1})
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(sleep=sleep) as client:
+        result = await client.get("https://example.test/limited")
+
+    assert result == {"ok": 1}
+    # Retry-After honoured exactly via the seam.
+    assert sleep.calls == [pytest.approx(3.0)]
+
+
+async def test_max_retries_exhausted_on_persistent_503(httpx_mock) -> None:
+    for _ in range(3):
+        httpx_mock.add_response(status_code=503, text="upstream down")
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(max_retries=3, sleep=sleep) as client:
+        with pytest.raises(HTTPError) as exc_info:
+            await client.get("https://example.test/down")
+
+    assert exc_info.value.status == 503
+    # Three attempts → three *increasing* backoff sleeps (0.5*2**0, *2**1, *2**2).
+    assert sleep.calls == [
+        pytest.approx(0.5),
+        pytest.approx(1.0),
+        pytest.approx(2.0),
+    ]
+
+
+async def test_retries_on_transport_error(httpx_mock) -> None:
+    httpx_mock.add_exception(httpx.ConnectError("boom"))
+    httpx_mock.add_response(status_code=200, json={"recovered": True})
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(sleep=sleep) as client:
+        result = await client.get("https://example.test/flaky")
+
+    assert result == {"recovered": True}
+    assert sleep.calls == [pytest.approx(0.5)]
+
+
+async def test_requires_context_manager() -> None:
+    client = AsyncHTTPClient()
+    with pytest.raises(RuntimeError):
+        await client.get("https://example.test/nope")
+
+
+async def test_limiter_acquired_before_request(httpx_mock) -> None:
+    httpx_mock.add_response(status_code=200, json={"ok": True})
+
+    class FakeLimiter:
+        def __init__(self) -> None:
+            self.acquired: list[str | None] = []
+
+        async def acquire(self, exchange: str | None) -> None:
+            self.acquired.append(exchange)
+
+    limiter = FakeLimiter()
+    async with AsyncHTTPClient(exchange="kraken", limiter=limiter) as client:
+        await client.get("https://example.test/data")
+
+    assert limiter.acquired == ["kraken"]
+
+
+@pytest.mark.network
+async def test_real_kraken_time() -> None:
+    """Live GET against Kraken's public Time endpoint (opt-in: ``-m network``)."""
+    async with AsyncHTTPClient() as client:
+        payload = await client.get("https://api.kraken.com/0/public/Time")
+
+    assert isinstance(payload, dict)
+    unixtime = payload["result"]["unixtime"]
+    assert isinstance(unixtime, int)
+    assert unixtime > 0

--- a/trading_bot/transport/__init__.py
+++ b/trading_bot/transport/__init__.py
@@ -1,0 +1,18 @@
+"""trading_bot transport layer — async I/O primitives.
+
+Unlike :mod:`trading_bot.domain` (pure, synchronous, no I/O), this layer **does**
+I/O (httpx). It stays venue-neutral plumbing: no auth/signing (that is the
+broker layer) and no domain business logic.
+
+Public surface:
+
+* :class:`~trading_bot.transport.http.AsyncHTTPClient` — async httpx wrapper with
+  retry/backoff, timeouts, and ``get`` / ``post``;
+* :class:`~trading_bot.transport.http.HTTPError` — transport-local HTTP failure.
+"""
+
+from __future__ import annotations
+
+from trading_bot.transport.http import AsyncHTTPClient, HTTPError
+
+__all__ = ["AsyncHTTPClient", "HTTPError"]

--- a/trading_bot/transport/http.py
+++ b/trading_bot/transport/http.py
@@ -1,0 +1,306 @@
+"""Async HTTP client with retry/backoff.
+
+Thin async wrapper over :class:`httpx.AsyncClient` for the execution layer. It
+adds bounded retry with exponential backoff, ``Retry-After`` handling on 429,
+and an optional proactive rate-limit hook. It is **venue-neutral plumbing**:
+it does no auth/signing (that belongs to the broker layer) and does not import
+domain business logic — :class:`HTTPError` is a transport-local error type.
+
+Mirrors ``dccd.transport.http.AsyncHTTPClient``; adapted for execution by adding
+:meth:`AsyncHTTPClient.post` (order placement is a POST) and an injectable
+``sleep`` seam so retry timing is testable without real waits.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, Protocol
+
+import httpx
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Mapping
+
+__all__ = ["AsyncHTTPClient", "HTTPError"]
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TIMEOUT = 10.0
+_DEFAULT_RETRIES = 3
+_DEFAULT_BACKOFF_BASE = 0.5
+# Cap a single backoff sleep so an unlucky ``backoff_base`` / attempt pair can
+# never park a request for an unreasonable time.
+_MAX_BACKOFF = 60.0
+
+
+class HTTPError(Exception):
+    """Raised when an HTTP request fails (non-retryable, or retries exhausted).
+
+    Parameters
+    ----------
+    status : int
+        HTTP status code that triggered the failure.
+    url : str
+        Target URL of the failed request.
+    body : str, optional
+        Response body (truncated in the message), kept for diagnostics.
+    """
+
+    def __init__(self, status: int, url: str, body: str = "") -> None:
+        self.status = status
+        self.url = url
+        self.body = body
+        super().__init__(f"HTTP {status} from {url}: {body[:200]}")
+
+
+class _Limiter(Protocol):
+    """Minimal structural type for a proactive rate limiter.
+
+    Typed as a :class:`~typing.Protocol` so this module has no hard import on
+    the (not-yet-built) ratelimit module: any object exposing an async
+    ``acquire(exchange)`` satisfies it.
+    """
+
+    async def acquire(self, exchange: str | None) -> None:
+        """Block until a token is available for *exchange*."""
+        ...
+
+
+class AsyncHTTPClient:
+    """Thin wrapper around :class:`httpx.AsyncClient` with retry/backoff.
+
+    Parameters
+    ----------
+    base_url : str, optional
+        Base URL prepended to relative request paths by httpx.
+    max_retries : int, default 3
+        Number of attempts on transient errors (5xx, network errors, 429).
+    backoff_base : float, default 0.5
+        Exponential backoff base, in seconds: zero-based attempt *n* waits
+        ``backoff_base * 2**n`` (0.5, 1.0, 2.0, … — increasing, capped at 60s).
+    timeout : float, default 10.0
+        Per-request timeout, in seconds.
+    headers : dict of str to str, optional
+        Default headers applied to every request.
+    exchange : str, optional
+        Exchange name used to key the proactive *limiter*. When both are set,
+        every request awaits a token before going out, smoothing bursts to the
+        exchange's published rate.
+    limiter : _Limiter, optional
+        Shared per-exchange limiter consulted only when *exchange* is also set.
+    sleep : callable, optional
+        ``asyncio.sleep``-compatible coroutine function used for backoff waits.
+        Injected as a seam so retry timing is testable without real waits.
+
+    Notes
+    -----
+    Must be used as an async context manager; the underlying client is created
+    on first entry. Nested entries are reference-counted (``_depth``) so a
+    shared instance survives concurrent users: the client is closed only when
+    the last user exits.
+    """
+
+    def __init__(
+        self,
+        *,
+        base_url: str | None = None,
+        max_retries: int = _DEFAULT_RETRIES,
+        backoff_base: float = _DEFAULT_BACKOFF_BASE,
+        timeout: float = _DEFAULT_TIMEOUT,
+        headers: dict[str, str] | None = None,
+        exchange: str | None = None,
+        limiter: _Limiter | None = None,
+        sleep: Callable[[float], Awaitable[Any]] = asyncio.sleep,
+    ) -> None:
+        self._base_url = base_url
+        self._max_retries = max_retries
+        self._backoff_base = backoff_base
+        self._timeout = timeout
+        self._headers = headers or {}
+        self._exchange = exchange
+        self._limiter = limiter
+        self._sleep = sleep
+        self._client: httpx.AsyncClient | None = None
+        # Adapters share one AsyncHTTPClient and wrap each call in
+        # ``async with self``. With two concurrent operations the first to
+        # finish would otherwise close the shared httpx client mid-flight for
+        # the other. Reference-count the context so the client is created on
+        # first entry and closed only when the last concurrent user exits. Safe
+        # under asyncio: the counter is mutated without intervening awaits.
+        self._depth = 0
+
+    async def __aenter__(self) -> AsyncHTTPClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                base_url=self._base_url or "",
+                timeout=self._timeout,
+                headers=self._headers,
+                follow_redirects=True,
+            )
+        self._depth += 1
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        self._depth -= 1
+        if self._depth <= 0 and self._client is not None:
+            self._depth = 0
+            await self._client.aclose()
+            self._client = None
+
+    def _backoff(self, attempt: int) -> float:
+        """Backoff delay (seconds) for a zero-based *attempt*, capped.
+
+        Monotonically increasing exponential backoff: ``backoff_base * 2**attempt``
+        (so a sustained outage waits longer each retry, never shorter).
+        """
+        return min(self._backoff_base * 2.0**attempt, _MAX_BACKOFF)
+
+    async def get(self, url: str, params: Mapping[str, Any] | None = None) -> Any:
+        """Perform a GET request with retry/backoff. Returns parsed JSON.
+
+        Parameters
+        ----------
+        url : str
+            Request URL (or path, if ``base_url`` is set).
+        params : mapping, optional
+            Query-string parameters.
+
+        Returns
+        -------
+        Any
+            The parsed JSON body of the 2xx response.
+
+        Raises
+        ------
+        HTTPError
+            On a non-retryable 4xx, or once retries are exhausted.
+        """
+        return await self._request("GET", url, params=params)
+
+    async def post(
+        self,
+        url: str,
+        *,
+        data: Mapping[str, Any] | None = None,
+        json: Any | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        """Perform a POST request with retry/backoff. Returns parsed JSON.
+
+        Parameters
+        ----------
+        url : str
+            Request URL (or path, if ``base_url`` is set).
+        data : mapping, optional
+            Form-encoded body.
+        json : Any, optional
+            JSON body (mutually exclusive with *data*, per httpx).
+        headers : mapping, optional
+            Per-request headers, merged over the client defaults.
+
+        Returns
+        -------
+        Any
+            The parsed JSON body of the 2xx response.
+
+        Raises
+        ------
+        HTTPError
+            On a non-retryable 4xx, or once retries are exhausted.
+        """
+        return await self._request(
+            "POST", url, data=data, json=json, headers=headers
+        )
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        data: Mapping[str, Any] | None = None,
+        json: Any | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> Any:
+        """Shared retry/backoff loop for GET and POST."""
+        client = self._client
+        if client is None:
+            raise RuntimeError(
+                "AsyncHTTPClient must be used as an async context manager"
+            )
+
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries):
+            try:
+                # Proactive throttle: wait for a token before each outbound
+                # request so concurrent operations on the same exchange stay
+                # under its published rate. Reactive 429 handling below remains
+                # a backstop.
+                if self._limiter is not None and self._exchange is not None:
+                    await self._limiter.acquire(self._exchange)
+
+                resp = await client.request(
+                    method,
+                    url,
+                    params=params,
+                    data=data,
+                    json=json,
+                    headers=dict(headers) if headers is not None else None,
+                )
+
+                if resp.status_code == 429:
+                    wait = self._retry_after(resp, attempt)
+                    logger.warning(
+                        "Rate-limited by %s, sleeping %.1fs", url, wait
+                    )
+                    last_exc = HTTPError(resp.status_code, url, resp.text)
+                    await self._sleep(wait)
+                    continue
+
+                if resp.status_code >= 500:
+                    wait = self._backoff(attempt)
+                    logger.warning(
+                        "HTTP %d from %s, retry in %.1fs",
+                        resp.status_code,
+                        url,
+                        wait,
+                    )
+                    last_exc = HTTPError(resp.status_code, url, resp.text)
+                    await self._sleep(wait)
+                    continue
+
+                if resp.status_code >= 400:
+                    raise HTTPError(resp.status_code, url, resp.text)
+
+                return resp.json()
+
+            except httpx.TransportError as exc:
+                wait = self._backoff(attempt)
+                logger.warning(
+                    "Transport error %s (attempt %d/%d), retry in %.1fs",
+                    exc,
+                    attempt + 1,
+                    self._max_retries,
+                    wait,
+                )
+                last_exc = exc
+                await self._sleep(wait)
+
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError(
+            f"{method} {url} failed after {self._max_retries} retries"
+        )
+
+    def _retry_after(self, resp: httpx.Response, attempt: int) -> float:
+        """Delay to honour a 429: ``Retry-After`` header, else backoff."""
+        header = resp.headers.get("Retry-After")
+        if header is not None:
+            try:
+                return min(float(header), _MAX_BACKOFF)
+            except ValueError:
+                # Retry-After can be an HTTP-date; fall back to backoff rather
+                # than parse the date format here.
+                logger.debug("Unparseable Retry-After %r, using backoff", header)
+        return self._backoff(attempt)


### PR DESCRIPTION
## Summary
- First leaf of **E2 — Transport**: `trading_bot/transport/http.py`.
- `AsyncHTTPClient` — async httpx wrapper (async CM, `get`/`post`, **increasing** exponential backoff, `Retry-After` on 429, timeouts, optional rate-limiter via a `Protocol` seam). `HTTPError(status, url, body)`.

## Why
- Transport is venue-neutral plumbing; auth/signing stays in the broker layer (E3). Review caught and fixed a decreasing-backoff bug (`base**attempt` with base 0.5) — backoff now lengthens under sustained outage. See `doc/dev/03-decisions.md`.

## Changes
- `transport/http.py` + `__init__`; `tests/transport/test_http.py` (9 offline + 1 `@network` real-Kraken smoke); `pytest-httpx` added to the `[dev]` extra.

## Changelog
Added under [Unreleased]:
- `transport.AsyncHTTPClient` — async httpx wrapper (get/post, retry with increasing exponential backoff, Retry-After on 429, timeouts).

## Test plan
- [x] `pytest` (189 passed, 6 skipped)
- [x] `pytest -m network` — real GET to Kraken public Time (unixtime returned)
- [x] `ruff` + `mypy` clean
- [ ] CI green