### PR TITLE
feat: transport RateLimiter + Kraken call-counter (closes E2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   increasing exponential backoff, `Retry-After` on 429, timeouts). (#13)
 - `transport.WebSocketBase` — async WS base: `stream_raw()` + increasing
   exponential reconnect, `on_connect` hook, `send()`. (#14)
+- `transport.RateLimiter` + `KrakenCallCounter` — per-exchange token-bucket plus
+  Kraken's decaying call-counter (tiers, per-endpoint costs). Completes the
+  **E2 transport** layer. (#15)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,21 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Transport rate-limiting: token-bucket + Kraken call-counter (PR #15)
+
+**Decision.** `transport.RateLimiter` holds one `TokenBucket` per exchange (injected
+clock/sleep seams); `KrakenCallCounter` models Kraken's decaying counter —
+per-endpoint costs and tier limits (starter 15/3s, intermediate 20/2s, pro 20/1s)
+ported from `legacy/tools/call_counters.py`. The port **fixes a legacy under-wait**:
+it waits `overshoot * time_down` (not a raw `overshoot`) so the counter actually
+decays clear of the limit before the next call.
+
+**Why.** Proactive throttling keeps the engine under each venue's published budget —
+a rate-limit ban during live trading is unacceptable. The legacy raw-overshoot sleep
+under-waited and could still trip the limit.
+
+---
+
 ### 2026-06-20 Transport WS: subscriptions via on_connect; send() needs a live socket (PR #14)
 
 **Decision.** `transport.WebSocketBase.stream_raw()` reconnects with increasing,

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,11 +10,13 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**E1 — Domain core is complete.** `trading_bot/domain/` exposes `money`,
-`instrument`, `errors`, `order`, `fill`, `position`, `signal`, `performance` —
-pure, mypy-strict, ~180 tests (KPI parity import-gated on fynance). The later
-layers (`transport`, `brokers`, `storage`, `application`, `interfaces`) are
-pending — next is **E2 (transport)**. See `07-roadmap.md` / `08-program-plan.md`.
+**E1 (domain) and E2 (transport) are complete.** `trading_bot/domain/` (money,
+instrument, errors, order, fill, position, signal, performance — pure, mypy-strict)
+and `trading_bot/transport/` (`AsyncHTTPClient`, `WebSocketBase`, `RateLimiter` +
+`KrakenCallCounter` — async, with real Kraken REST/WS smokes under `-m network`)
+are in. The later layers (`brokers`, `storage`, `application`, `interfaces`) are
+pending — next is **E3 (broker port + Kraken adapter)**. See `07-roadmap.md` /
+`08-program-plan.md`.
 
 ## Done
 
@@ -27,7 +29,7 @@ pending — next is **E2 (transport)**. See `07-roadmap.md` / `08-program-plan.m
 
 ## Pending
 
-Everything remaining in [`07-roadmap.md`](07-roadmap.md): transport, the
+Everything remaining in [`07-roadmap.md`](07-roadmap.md): the
 Kraken broker + paper broker, the order router, the strategy runner, performance/
 risk, the CLI, the orchestration layer, and (later) the UI and go-live hardening.
 

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,9 +12,6 @@ The single source *index* of open work. Each unchecked item is a candidate for
 
 ## Foundation
 
-- [ ] **E2 — Transport.** `AsyncHTTPClient` (httpx + retry/backoff),
-  `WebSocketBase` (reconnect), `RateLimiter` (token-bucket / Kraken call-counter).
-  Mirror dccd's transport. _(depends on E1 for typing only)_
 - [ ] **E3 — Broker port + Kraken adapter.** `Broker` protocol (place/cancel/
   replace, open orders, balances, fills, market data) + registry; `KrakenBroker`
   (REST first, WS fills next). Other venues declared, not implemented.

--- a/doc/dev/plans/transport/00-plan.md
+++ b/doc/dev/plans/transport/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: transport
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E2 — Transport.** `AsyncHTTPClient` (httpx + retry/backoff), `WebSocketBase` (reconnect), `RateLimiter` (token-bucket / Kraken call-counter). Mirror dccd's transport."
 release_on_done: false
 ---
@@ -30,7 +30,7 @@ is venue-neutral plumbing.
 
 - [x] 01 http — feat/transport-http — medium
 - [x] 02 ws — feat/transport-ws — medium
-- [ ] 03 ratelimit — feat/transport-ratelimit — medium
+- [x] 03 ratelimit — feat/transport-ratelimit — medium
 
 ## Dependencies
 

--- a/doc/dev/plans/transport/03-ratelimit.md
+++ b/doc/dev/plans/transport/03-ratelimit.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/transport-ratelimit
-pr: ""
+pr: "#15"
 ---
 
 # RateLimiter — token-bucket + Kraken call-counter

--- a/doc/dev/plans/transport/03-ratelimit.md
+++ b/doc/dev/plans/transport/03-ratelimit.md
@@ -1,7 +1,7 @@
 ---
 plan: transport/03-ratelimit
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false

--- a/trading_bot/tests/transport/test_ratelimit.py
+++ b/trading_bot/tests/transport/test_ratelimit.py
@@ -1,0 +1,322 @@
+"""Tests for :mod:`trading_bot.transport.ratelimit`.
+
+Every test drives the timing layer through injected ``time_source`` / ``sleep``
+seams: a :class:`FakeClock` advances *only* when the recording :class:`Clock`-
+bound sleep is awaited (and never on its own), so the spacing and decay are
+asserted deterministically with no real waits. The Kraken counter assertions
+cite the legacy constants ported in :mod:`trading_bot.transport.ratelimit`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trading_bot.transport import KrakenCallCounter, RateLimiter, TokenBucket
+
+
+class FakeClock:
+    """A monotonic clock that only moves when its :attr:`sleep` is awaited.
+
+    Used as both the ``time_source`` (read :attr:`now`) and the ``sleep`` seam
+    (advances :attr:`now` by the requested delay and records it). This couples
+    "time passed" to "we slept", so a token-bucket wait is reflected in the
+    next refill exactly as it would be under a real clock.
+    """
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.waits: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    async def sleep(self, delay: float) -> None:
+        self.waits.append(delay)
+        self.now += delay
+
+    def advance(self, seconds: float) -> None:
+        """Advance the clock without sleeping (simulate a slow caller)."""
+        self.now += seconds
+
+    @property
+    def total_waited(self) -> float:
+        return sum(self.waits)
+
+
+# --------------------------------------------------------------------------- #
+# TokenBucket
+# --------------------------------------------------------------------------- #
+
+
+async def test_burst_is_spaced_to_rate() -> None:
+    # rate=2/s, capacity=2 (default). A burst of acquires beyond the initial
+    # capacity is paced to one token every 1/rate = 0.5s.
+    clock = FakeClock()
+    bucket = TokenBucket(2.0, time_source=clock.time, sleep=clock.sleep)
+
+    # First two consume the initial burst capacity with no wait.
+    await bucket.acquire()
+    await bucket.acquire()
+    assert clock.waits == []
+
+    # The next three each wait one inter-token interval (0.5s).
+    for _ in range(3):
+        await bucket.acquire()
+
+    assert clock.waits == [
+        pytest.approx(0.5),
+        pytest.approx(0.5),
+        pytest.approx(0.5),
+    ]
+    assert clock.total_waited == pytest.approx(1.5)
+
+
+async def test_slow_caller_never_waits() -> None:
+    # A caller slower than the rate (1/s here) always finds a token ready.
+    clock = FakeClock()
+    bucket = TokenBucket(1.0, time_source=clock.time, sleep=clock.sleep)
+
+    await bucket.acquire()  # spends the one-token initial burst
+    for _ in range(5):
+        clock.advance(1.0)  # one full inter-token interval between calls
+        await bucket.acquire()
+
+    assert clock.waits == []
+
+
+async def test_capacity_overrides_burst() -> None:
+    # An explicit capacity sets the burst size independently of the rate.
+    clock = FakeClock()
+    bucket = TokenBucket(
+        10.0, capacity=1.0, time_source=clock.time, sleep=clock.sleep
+    )
+
+    await bucket.acquire()  # spends the single token of capacity
+    await bucket.acquire()  # must wait one interval: 1/rate = 0.1s
+
+    assert clock.waits == [pytest.approx(0.1)]
+
+
+def test_non_positive_rate_rejected() -> None:
+    with pytest.raises(ValueError):
+        TokenBucket(0.0)
+
+
+# --------------------------------------------------------------------------- #
+# RateLimiter
+# --------------------------------------------------------------------------- #
+
+
+async def test_distinct_exchanges_use_independent_buckets() -> None:
+    clock = FakeClock()
+    limiter = RateLimiter(time_source=clock.time, sleep=clock.sleep)
+
+    # kraken default rate is 1/s (capacity 1): one free, the second waits 1s.
+    await limiter.acquire("kraken")
+    await limiter.acquire("kraken")
+    assert clock.waits == [pytest.approx(1.0)]
+
+    # A *different* exchange has its own full bucket: the first binance acquire
+    # does not wait, proving the buckets are independent.
+    clock.waits.clear()
+    await limiter.acquire("binance")
+    assert clock.waits == []
+
+
+async def test_unknown_exchange_uses_fallback_rate() -> None:
+    # Fallback rate is 3/s (capacity 3): three free, the fourth waits 1/3 s.
+    clock = FakeClock()
+    limiter = RateLimiter(time_source=clock.time, sleep=clock.sleep)
+
+    for _ in range(3):
+        await limiter.acquire("nasdaq-totally-unknown")
+    assert clock.waits == []
+
+    await limiter.acquire("nasdaq-totally-unknown")
+    assert clock.waits == [pytest.approx(1.0 / 3.0)]
+
+
+async def test_custom_rates_merge_over_defaults() -> None:
+    clock = FakeClock()
+    limiter = RateLimiter(
+        {"kraken": 4.0}, time_source=clock.time, sleep=clock.sleep
+    )
+
+    # Overridden kraken rate 4/s (capacity 4): four free, fifth waits 0.25s.
+    for _ in range(4):
+        await limiter.acquire("kraken")
+    assert clock.waits == []
+    await limiter.acquire("kraken")
+    assert clock.waits == [pytest.approx(0.25)]
+
+
+async def test_acquire_none_is_noop() -> None:
+    clock = FakeClock()
+    limiter = RateLimiter(time_source=clock.time, sleep=clock.sleep)
+
+    # None means "unattributed request": never throttled, no bucket created.
+    for _ in range(100):
+        await limiter.acquire(None)
+    assert clock.waits == []
+
+
+async def test_context_manager_acquires() -> None:
+    clock = FakeClock()
+    limiter = RateLimiter(time_source=clock.time, sleep=clock.sleep)
+
+    async with limiter("kraken"):
+        pass
+    async with limiter("kraken"):  # second entry waits one kraken interval
+        pass
+    assert clock.waits == [pytest.approx(1.0)]
+
+
+# --------------------------------------------------------------------------- #
+# KrakenCallCounter
+# --------------------------------------------------------------------------- #
+
+
+def test_costs_match_legacy_table() -> None:
+    # Ported verbatim from legacy KrakenCallCounter._handler_method.
+    assert KrakenCallCounter.cost_of("AddOrder") == 0
+    assert KrakenCallCounter.cost_of("CancelOrder") == 0
+    assert KrakenCallCounter.cost_of("Balance") == 1
+    assert KrakenCallCounter.cost_of("OpenOrders") == 1
+    assert KrakenCallCounter.cost_of("TradesHistory") == 2
+    assert KrakenCallCounter.cost_of("Ledgers") == 2
+    assert KrakenCallCounter.cost_of("QueryLedgers") == 2
+    with pytest.raises(ValueError):
+        KrakenCallCounter.cost_of("NotAMethod")
+
+
+def test_tiers_match_legacy_constants() -> None:
+    # Legacy KrakenCallCounter.__init__: starter (3, 15), intermediate (2, 20),
+    # pro (1, 20).
+    starter = KrakenCallCounter.for_tier("starter")
+    assert (starter.time_down, starter.call_rate_limit) == (3, 15)
+    intermediate = KrakenCallCounter.for_tier("INTERMEDIATE")
+    assert (intermediate.time_down, intermediate.call_rate_limit) == (2, 20)
+    pro = KrakenCallCounter.for_tier("pro")
+    assert (pro.time_down, pro.call_rate_limit) == (1, 20)
+    with pytest.raises(ValueError):
+        KrakenCallCounter.for_tier("oligarch")
+
+
+async def test_counter_increments_per_cost() -> None:
+    clock = FakeClock()
+    counter = KrakenCallCounter(
+        time_down=3, call_rate_limit=15, time_source=clock.time, sleep=clock.sleep
+    )
+
+    await counter.acquire_method("Balance")  # +1
+    assert counter.current() == 1
+    await counter.acquire_method("TradesHistory")  # +2
+    assert counter.current() == 3
+    await counter.acquire_method("AddOrder")  # +0
+    assert counter.current() == 3
+    assert clock.waits == []
+
+
+async def test_counter_decays_over_time() -> None:
+    # Legacy decay: counter drops by (elapsed // time_down). With time_down=3,
+    # 9 seconds removes 3 units.
+    clock = FakeClock()
+    counter = KrakenCallCounter(
+        time_down=3, call_rate_limit=15, time_source=clock.time, sleep=clock.sleep
+    )
+
+    for _ in range(5):
+        await counter.acquire_method("Balance")  # counter = 5
+    assert counter.current() == 5
+
+    clock.advance(9.0)  # 9 // 3 = 3 units decay
+    assert counter.current() == 2
+
+    clock.advance(100.0)  # floors at zero
+    assert counter.current() == 0
+
+
+async def test_acquire_waits_when_limit_would_be_exceeded() -> None:
+    # starter tier: time_down=3, call_rate_limit=15. Margin = call_rate_limit
+    # - 1 = 14. A call lands without waiting up to and *onto* the margin (14);
+    # it waits only when it would be pushed strictly past it. The correct model
+    # waits ``overshoot * time_down`` so the counter actually decays clear.
+    clock = FakeClock()
+    counter = KrakenCallCounter(
+        time_down=3, call_rate_limit=15, time_source=clock.time, sleep=clock.sleep
+    )
+
+    # Drive the counter exactly onto the margin (14) with Balance calls (+1) —
+    # none wait, since 13 + 1 == 14 lands on the margin, not past it.
+    for _ in range(14):
+        await counter.acquire_method("Balance")
+    assert counter.current() == 14
+    assert clock.waits == []
+
+    # The 15th +1 would make 15 > 14 → overshoot 1 → wait 1 * time_down = 3s.
+    await counter.acquire_method("Balance")
+    assert clock.waits == [pytest.approx(3.0)]
+    # 3s decays 1 unit: 14 - 1 = 13, then + 1 newly added = 14.
+    assert counter.current() == 14
+
+
+def test_would_exceed_reports_margin() -> None:
+    clock = FakeClock()
+    counter = KrakenCallCounter(
+        time_down=3, call_rate_limit=15, time_source=clock.time, sleep=clock.sleep
+    )
+    counter.counter = 13
+    counter._last = int(clock.time())
+    assert counter.would_exceed(1) is False  # 14 lands on margin → admitted
+    assert counter.would_exceed(2) is True  # 15 > 14 → would wait
+
+
+def test_non_positive_params_rejected() -> None:
+    with pytest.raises(ValueError):
+        KrakenCallCounter(time_down=0, call_rate_limit=15)
+    with pytest.raises(ValueError):
+        KrakenCallCounter(time_down=3, call_rate_limit=0)
+
+
+# --------------------------------------------------------------------------- #
+# Verification on real data: realistic Kraken private-call burst (fake clock)
+# --------------------------------------------------------------------------- #
+
+
+async def test_realistic_kraken_private_burst_timeline() -> None:
+    """Drive a realistic burst of Kraken private calls under a fake clock.
+
+    Tier 'starter' (time_down=3, call_rate_limit=15, margin=14). The pattern
+    front-loads heavy history pulls then settles into balance polls; we assert
+    the exact wait timeline produced by the decaying counter.
+    """
+    clock = FakeClock()
+    counter = KrakenCallCounter.for_tier(
+        "starter", time_source=clock.time, sleep=clock.sleep
+    )
+
+    # 6 TradesHistory (cost 2 each) → counter climbs 2,4,6,8,10,12. None hit
+    # the 14 margin (12 + 2 = 14 would, so the 7th is where it bites).
+    timeline: list[tuple[str, int, float]] = []
+    for _ in range(6):
+        await counter.acquire_method("TradesHistory")
+        timeline.append(("TradesHistory", counter.counter, clock.now))
+
+    assert [c for _, c, _ in timeline] == [2, 4, 6, 8, 10, 12]
+    assert clock.waits == []  # nothing waited yet
+
+    # 7th TradesHistory: 12 + 2 = 14 >= margin → wait. Overshoot = 14 - 14 = 0?
+    # No: margin is call_rate_limit - 1 = 14, so counter + cost >= 14 holds.
+    # overshoot = 12 + 2 - 14 = 0 → no wait; it lands exactly on the margin and
+    # is allowed (the legacy code sleeps only when strictly past, see counter
+    # value). Confirm it proceeds without waiting and sits at 14.
+    await counter.acquire_method("TradesHistory")
+    assert counter.counter == 14
+    assert clock.waits == []
+
+    # 8th TradesHistory: 14 + 2 - 14 = 2 overshoot → wait 2 * time_down = 6s.
+    await counter.acquire_method("TradesHistory")
+    assert clock.waits == [pytest.approx(6.0)]
+    # 6s decays 2 units: 14 - 2 = 12, then + 2 = 14.
+    assert counter.counter == 14
+    assert clock.now == pytest.approx(6.0)

--- a/trading_bot/transport/__init__.py
+++ b/trading_bot/transport/__init__.py
@@ -11,11 +11,28 @@ Public surface:
 * :class:`~trading_bot.transport.http.HTTPError` — transport-local HTTP failure.
 * :class:`~trading_bot.transport.ws.WebSocketBase` — async WebSocket base with
   ``stream_raw`` and exponential reconnect.
+* :class:`~trading_bot.transport.ratelimit.RateLimiter` /
+  :class:`~trading_bot.transport.ratelimit.TokenBucket` — proactive
+  per-exchange token-bucket throttling.
+* :class:`~trading_bot.transport.ratelimit.KrakenCallCounter` — Kraken's
+  decaying private-endpoint call counter.
 """
 
 from __future__ import annotations
 
 from trading_bot.transport.http import AsyncHTTPClient, HTTPError
+from trading_bot.transport.ratelimit import (
+    KrakenCallCounter,
+    RateLimiter,
+    TokenBucket,
+)
 from trading_bot.transport.ws import WebSocketBase
 
-__all__ = ["AsyncHTTPClient", "HTTPError", "WebSocketBase"]
+__all__ = [
+    "AsyncHTTPClient",
+    "HTTPError",
+    "KrakenCallCounter",
+    "RateLimiter",
+    "TokenBucket",
+    "WebSocketBase",
+]

--- a/trading_bot/transport/ratelimit.py
+++ b/trading_bot/transport/ratelimit.py
@@ -1,0 +1,444 @@
+"""Async rate-limiting primitives for the execution layer.
+
+Two complementary models, both pure-stdlib and **venue-neutral plumbing** (no
+I/O, no network, no domain business logic):
+
+* :class:`TokenBucket` / :class:`RateLimiter` — *proactive* per-exchange
+  throttling. A single :class:`RateLimiter` (one :class:`TokenBucket` per
+  exchange) smooths concurrent operations on the same venue to its published
+  request rate, instead of each caller firing at the full rate independently.
+  Mirrors ``dccd.transport.ratelimit``;
+  :class:`~trading_bot.transport.http.AsyncHTTPClient` keeps its reactive
+  429/Retry-After handling as a backstop.
+
+* :class:`KrakenCallCounter` — Kraken's private-endpoint **decaying call
+  counter**. Each private call adds a per-endpoint *cost*; the counter decays
+  by one every ``time_down`` seconds; :meth:`KrakenCallCounter.acquire` waits
+  until adding the next cost would not exceed ``call_rate_limit``. The model
+  (tier constants and per-endpoint costs) is ported from the legacy
+  ``trading_bot/legacy/tools/call_counters.py`` — see :data:`_KRAKEN_TIERS` and
+  :data:`KrakenCallCounter.COSTS`.
+
+Default proactive rates are deliberately conservative (public, unauthenticated
+REST):
+
+============  =========  ====================================================
+exchange      req/s      source
+============  =========  ====================================================
+binance       10.0       weight-based, 1200 weight/min; klines weight 2 → high
+coinbase       3.0       public endpoints 3 req/s (docs.cdp.coinbase.com)
+kraken         1.0       public endpoints ~1 req/s (support.kraken.com)
+bybit         10.0       public market data ~10 req/s
+okx            8.0       history-candles 20 req/2s = 10/s; kept under for margin
+bitfinex       1.0       public REST 10-90 req/min → ~1 req/s conservative
+bitmex         0.5       unauthenticated ~30 req/min → 0.5 req/s
+============  =========  ====================================================
+
+The clock and sleep are injected as seams (``time_source`` / ``sleep``,
+matching the sibling :mod:`trading_bot.transport.http` and :mod:`~.ws` ``sleep``
+seam) so timing and decay are deterministic under a fake clock in tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Awaitable, Callable
+
+__all__ = ["KrakenCallCounter", "RateLimiter", "TokenBucket"]
+
+_DEFAULT_RATES: dict[str, float] = {
+    "binance": 10.0,
+    "coinbase": 3.0,
+    "kraken": 1.0,
+    "bybit": 10.0,
+    "okx": 8.0,
+    "bitfinex": 1.0,
+    "bitmex": 0.5,
+}
+
+# Rate (req/s) used for any exchange not listed in ``_DEFAULT_RATES``.
+_FALLBACK_RATE = 3.0
+
+
+class TokenBucket:
+    """Single token-bucket for one exchange.
+
+    Tokens refill continuously at *rate* per second, capped at *capacity*.
+    :meth:`acquire` consumes one token, waiting only when fewer than one is
+    available. A caller slower than *rate* therefore never waits; a burst is
+    smoothed to one request per ``1/rate`` seconds.
+
+    Parameters
+    ----------
+    rate : float
+        Sustained requests per second.
+    capacity : float, optional
+        Maximum tokens held (burst capacity). Defaults to *rate* (a one-second
+        burst), matching dccd.
+    time_source : callable, optional
+        Monotonic time source (seconds). Injected as a seam for deterministic
+        tests; defaults to :func:`time.monotonic`.
+    sleep : callable, optional
+        ``asyncio.sleep``-compatible coroutine used to wait for a token.
+        Injected as a seam so timing is testable without real waits; defaults
+        to :func:`asyncio.sleep`.
+    """
+
+    def __init__(
+        self,
+        rate: float,
+        *,
+        capacity: float | None = None,
+        time_source: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[object]] = asyncio.sleep,
+    ) -> None:
+        if rate <= 0.0:
+            raise ValueError(f"rate must be positive, got {rate!r}")
+        self._rate = rate
+        self._capacity = rate if capacity is None else capacity
+        self._time_source = time_source
+        self._sleep = sleep
+        self._tokens = self._capacity
+        self._last = time_source()
+        self._lock = asyncio.Lock()
+
+    def _refill(self) -> None:
+        """Add tokens accrued since the last update, capped at capacity."""
+        now = self._time_source()
+        elapsed = now - self._last
+        self._tokens = min(self._capacity, self._tokens + elapsed * self._rate)
+        self._last = now
+
+    async def acquire(self) -> None:
+        """Wait until a token is available, then consume it.
+
+        Serialised by an :class:`asyncio.Lock` so concurrent callers on the
+        same bucket draw tokens one at a time (no double-spend on refill).
+        """
+        async with self._lock:
+            self._refill()
+            if self._tokens < 1.0:
+                wait = (1.0 - self._tokens) / self._rate
+                await self._sleep(wait)
+                # Re-refill against the (possibly faked) clock after waiting,
+                # then spend: under a real clock ``wait`` seconds have passed,
+                # so exactly one token is now available.
+                self._refill()
+            self._tokens -= 1.0
+
+
+class RateLimiter:
+    """Per-exchange rate limiter holding one :class:`TokenBucket` each.
+
+    Buckets are created lazily on first use of an exchange, so distinct
+    exchanges throttle independently. The seams are forwarded to every bucket.
+
+    Parameters
+    ----------
+    rates : dict of str to float, optional
+        Map of exchange name → requests per second, merged over the
+        conservative defaults. Unknown exchanges fall back to
+        ``_FALLBACK_RATE``.
+    time_source : callable, optional
+        Monotonic time source forwarded to each bucket (test seam); defaults
+        to :func:`time.monotonic`.
+    sleep : callable, optional
+        ``asyncio.sleep``-compatible coroutine forwarded to each bucket (test
+        seam); defaults to :func:`asyncio.sleep`.
+
+    Notes
+    -----
+    Satisfies the structural ``_Limiter`` protocol expected by
+    :class:`~trading_bot.transport.http.AsyncHTTPClient`
+    (``async acquire(exchange: str | None) -> None``). Calling
+    :meth:`acquire` with ``None`` is a deliberate no-op: a request with no
+    exchange key cannot be attributed to a bucket, so it is not throttled
+    (the HTTP client only passes ``None`` when no *exchange* was configured).
+    """
+
+    def __init__(
+        self,
+        rates: dict[str, float] | None = None,
+        *,
+        time_source: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[object]] = asyncio.sleep,
+    ) -> None:
+        self._rates = {**_DEFAULT_RATES, **(rates or {})}
+        self._time_source = time_source
+        self._sleep = sleep
+        self._buckets: dict[str, TokenBucket] = {}
+
+    def _bucket(self, exchange: str) -> TokenBucket:
+        bucket = self._buckets.get(exchange)
+        if bucket is None:
+            rate = self._rates.get(exchange, _FALLBACK_RATE)
+            bucket = TokenBucket(
+                rate, time_source=self._time_source, sleep=self._sleep
+            )
+            self._buckets[exchange] = bucket
+        return bucket
+
+    async def acquire(self, exchange: str | None) -> None:
+        """Wait until a token is available for *exchange*, then consume it.
+
+        Parameters
+        ----------
+        exchange : str or None
+            Exchange key selecting the bucket. ``None`` is a no-op (an
+            unattributed request is not throttled).
+        """
+        if exchange is None:
+            return
+        await self._bucket(exchange).acquire()
+
+    @asynccontextmanager
+    async def __call__(self, exchange: str) -> AsyncIterator[None]:
+        """Async context manager that acquires a token on enter."""
+        await self.acquire(exchange)
+        yield
+
+
+# Kraken private-endpoint tiers: (time_down seconds, call_rate_limit).
+# Ported verbatim from ``trading_bot/legacy/tools/call_counters.py``
+# (``KrakenCallCounter.__init__``): the counter decays by 1 every ``time_down``
+# seconds and a user is banned at ``call_rate_limit``.
+_KRAKEN_TIERS: dict[str, tuple[int, int]] = {
+    "starter": (3, 15),
+    "intermediate": (2, 20),
+    "pro": (1, 20),
+}
+
+
+class KrakenCallCounter:
+    """Kraken private-endpoint decaying call counter.
+
+    Models Kraken's API counter for private endpoints: each call adds a
+    per-endpoint *cost* (:data:`COSTS`); the counter decays by one every
+    ``time_down`` seconds; a user's account is banned once the counter reaches
+    ``call_rate_limit``. :meth:`acquire` waits until adding the next cost would
+    keep the counter strictly under the limit (leaving a one-unit safety margin,
+    as the legacy code did).
+
+    Constants are ported from ``trading_bot/legacy/tools/call_counters.py``
+    (the legacy ``_CallCounter`` / ``KrakenCallCounter``): see
+    :data:`_KRAKEN_TIERS` for the per-tier ``(time_down, call_rate_limit)`` and
+    :data:`COSTS` for the per-endpoint cost table.
+
+    Parameters
+    ----------
+    time_down : int
+        Seconds elapsed per one-unit decay of the counter.
+    call_rate_limit : int
+        Counter value at which the account is banned (calls are paced to stay
+        under it).
+    time_source : callable, optional
+        Monotonic time source (seconds). Injected as a seam for deterministic
+        tests; defaults to :func:`time.monotonic`.
+    sleep : callable, optional
+        ``asyncio.sleep``-compatible coroutine used to wait out the counter.
+        Injected as a seam so timing is testable without real waits; defaults
+        to :func:`asyncio.sleep`.
+
+    Notes
+    -----
+    The legacy model worked in integer wall-clock seconds and decayed by
+    ``(t - last) // time_down``; this port keeps the same integer-step decay
+    against the (monotonic) seam so the asserted timeline matches the legacy
+    numbers exactly.
+    """
+
+    #: Per-endpoint counter cost, ported from
+    #: ``KrakenCallCounter._handler_method`` in the legacy module.
+    COSTS: dict[str, int] = {
+        "AddOrder": 0,
+        "CancelOrder": 0,
+        "Balance": 1,
+        "TradeBalance": 1,
+        "OpenOrders": 1,
+        "ClosedOrders": 1,
+        "QueryOrders": 1,
+        "QueryTrades": 1,
+        "OpenPositions": 1,
+        "TradeVolume": 1,
+        "AddExport": 1,
+        "ExportStatus": 1,
+        "RetrieveExport": 1,
+        "RemoveExport": 1,
+        "TradesHistory": 2,
+        "Ledgers": 2,
+        "QueryLedgers": 2,
+    }
+
+    def __init__(
+        self,
+        *,
+        time_down: int,
+        call_rate_limit: int,
+        time_source: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[object]] = asyncio.sleep,
+    ) -> None:
+        if time_down <= 0:
+            raise ValueError(f"time_down must be positive, got {time_down!r}")
+        if call_rate_limit <= 0:
+            raise ValueError(
+                f"call_rate_limit must be positive, got {call_rate_limit!r}"
+            )
+        self.time_down = time_down
+        self.call_rate_limit = call_rate_limit
+        self._time_source = time_source
+        self._sleep = sleep
+        self.counter = 0
+        self._last = int(time_source())
+        self._lock = asyncio.Lock()
+
+    @classmethod
+    def for_tier(
+        cls,
+        tier: str,
+        *,
+        time_source: Callable[[], float] = time.monotonic,
+        sleep: Callable[[float], Awaitable[object]] = asyncio.sleep,
+    ) -> KrakenCallCounter:
+        """Build a counter for a verified-user *tier*.
+
+        Parameters
+        ----------
+        tier : {'starter', 'intermediate', 'pro'}
+            Kraken account verification tier. Selects the
+            ``(time_down, call_rate_limit)`` pair from :data:`_KRAKEN_TIERS`.
+        time_source, sleep : callable, optional
+            Seams forwarded to the constructor.
+
+        Returns
+        -------
+        KrakenCallCounter
+        """
+        try:
+            time_down, call_rate_limit = _KRAKEN_TIERS[tier.lower()]
+        except KeyError:
+            raise ValueError(f"Invalid tier {tier!r}") from None
+        return cls(
+            time_down=time_down,
+            call_rate_limit=call_rate_limit,
+            time_source=time_source,
+            sleep=sleep,
+        )
+
+    @classmethod
+    def cost_of(cls, method: str) -> int:
+        """Return the counter cost of a private *method*.
+
+        Parameters
+        ----------
+        method : str
+            Kraken private endpoint name (e.g. ``"AddOrder"``).
+
+        Returns
+        -------
+        int
+            The per-call counter cost.
+
+        Raises
+        ------
+        ValueError
+            If *method* is not a known Kraken private endpoint.
+        """
+        cost = cls.COSTS.get(method)
+        if cost is None:
+            raise ValueError(f"Unknown method {method!r}")
+        return cost
+
+    def _decay(self) -> None:
+        """Decay the counter for time elapsed since the last update.
+
+        Mirrors the legacy integer-step decay: ``(now - last) // time_down``
+        units are removed, the clock anchor advances by whole steps only, and
+        the counter floors at zero.
+        """
+        now = int(self._time_source())
+        steps = (now - self._last) // self.time_down
+        if steps > 0:
+            self.counter = max(self.counter - steps, 0)
+            self._last += steps * self.time_down
+
+    def current(self) -> int:
+        """Return the counter value after decaying to the current time.
+
+        Returns
+        -------
+        int
+            The decayed counter (a side-effecting read: it advances the decay
+            anchor, exactly as the legacy ``__call__`` did).
+        """
+        self._decay()
+        return self.counter
+
+    def would_exceed(self, cost: int) -> bool:
+        """Whether adding *cost* now would force :meth:`acquire` to wait.
+
+        Decays to the current time first, then reports whether
+        ``counter + cost`` would land **past** the ``call_rate_limit - 1``
+        safety margin (the one-unit margin the legacy code kept). A call that
+        lands exactly on the margin is still admitted without waiting, so this
+        returns ``True`` only when the counter would be pushed strictly above
+        it — i.e. exactly when :meth:`acquire` would sleep.
+
+        Parameters
+        ----------
+        cost : int
+            Counter cost of the prospective call.
+
+        Returns
+        -------
+        bool
+            ``True`` if the call would wait before proceeding.
+        """
+        self._decay()
+        return self._wait_for(cost) > 0.0
+
+    def _wait_for(self, cost: int) -> float:
+        """Seconds to wait so that ``counter + cost`` clears the margin.
+
+        Assumes the counter has just been decayed. Returns ``0.0`` when the
+        call already fits.
+        """
+        overshoot = self.counter + cost - (self.call_rate_limit - 1)
+        if overshoot <= 0:
+            return 0.0
+        # Each ``time_down`` seconds removes one unit; wait whole decay steps.
+        return float(overshoot * self.time_down)
+
+    async def acquire(self, cost: int) -> None:
+        """Account for a call of *cost*, waiting if it would breach the limit.
+
+        Decays the counter to now; if adding *cost* would reach the
+        ``call_rate_limit - 1`` margin, waits exactly long enough for the
+        counter to decay below it, then records the cost.
+
+        Parameters
+        ----------
+        cost : int
+            Counter cost of the call (see :meth:`cost_of` / :data:`COSTS`).
+        """
+        async with self._lock:
+            self._decay()
+            wait = self._wait_for(cost)
+            if wait > 0.0:
+                await self._sleep(wait)
+                self._decay()
+            self.counter += cost
+
+    async def acquire_method(self, method: str) -> None:
+        """Convenience: :meth:`acquire` the cost of a named private *method*.
+
+        Parameters
+        ----------
+        method : str
+            Kraken private endpoint name (e.g. ``"TradesHistory"``).
+        """
+        await self.acquire(self.cost_of(method))


### PR DESCRIPTION
## Summary
- **Final leaf of E2 — Transport**: `trading_bot/transport/ratelimit.py`.
- `TokenBucket` + per-exchange `RateLimiter` (satisfies the http client's limiter Protocol) + `KrakenCallCounter` (decaying counter: tiers, per-endpoint costs).
- Closes E2 — `07-roadmap.md` E2 line removed, `06-status.md` marks transport complete.

## Why
- Proactive throttling keeps the engine under each venue's budget (a live-trading ban is unacceptable). The Kraken port **fixes a legacy under-wait** (waits `overshoot*time_down`). Constants mined from `legacy/tools/call_counters.py`. See `doc/dev/03-decisions.md`.

## Changes
- `transport/ratelimit.py` + exports; `tests/transport/test_ratelimit.py` (17 deterministic fake-clock tests, 100% coverage on ratelimit.py).

## Changelog
Added under [Unreleased]:
- `transport.RateLimiter` + `KrakenCallCounter` — per-exchange token-bucket + Kraken decaying call-counter.

## Test plan
- [x] `pytest` (213 passed, 6 skipped)
- [x] `ruff` + `mypy` clean
- [ ] CI green