### PR TITLE
feat: transport WebSocketBase (stream_raw, reconnect)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **E1 domain core**. (#11)
 - `transport.AsyncHTTPClient` — async httpx wrapper (get/post, retry with
   increasing exponential backoff, `Retry-After` on 429, timeouts). (#13)
+- `transport.WebSocketBase` — async WS base: `stream_raw()` + increasing
+  exponential reconnect, `on_connect` hook, `send()`. (#14)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,19 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Transport WS: subscriptions via on_connect; send() needs a live socket (PR #14)
+
+**Decision.** `transport.WebSocketBase.stream_raw()` reconnects with increasing,
+capped backoff (the attempt counter resets after a successful connect). `send()`
+raises if not connected; subscriptions/auth go through the `on_connect` hook, which
+re-runs on every (re)connect so they **self-heal** across drops.
+
+**Why.** A frame queued while disconnected would either miss its window or land on
+the wrong post-reconnect socket. Putting subscriptions in `on_connect` makes them
+idempotent across reconnects with no bookkeeping.
+
+---
+
 ### 2026-06-20 Transport HTTP: increasing backoff + Protocol limiter seam (PR #13)
 
 **Decision.** `transport.AsyncHTTPClient` retries transient failures (5xx, network

--- a/doc/dev/plans/transport/00-plan.md
+++ b/doc/dev/plans/transport/00-plan.md
@@ -29,7 +29,7 @@ is venue-neutral plumbing.
 ## Leaf checklist
 
 - [x] 01 http — feat/transport-http — medium
-- [ ] 02 ws — feat/transport-ws — medium
+- [x] 02 ws — feat/transport-ws — medium
 - [ ] 03 ratelimit — feat/transport-ratelimit — medium
 
 ## Dependencies

--- a/doc/dev/plans/transport/02-ws.md
+++ b/doc/dev/plans/transport/02-ws.md
@@ -1,7 +1,7 @@
 ---
 plan: transport/02-ws
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false

--- a/doc/dev/plans/transport/02-ws.md
+++ b/doc/dev/plans/transport/02-ws.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/transport-ws
-pr: ""
+pr: "#14"
 ---
 
 # WebSocketBase — stream_raw + exponential reconnect

--- a/trading_bot/tests/transport/test_ws.py
+++ b/trading_bot/tests/transport/test_ws.py
@@ -1,0 +1,248 @@
+"""Tests for :mod:`trading_bot.transport.ws`.
+
+Offline tests drive :class:`WebSocketBase` through injected ``connect`` and
+``sleep`` seams: a fake connection can raise on connect (to exercise reconnect)
+then yield a scripted list of frames, while a recording sleep asserts the
+backoff schedule without real waits. The opt-in network test (``-m network``)
+hits Kraken's public v2 WebSocket.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from trading_bot.transport import WebSocketBase
+
+
+class RecordingSleep:
+    """Async ``asyncio.sleep`` stand-in that records every requested delay."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, delay: float) -> None:
+        self.calls.append(delay)
+
+
+class FakeWS:
+    """A fake live connection: async-iterates *frames* and records sends."""
+
+    def __init__(self, frames: list[str | bytes]) -> None:
+        self._frames = frames
+        self.sent: list[Any] = []
+
+    async def send(self, message: Any) -> None:
+        self.sent.append(message)
+
+    def __aiter__(self) -> AsyncIterator[str | bytes]:
+        async def _gen() -> AsyncIterator[str | bytes]:
+            for frame in self._frames:
+                yield frame
+
+        return _gen()
+
+
+class _Conn:
+    """Async context manager standing in for ``websockets.connect(url)``.
+
+    ``__aenter__`` either raises a scripted exception (failed connect) or
+    returns the scripted :class:`FakeWS` (successful connect).
+    """
+
+    def __init__(self, result: BaseException | FakeWS) -> None:
+        self._result = result
+
+    async def __aenter__(self) -> FakeWS:
+        if isinstance(self._result, BaseException):
+            raise self._result
+        return self._result
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeConnector:
+    """Injectable ``connect`` seam yielding a scripted sequence of attempts.
+
+    Each call pops the next scripted *result*: a :class:`BaseException` (the
+    connect fails) or a :class:`FakeWS` (the connect succeeds and yields its
+    frames). Records the per-call URL for assertions.
+    """
+
+    def __init__(self, results: list[BaseException | FakeWS]) -> None:
+        self._results = list(results)
+        self.urls: list[str] = []
+
+    def __call__(self, url: str) -> _Conn:
+        self.urls.append(url)
+        if not self._results:
+            raise AssertionError("FakeConnector called more times than scripted")
+        return _Conn(self._results.pop(0))
+
+
+async def test_reconnects_after_failure_and_yields_all_frames() -> None:
+    # First connect raises, second succeeds and yields two frames.
+    ws = FakeWS(["frame-1", "frame-2"])
+    connector = FakeConnector([ConnectionError("boom"), ws])
+    sleep = RecordingSleep()
+    base = WebSocketBase(
+        "wss://example.test", connect=connector, sleep=sleep, backoff_base=0.5
+    )
+
+    received: list[str | bytes] = []
+    async for frame in base.stream_raw():
+        received.append(frame)
+        if len(received) == 2:
+            base.stop()
+
+    assert received == ["frame-1", "frame-2"]
+    # Exactly one failed connect → exactly one backoff sleep, at base * 2**0.
+    assert sleep.calls == [pytest.approx(0.5)]
+
+
+async def test_backoff_increasing_capped_and_resets_after_success() -> None:
+    # Three consecutive failed connects, then a success that yields one frame.
+    ws = FakeWS(["ok"])
+    connector = FakeConnector(
+        [
+            ConnectionError("1"),
+            ConnectionError("2"),
+            ConnectionError("3"),
+            ws,
+        ]
+    )
+    sleep = RecordingSleep()
+    base = WebSocketBase(
+        "wss://example.test",
+        connect=connector,
+        sleep=sleep,
+        backoff_base=0.5,
+        max_backoff=1.0,  # low cap so the 3rd failure is clamped
+    )
+
+    received: list[str | bytes] = []
+    async for frame in base.stream_raw():
+        received.append(frame)
+        base.stop()
+
+    assert received == ["ok"]
+    # Increasing then capped: 0.5*2**0, 0.5*2**1, then clamped to max_backoff=1.0.
+    assert sleep.calls == [
+        pytest.approx(0.5),
+        pytest.approx(1.0),
+        pytest.approx(1.0),
+    ]
+
+
+async def test_backoff_resets_to_base_after_a_good_connect() -> None:
+    # success (1 frame) → fail → success (1 frame). The failure after a good
+    # connect must use base*2**0, proving the attempt counter reset.
+    ws1 = FakeWS(["a"])
+    ws2 = FakeWS(["b"])
+    connector = FakeConnector([ws1, ConnectionError("blip"), ws2])
+    sleep = RecordingSleep()
+    base = WebSocketBase(
+        "wss://example.test", connect=connector, sleep=sleep, backoff_base=0.5
+    )
+
+    received: list[str | bytes] = []
+    async for frame in base.stream_raw():
+        received.append(frame)
+        if len(received) == 2:
+            base.stop()
+
+    assert received == ["a", "b"]
+    # The single reconnect waited base*2**0 (not a larger inherited delay).
+    assert sleep.calls == [pytest.approx(0.5)]
+
+
+async def test_on_connect_called_on_every_reconnect() -> None:
+    calls: list[int] = []
+
+    class Counting(WebSocketBase):
+        async def on_connect(self, ws: Any) -> None:
+            calls.append(1)
+
+    ws1 = FakeWS(["a"])
+    ws2 = FakeWS(["b"])
+    # fail, success, fail, success → two successful connects → two on_connect.
+    connector = FakeConnector(
+        [ConnectionError("x"), ws1, ConnectionError("y"), ws2]
+    )
+    sleep = RecordingSleep()
+    base = Counting("wss://example.test", connect=connector, sleep=sleep)
+
+    received: list[str | bytes] = []
+    async for frame in base.stream_raw():
+        received.append(frame)
+        if len(received) == 2:
+            base.stop()
+
+    assert received == ["a", "b"]
+    # on_connect fires once per *successful* connect, not on failed attempts.
+    assert len(calls) == 2
+
+
+async def test_send_writes_to_active_socket_via_on_connect() -> None:
+    ws = FakeWS(["frame"])
+
+    class Subscriber(WebSocketBase):
+        async def on_connect(self, sock: Any) -> None:
+            await self.send({"method": "subscribe"})
+
+    connector = FakeConnector([ws])
+    base = Subscriber("wss://example.test", connect=connector)
+
+    async for _ in base.stream_raw():
+        base.stop()
+
+    assert ws.sent == [{"method": "subscribe"}]
+
+
+async def test_send_while_disconnected_raises() -> None:
+    base = WebSocketBase("wss://example.test", connect=FakeConnector([]))
+    with pytest.raises(RuntimeError):
+        await base.send("nope")
+
+
+async def test_stop_before_start_yields_nothing() -> None:
+    connector = FakeConnector([FakeWS(["never"])])
+    base = WebSocketBase("wss://example.test", connect=connector)
+    base.stop()
+
+    received = [frame async for frame in base.stream_raw()]
+    assert received == []
+
+
+@pytest.mark.network
+async def test_real_kraken_ticker_frame() -> None:
+    """Live subscribe to Kraken v2 ``ticker`` for BTC/USD (opt-in: ``-m network``).
+
+    Subscribes from :meth:`on_connect`, asserts at least one real frame arrives,
+    then stops. The first frame is typically the subscription ack.
+    """
+
+    class KrakenTicker(WebSocketBase):
+        async def on_connect(self, ws: Any) -> None:
+            await self.send(
+                json.dumps(
+                    {
+                        "method": "subscribe",
+                        "params": {"channel": "ticker", "symbol": ["BTC/USD"]},
+                    }
+                )
+            )
+
+    base = KrakenTicker("wss://ws.kraken.com/v2")
+    frames: list[str | bytes] = []
+    async for frame in base.stream_raw():
+        frames.append(frame)
+        base.stop()
+
+    assert frames
+    payload = json.loads(frames[0])
+    assert isinstance(payload, dict)

--- a/trading_bot/transport/__init__.py
+++ b/trading_bot/transport/__init__.py
@@ -9,10 +9,13 @@ Public surface:
 * :class:`~trading_bot.transport.http.AsyncHTTPClient` — async httpx wrapper with
   retry/backoff, timeouts, and ``get`` / ``post``;
 * :class:`~trading_bot.transport.http.HTTPError` — transport-local HTTP failure.
+* :class:`~trading_bot.transport.ws.WebSocketBase` — async WebSocket base with
+  ``stream_raw`` and exponential reconnect.
 """
 
 from __future__ import annotations
 
 from trading_bot.transport.http import AsyncHTTPClient, HTTPError
+from trading_bot.transport.ws import WebSocketBase
 
-__all__ = ["AsyncHTTPClient", "HTTPError"]
+__all__ = ["AsyncHTTPClient", "HTTPError", "WebSocketBase"]

--- a/trading_bot/transport/ws.py
+++ b/trading_bot/transport/ws.py
@@ -1,0 +1,236 @@
+"""Async WebSocket base with auto-reconnect.
+
+Thin async wrapper over the ``websockets`` library for the execution layer. It
+provides a raw-frame stream (:meth:`WebSocketBase.stream_raw`) that reconnects
+on disconnect/error with **monotonically increasing, capped** exponential
+backoff, plus an overridable :meth:`WebSocketBase.on_connect` hook and a
+:meth:`WebSocketBase.send` helper.
+
+It is **venue-neutral plumbing**: it does no auth/signing and sends no
+subscription payloads of its own (that belongs to the broker layer, which
+subclasses this base and overrides :meth:`WebSocketBase.on_connect`). It does
+not import domain business logic.
+
+Mirrors ``dccd.transport.ws.WebSocketBase``; adapted for execution by injecting
+the ``connect`` and ``sleep`` callables as seams so reconnect timing and
+behaviour are testable without a real server (matching the ``sleep`` seam and
+``_MAX_BACKOFF`` cap of the sibling :mod:`trading_bot.transport.http`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable
+
+__all__ = ["WebSocketBase"]
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BACKOFF_BASE = 0.5
+# Cap a single reconnect backoff so a sustained outage never parks the stream
+# for an unreasonable time. Mirrors ``http._MAX_BACKOFF``.
+_DEFAULT_MAX_BACKOFF = 60.0
+
+
+class _WSConnection(Protocol):
+    """Minimal structural type for a live ``websockets`` connection.
+
+    Typed as a :class:`~typing.Protocol` so the ``connect`` seam can yield any
+    object exposing ``send`` and async iteration — the real
+    ``websockets.ClientConnection`` and a test fake both satisfy it.
+    """
+
+    async def send(self, message: Any) -> None:
+        """Send one frame on the connection."""
+        ...
+
+    def __aiter__(self) -> AsyncIterator[str | bytes]:
+        """Iterate inbound frames."""
+        ...
+
+
+class _Connector(Protocol):
+    """Structural type for the injected ``connect`` callable.
+
+    Must return an async context manager that yields a :class:`_WSConnection`
+    on ``__aenter__`` (exactly how ``websockets.connect(url)`` behaves). A test
+    fake can therefore raise on ``__aenter__`` to simulate a failed connect,
+    then yield a frame-producing fake on a later attempt.
+    """
+
+    def __call__(self, url: str) -> Any:
+        """Open a connection to *url*; returns an async context manager."""
+        ...
+
+
+def _default_connect(url: str) -> Any:
+    """Open a real ``websockets`` connection (imported lazily).
+
+    ``close_timeout=1`` keeps shutdown snappy: without it the closing handshake
+    can block several seconds on :meth:`WebSocketBase.stop`/cancel.
+    """
+    import websockets
+
+    return websockets.connect(url, close_timeout=1)
+
+
+class WebSocketBase:
+    """Base async WebSocket client with exponential reconnect.
+
+    Subclasses override :meth:`on_connect` to send subscription/auth messages
+    after each (re)connect, and consume :meth:`stream_raw` (or :meth:`stream`
+    via an overridden :meth:`parse_message`) for inbound frames.
+
+    Parameters
+    ----------
+    url : str
+        WebSocket endpoint URL.
+    max_backoff : float, default 60.0
+        Upper bound (seconds) on a single reconnect backoff sleep.
+    backoff_base : float, default 0.5
+        Exponential backoff base, in seconds: the zero-based reconnect
+        *attempt* ``n`` waits ``backoff_base * 2**n`` (0.5, 1.0, 2.0, … —
+        increasing, capped at *max_backoff*). The attempt counter resets to 0
+        after every successful connect, so a brief blip never inherits a long
+        delay from an earlier outage.
+    connect : callable, optional
+        ``websockets.connect``-compatible factory returning an async context
+        manager that yields the live connection. Injected as a seam so
+        reconnect behaviour is testable without a real server.
+    sleep : callable, optional
+        ``asyncio.sleep``-compatible coroutine used for backoff waits. Injected
+        as a seam so reconnect timing is testable without real waits.
+
+    Notes
+    -----
+    The active connection is exposed (privately) only while
+    :meth:`stream_raw` holds it, so :meth:`send` can write subscription/auth
+    frames mid-stream. Calling :meth:`send` while disconnected raises
+    :class:`RuntimeError` rather than silently dropping the frame — the caller
+    should subscribe from :meth:`on_connect` (re-run on every reconnect) and
+    treat a live socket as a precondition for ad-hoc sends.
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        max_backoff: float = _DEFAULT_MAX_BACKOFF,
+        backoff_base: float = _DEFAULT_BACKOFF_BASE,
+        connect: _Connector = _default_connect,
+        sleep: Callable[[float], Awaitable[Any]] = asyncio.sleep,
+    ) -> None:
+        self.url = url
+        self._max_backoff = max_backoff
+        self._backoff_base = backoff_base
+        self._connect = connect
+        self._sleep = sleep
+        self._stop = asyncio.Event()
+        self._ws: _WSConnection | None = None
+
+    def stop(self) -> None:
+        """Request graceful shutdown of the stream."""
+        self._stop.set()
+
+    def _backoff(self, attempt: int) -> float:
+        """Backoff delay (seconds) for a zero-based *attempt*, capped.
+
+        Monotonically increasing exponential backoff: ``backoff_base * 2**attempt``
+        (a sustained outage waits longer each retry, never shorter), capped at
+        ``max_backoff``.
+        """
+        return min(self._backoff_base * 2.0**attempt, self._max_backoff)
+
+    async def on_connect(self, ws: _WSConnection) -> None:
+        """Called after each (re)connect. Override to send subscriptions/auth.
+
+        Default is a no-op (this base is venue-neutral). Because it runs on
+        every reconnect, subscriptions are automatically re-established.
+        """
+
+    async def send(self, message: Any) -> None:
+        """Send a frame on the live connection.
+
+        Parameters
+        ----------
+        message : Any
+            Payload to send (``str`` / ``bytes``, as ``websockets`` accepts).
+
+        Raises
+        ------
+        RuntimeError
+            If called while no connection is active (i.e. outside an active
+            :meth:`stream_raw`, or during a reconnect gap). Re-establish
+            subscriptions from :meth:`on_connect` instead of relying on sends
+            surviving a disconnect.
+        """
+        ws = self._ws
+        if ws is None:
+            raise RuntimeError("send() called while WebSocket is not connected")
+        await ws.send(message)
+
+    async def parse_message(self, raw: str | bytes) -> AsyncIterator[Any]:
+        """Parse a raw frame and yield records. Override in subclass.
+
+        Default yields nothing; brokers override this to turn frames into
+        domain-facing records (the base stays venue-neutral).
+        """
+        return
+        yield  # pragma: no cover - makes this an async generator
+
+    async def stream(self) -> AsyncIterator[Any]:
+        """Yield parsed records, reconnecting on errors.
+
+        Delegates frame parsing to :meth:`parse_message`. Kept thin to mirror
+        dccd; most execution adapters consume :meth:`stream_raw` directly.
+        """
+        async for raw in self.stream_raw():
+            async for record in self.parse_message(raw):
+                yield record
+
+    async def stream_raw(self) -> AsyncIterator[str | bytes]:
+        """Yield raw WebSocket frames, reconnecting with exponential backoff.
+
+        Connects, runs :meth:`on_connect`, then yields inbound frames. On any
+        disconnect or error it reconnects with **increasing, capped**
+        exponential backoff (the attempt counter resets after each successful
+        connect). The loop ends cleanly once :meth:`stop` is called.
+
+        Yields
+        ------
+        str or bytes
+            Raw inbound WebSocket frames, in arrival order.
+        """
+        attempt = 0
+        while not self._stop.is_set():
+            try:
+                async with self._connect(self.url) as ws:
+                    # Successful connect: reset backoff and expose the socket
+                    # so send() can write while the stream runs.
+                    attempt = 0
+                    self._ws = ws
+                    await self.on_connect(ws)
+                    async for raw in ws:
+                        if self._stop.is_set():
+                            return
+                        yield raw
+            except asyncio.CancelledError:
+                return
+            except Exception as exc:
+                if self._stop.is_set():
+                    return
+                delay = self._backoff(attempt)
+                logger.warning(
+                    "WS %s disconnected: %s — reconnect in %.1fs",
+                    self.url,
+                    exc,
+                    delay,
+                )
+                await self._sleep(delay)
+                attempt += 1
+            finally:
+                self._ws = None


### PR DESCRIPTION
## Summary
- Second leaf of **E2 — Transport**: `trading_bot/transport/ws.py`.
- `WebSocketBase` — async `stream_raw()` with **increasing, capped** exponential reconnect (resets after a good connect), `on_connect` hook (subscribe/auth, self-heals on reconnect), `send()`.

## Why
- Base for the broker's private order/fill streams (E3). `send()` requires a live socket; subscriptions live in `on_connect` so they survive drops. See `doc/dev/03-decisions.md`.

## Changes
- `transport/ws.py` + export; `tests/transport/test_ws.py` (8 offline via injected connect/sleep seams + 1 `@network` real Kraken v2 ticker frame).

## Changelog
Added under [Unreleased]:
- `transport.WebSocketBase` — async WS base: stream_raw + increasing exponential reconnect, on_connect hook, send().

## Test plan
- [x] `pytest` (196 passed, 6 skipped)
- [x] `pytest -m network` — real Kraken `wss://ws.kraken.com/v2` ticker frame received
- [x] `ruff` + `mypy` clean
- [ ] CI green