### PR TITLE
docs: plan broker-kraken (E3)

### DIFF
--- a/doc/dev/plans/broker-kraken/00-plan.md
+++ b/doc/dev/plans/broker-kraken/00-plan.md
@@ -1,0 +1,50 @@
+---
+plan: broker-kraken
+kind: global
+status: planning
+roadmap: "- [ ] **E3 — Broker port + Kraken adapter.** `Broker` protocol (place/cancel/replace, open orders, balances, fills, market data) + registry; `KrakenBroker` (REST first, WS fills next). Other venues declared, not implemented."
+release_on_done: false
+---
+
+# E3 — Broker port + Kraken adapter
+
+## Goal
+
+Define the venue-neutral **`Broker` port** (+ registry + capability model) that the
+execution engine talks to, and implement the **Kraken** adapter over it — REST first
+(orders/balances/fills), then the private WebSocket (own-trades / order updates).
+Mirrors dccd's `sources/` shape (base protocol + registry + per-exchange adapter:
+`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/sources/`). Sits on the E2
+transport (`AsyncHTTPClient`, `WebSocketBase`, `RateLimiter`/`KrakenCallCounter`) and
+speaks domain types (`Order`, `Fill`, `Instrument`, `Money`).
+
+**Posture (decided):** mocks + **real public** endpoint smokes only — **no API key**.
+Authenticated (private) endpoints are implemented and tested via **mocks**; the
+**signing** is verified against **Kraken's published signature test vector**
+(deterministic, no key). Real private verification (balances, live orders) is
+**deferred** until a key is provided. Secrets live in `.env` (gitignored), are never
+logged or committed.
+
+## Decomposition
+
+1. **broker-port** — `brokers/base.py` `Broker` protocol + capabilities; `brokers/registry.py`.
+2. **kraken-rest** — `KrakenBroker` REST: signing (vs Kraken test vector), orders/balances/fills, domain mapping.
+3. **kraken-ws** — Kraken private WS (own-trades/openOrders) parsed into domain `Fill`/order updates.
+
+## Leaf checklist
+
+- [ ] 01 broker-port — feat/broker-port — high
+- [ ] 02 kraken-rest — feat/broker-kraken-rest — high (depends on 01)
+- [ ] 03 kraken-ws — feat/broker-kraken-ws — high (depends on 02)
+
+## Dependencies
+
+- 02 depends on 01; 03 depends on 02. (Serial.)
+
+## Done criteria
+
+- `trading_bot/brokers/` exposes the `Broker` port, a `BrokerRegistry`, and `KrakenBroker`.
+- `ruff` + `mypy` + `pytest` green; signing matches Kraken's documented test vector;
+  private endpoints covered by mocks; a real **public** Kraken smoke (`-m network`) passes.
+- Secrets only via env; no key material in the repo or logs.
+- Last leaf (03) removes the E3 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/broker-kraken/01-broker-port.md
+++ b/doc/dev/plans/broker-kraken/01-broker-port.md
@@ -1,0 +1,67 @@
+---
+plan: broker-kraken/01-broker-port
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: feat/broker-port
+pr: ""
+---
+
+# Broker port + registry
+
+## Goal
+
+The venue-neutral **`Broker`** contract every exchange adapter implements, plus a
+capability model and a `BrokerRegistry`. Pure interface layer (typed, async); the
+only concrete thing here is a tiny in-test stub. Mirrors dccd's `sources/base.py` +
+`sources/registry.py`.
+
+## Files to change
+
+- `trading_bot/brokers/__init__.py` — new; export the port + registry + errors.
+- `trading_bot/brokers/base.py` — new; the `Broker` protocol/ABC + `Capability`/`BrokerError`.
+- `trading_bot/brokers/registry.py` — new; `BrokerRegistry`.
+- `trading_bot/tests/brokers/__init__.py` — new (empty).
+- `trading_bot/tests/brokers/test_base.py` — new (a stub broker + registry tests).
+
+## Steps
+
+1. Read dccd's `sources/base.py` and `sources/registry.py` for the pattern.
+2. `brokers/base.py`: define the async **`Broker`** surface over **domain types**:
+   - `async place_order(order: Order) -> str` — submit; returns the venue order id.
+   - `async cancel_order(venue_order_id: str) -> None`.
+   - `async open_orders() -> list[Order]` — reconstruct domain `Order`s.
+   - `async balances() -> dict[str, Money]` — asset → free balance (Decimal).
+   - `async fills(since_ms: int | None = None) -> list[Fill]` — domain `Fill`s.
+   - `async ticker(instrument: Instrument) -> Money` — last/mark price (public).
+   - `capabilities() -> set[...]` — what the adapter actually supports (declare honestly).
+   - `name: str` (the venue key).
+   Use a `Protocol` (runtime-checkable) or an ABC — pick the cleaner; document it.
+   Money/quantities are `Decimal` (`domain.money`).
+3. `brokers/registry.py`: `BrokerRegistry.register(name, broker)` / `get(name) -> Broker`
+   (raises `NoCapability`/`BrokerError` if absent). Mirror dccd's registry.
+4. Capability model: a small enum/set declaring `{PLACE_ORDER, CANCEL, OPEN_ORDERS,
+   BALANCES, FILLS, TICKER, PRIVATE_WS, ...}`; the engine rejects operations a broker
+   hasn't declared.
+
+## Tests
+
+- A `StubBroker` implementing the port: registry `register`/`get` round-trip;
+  `get` of an unknown venue raises.
+- Capability declaration: a broker that doesn't declare `PLACE_ORDER` is rejected
+  by a helper that checks capability before use.
+- The port is satisfiable purely with domain types (a stub returns domain `Order`/`Fill`).
+
+## Verification on real data
+
+Interface layer — no live I/O. Verify the contract is *implementable and coherent*:
+the `StubBroker` exercises every method with domain objects and round-trips an
+`Order` through `place_order` → `open_orders`. `pytest`/`ruff`/`mypy` green.
+
+## Closeout
+
+- CHANGELOG (Added): "`brokers.Broker` port + `BrokerRegistry` + capability model."
+- ADR: the Broker surface + capability-declaration rule (and Protocol-vs-ABC choice).
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/broker-kraken/02-kraken-rest.md
+++ b/doc/dev/plans/broker-kraken/02-kraken-rest.md
@@ -1,0 +1,73 @@
+---
+plan: broker-kraken/02-kraken-rest
+kind: leaf
+status: planned
+complexity: high
+depends: [01]
+parallel: false
+branch: feat/broker-kraken-rest
+pr: ""
+---
+
+# KrakenBroker — REST (signing, orders, balances, fills)
+
+## Goal
+
+`KrakenBroker` implementing the `Broker` port over Kraken's REST API: request
+**signing** (nonce + HMAC-SHA512 `API-Sign`), the public market-data calls and the
+private order/balance/fills calls, mapping domain `Order`/`Fill`/`Money`/`Instrument`
+to and from Kraken payloads. Sits on `transport.AsyncHTTPClient` +
+`RateLimiter`/`KrakenCallCounter`. **No API key required to build or test** (see posture).
+
+## Files to change
+
+- `trading_bot/brokers/kraken.py` — new; `KrakenBroker` (+ a `_sign` helper).
+- `trading_bot/brokers/__init__.py` — export `KrakenBroker`.
+- `trading_bot/tests/brokers/test_kraken_rest.py` — new.
+- `.env.example` — new; document `KRAKEN_API_KEY` / `KRAKEN_API_SECRET` (real `.env` is gitignored).
+
+## Steps
+
+1. Read `trading_bot/legacy/exchanges/API_kraken.py` (`set_sign`/`_nonce`/`query_private`)
+   and dccd's `sources/kraken.py` (public calls, pair rendering). Reuse
+   `domain.instrument` for pair normalisation and `transport` for I/O.
+2. **Signing** (`_sign(path, data, secret)`): `post = urlencode(data)`;
+   `message = path.encode() + sha256((nonce + post).encode())`;
+   `sig = base64(hmac_sha512(b64decode(secret), message))`. Headers: `API-Key`,
+   `API-Sign`. Credentials read from env (`KRAKEN_API_KEY`/`KRAKEN_API_SECRET`); the
+   broker is constructible without them for public-only/mocked use.
+3. **Public**: `AssetPairs` (tick/lot precision → `Instrument`), `Ticker` (→ `ticker()`),
+   optional `OHLC`. **Private**: `Balance` (→ `balances()`), `AddOrder` (→ `place_order`,
+   mapping side/type/ordertype/price/volume from domain `Order`), `CancelOrder`
+   (→ `cancel_order`), `OpenOrders` (→ `open_orders()` rebuilding domain `Order`s),
+   `ClosedOrders`/`TradesHistory` (→ `fills()` building domain `Fill`s). Use the rate
+   limiter with the right per-endpoint cost.
+4. Map errors: Kraken's `error` array → `BrokerError`/`OrderError`; transient
+   `EService:Unavailable` etc. left to transport retry.
+
+## Tests
+
+- **Signing vs Kraken's published test vector** (deterministic, no key): secret
+  `kQH5HW/8p1uGOVjbgWA7FunAmGO8lsSUXNsu3eow76sz84Q18fWxnyRzBHCd3pd5nE9qa99HAZtuZuj6F1huXg==`,
+  nonce `1616492376594`, path `/0/private/AddOrder`, data
+  `ordertype=limit&pair=XBTUSD&price=37500&type=buy&volume=1.25` →
+  `API-Sign == 4/dpxb3iT4tp/ZCVEwSnEsLxx0bqyhLpdfOpc6fn7OR8+UClSV5n9E6aSS8MPtnRfp32bAb0nmbRn6H8ndwLUQ==`.
+- `place_order`/`cancel_order`/`open_orders`/`balances`/`fills` via **`pytest-httpx` mocks**
+  of Kraken JSON responses → assert the request payload (signed headers present, body
+  fields) and the parsed domain objects (Decimal amounts, instrument, order/fill fields).
+- Domain `Order` → Kraken `AddOrder` payload mapping for market/limit/stop-loss.
+- A Kraken `error` response → `BrokerError`.
+
+## Verification on real data
+
+Network IS reachable. Real **public** smoke (`@pytest.mark.network`, no key): call
+`AssetPairs`/`Ticker` for `BTC/USD` live and assert a sane parse (price > 0,
+instrument precision present). **Run it.** Private endpoints are mock-only here
+(no key) — note this explicitly; signing correctness is proven by the test vector.
+
+## Closeout
+
+- CHANGELOG (Added): "`brokers.KrakenBroker` — REST adapter (signed orders/balances/fills, public market data)."
+- ADR: signing scheme (verified vs Kraken's vector), env-based credentials, the
+  mock+public-only test posture (private verification deferred).
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/broker-kraken/03-kraken-ws.md
+++ b/doc/dev/plans/broker-kraken/03-kraken-ws.md
@@ -1,0 +1,66 @@
+---
+plan: broker-kraken/03-kraken-ws
+kind: leaf
+status: planned
+complexity: high
+depends: [02]
+parallel: false
+branch: feat/broker-kraken-ws
+pr: ""
+---
+
+# KrakenBroker — private WebSocket (fills / order updates)
+
+## Goal
+
+Stream Kraken's **private** WebSocket channels (`executions` / own-trades and order
+updates) on top of `transport.WebSocketBase`, parsing frames into domain `Fill`s and
+order-status updates — the live feed the order router/position tracker (E4) consume.
+This is the **last E3 leaf** — it closes the E3 roadmap line. **No API key here**:
+the auth-token step and frame parsing are tested via **mocks**; real private WS is
+deferred until a key is provided.
+
+## Files to change
+
+- `trading_bot/brokers/kraken_ws.py` — new (or extend `kraken.py`); `KrakenPrivateWS`.
+- `trading_bot/brokers/__init__.py` — export it.
+- `trading_bot/tests/brokers/test_kraken_ws.py` — new.
+- `doc/dev/07-roadmap.md` — remove the E3 line. `doc/dev/06-status.md` — mark E3 done.
+
+## Steps
+
+1. Read dccd's `_KrakenWS` (`sources/kraken.py`) and the local `transport/ws.py`
+   (`on_connect`, `stream_raw`, `send`). The private feed needs a **WebSocket token**
+   from the REST `GetWebSocketsToken` (private → uses leaf 02's signing); fetch it in
+   `on_connect`/setup. Token retrieval is **mocked** here (no key).
+2. `KrakenPrivateWS(WebSocketBase)`:
+   - `on_connect`: authenticate + subscribe to the executions / own-trades + open-orders
+     channels (Kraken v2 private subscribe with the token).
+   - `async fills() -> AsyncIterator[Fill]` (or `events()` yielding parsed fills + order
+     updates) — parse frames into domain `Fill`s (Decimal qty/price/fee, `client_order_id`
+     / `venue_order_id` linkage) and order-status changes.
+   - Handle snapshot vs update frames; ignore heartbeats/status.
+3. Inject the token-fetch and the `connect` seam so the whole path is testable offline.
+
+## Tests (mocks; no real private connection)
+
+- A canned sequence of Kraken private frames (snapshot + an own-trade update) → parsed
+  into the expected domain `Fill`s (exact Decimal fields, correct instrument/side).
+- An order-status update frame → the expected order-update event.
+- `on_connect` performs auth+subscribe (assert the subscribe message includes the token,
+  fed by the mocked token-fetch); reconnect re-subscribes (self-heal).
+- Heartbeat/status frames are ignored.
+
+## Verification on real data
+
+The **public** WS path is already proven (E2 ws leaf, real Kraken frame). The private
+path needs a key → **deferred**: verify here against **realistic canned private frames**
+(copy the shape from Kraken's v2 private docs) that parse to correct domain `Fill`s, and
+state clearly that the live private connection is gated on credentials. **Run** the
+mock-based suite.
+
+## Closeout
+
+- CHANGELOG (Added): "`brokers.KrakenPrivateWS` — private WS fills/order-update parsing (mock-verified; live gated on a key)."
+- ADR: the private-WS auth-token flow + the deferred real-private-verification posture.
+- Status/roadmap: **remove the E3 line** from `07-roadmap.md`; mark E3 done in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E3 — Broker port + Kraken adapter** (mirrors dccd's `sources/`).

## Goal
The venue-neutral `Broker` port (+ registry + capabilities) and the Kraken adapter:
REST (signed orders/balances/fills + public market data), then the private WS
(own-trades/order updates). Sits on E2 transport; speaks domain types.

## Posture (decided)
Mocks + **real public** smokes only — **no API key**. Private endpoints tested via mocks;
**signing verified against Kraken's published test vector**; real private verification
deferred until a key is provided. Secrets via `.env` (gitignored), never logged.

## Leaves
- [ ] 01 broker-port — feat/broker-port — high
- [ ] 02 kraken-rest — feat/broker-kraken-rest — high (depends on 01)
- [ ] 03 kraken-ws — feat/broker-kraken-ws — high (depends on 02)

After merge: `/execute-leaf broker-kraken next`.