### PR TITLE
feat: broker port + registry + capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `transport.RateLimiter` + `KrakenCallCounter` — per-exchange token-bucket plus
   Kraken's decaying call-counter (tiers, per-endpoint costs). Completes the
   **E2 transport** layer. (#15)
+- `brokers.Broker` port (runtime-checkable Protocol over domain types) +
+  `Capability` model + `BrokerRegistry`. (#17)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,22 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Broker port: runtime-checkable Protocol + capability declaration (PR #17)
+
+**Decision.** `brokers/base.py` defines the venue-neutral async `Broker` as a
+`runtime_checkable` `Protocol` (`place_order`/`cancel_order`/`open_orders`/
+`balances`/`fills`/`ticker` over domain types), with a `Capability` enum each adapter
+declares via `capabilities()`; `require(broker, cap)` gates every operation and raises
+`NoCapability`. A `BrokerRegistry` maps venue name → adapter. `BrokerError` was added
+to `domain.errors`.
+
+**Why.** A port has no shared implementation to inherit, so structural typing keeps
+adapters decoupled from the port (no import back-coupling) and registry-friendly.
+Honest support is the declared capability *set*, not the class hierarchy — the engine
+never asks a venue for an undeclared operation.
+
+---
+
 ### 2026-06-20 Transport rate-limiting: token-bucket + Kraken call-counter (PR #15)
 
 **Decision.** `transport.RateLimiter` holds one `TokenBucket` per exchange (injected

--- a/doc/dev/plans/broker-kraken/00-plan.md
+++ b/doc/dev/plans/broker-kraken/00-plan.md
@@ -33,7 +33,7 @@ logged or committed.
 
 ## Leaf checklist
 
-- [ ] 01 broker-port — feat/broker-port — high
+- [x] 01 broker-port — feat/broker-port — high
 - [ ] 02 kraken-rest — feat/broker-kraken-rest — high (depends on 01)
 - [ ] 03 kraken-ws — feat/broker-kraken-ws — high (depends on 02)
 

--- a/doc/dev/plans/broker-kraken/01-broker-port.md
+++ b/doc/dev/plans/broker-kraken/01-broker-port.md
@@ -1,7 +1,7 @@
 ---
 plan: broker-kraken/01-broker-port
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: []
 parallel: false

--- a/doc/dev/plans/broker-kraken/01-broker-port.md
+++ b/doc/dev/plans/broker-kraken/01-broker-port.md
@@ -6,7 +6,7 @@ complexity: high
 depends: []
 parallel: false
 branch: feat/broker-port
-pr: ""
+pr: "#17"
 ---
 
 # Broker port + registry

--- a/trading_bot/brokers/__init__.py
+++ b/trading_bot/brokers/__init__.py
@@ -1,0 +1,40 @@
+"""trading_bot brokers layer — venue adapters behind a :class:`Broker` port.
+
+This is the **execution layer**: the venue-neutral
+:class:`~trading_bot.brokers.base.Broker` contract that every exchange adapter
+implements, a :class:`~trading_bot.brokers.base.Capability` model declaring what
+a given adapter actually serves, and a
+:class:`~trading_bot.brokers.registry.BrokerRegistry` mapping venue names to
+adapters. The port speaks :mod:`trading_bot.domain` types only and its concrete
+adapters use the :mod:`trading_bot.transport` plumbing; the domain never imports
+a broker.
+
+This package is a pure interface here — the concrete Kraken adapter lands in the
+next leaf.
+
+Public surface:
+
+* :class:`~trading_bot.brokers.base.Broker` — the async, runtime-checkable
+  :class:`~typing.Protocol` every venue adapter satisfies;
+* :class:`~trading_bot.brokers.base.Capability` — the operations an adapter may
+  declare it supports;
+* :func:`~trading_bot.brokers.base.require` — the gate that raises
+  :class:`~trading_bot.domain.errors.NoCapability` when an adapter is asked for
+  an operation it has not declared;
+* :class:`~trading_bot.brokers.registry.BrokerRegistry` — venue key to adapter;
+* :class:`~trading_bot.domain.errors.BrokerError` — the venue-neutral broker
+  failure (re-exported for convenience).
+"""
+
+from __future__ import annotations
+
+from trading_bot.brokers.base import Broker, BrokerError, Capability, require
+from trading_bot.brokers.registry import BrokerRegistry
+
+__all__ = [
+    "Broker",
+    "Capability",
+    "require",
+    "BrokerError",
+    "BrokerRegistry",
+]

--- a/trading_bot/brokers/base.py
+++ b/trading_bot/brokers/base.py
@@ -1,0 +1,241 @@
+"""The venue-neutral :class:`Broker` port + capability model.
+
+This is the **execution-side port** of the trading bot: the single, async,
+venue-neutral contract every exchange adapter (Kraken next, others later)
+implements. It speaks **domain types only** — :class:`~trading_bot.domain.
+order.Order`, :class:`~trading_bot.domain.fill.Fill`,
+:class:`~trading_bot.domain.instrument.Instrument`, :class:`~trading_bot.domain.
+money.Money` — and may use the :mod:`trading_bot.transport` plumbing in its
+concrete adapters; no domain code ever imports a broker. All money and
+quantities are exact :class:`~decimal.Decimal` (:data:`~trading_bot.domain.
+money.Money`).
+
+Protocol, not ABC
+-----------------
+The port is a :func:`~typing.runtime_checkable` :class:`~typing.Protocol`
+rather than an abstract base class. The reasons, carried into the ADR:
+
+* **Structural, not nominal.** A concrete adapter (the Kraken adapter, a test
+  stub) is a :class:`Broker` because it *has the methods*, not because it
+  inherited a base — no import coupling from adapters back to this module, which
+  keeps the venue layer a flat set of independent adapters. This mirrors the
+  spirit of dccd's source mixins while avoiding the inheritance ceremony.
+* **Registry-friendly.** ``@runtime_checkable`` lets the
+  :class:`~trading_bot.brokers.registry.BrokerRegistry` (and the
+  :func:`require` helper) ``isinstance``-check what it stores, so a misconfigured
+  registration fails loudly at the boundary rather than at first call.
+* **Capabilities are declared, not inherited.** Whether an adapter actually
+  *supports* an operation is answered by :meth:`Broker.capabilities` returning a
+  :class:`Capability` set, **not** by which base classes it subclasses. The port
+  surface is the full menu; the capability set is the honest subset a given
+  venue serves. The engine gates every operation through :func:`require` so a
+  venue is never asked for something it has not declared.
+
+The trade-off of a ``Protocol`` is that it gives adapters no default method
+bodies — but a port should have none anyway (every method is venue-specific
+I/O), so there is nothing to inherit. ``runtime_checkable`` only checks method
+*presence*, not signatures; the typed signatures here are enforced statically by
+mypy on each concrete adapter.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Protocol, runtime_checkable
+
+from trading_bot.domain.errors import BrokerError, NoCapability
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument
+from trading_bot.domain.money import Money
+from trading_bot.domain.order import Order
+
+__all__ = [
+    "Broker",
+    "Capability",
+    "BrokerError",
+    "require",
+]
+
+
+class Capability(Enum):
+    """A discrete operation a :class:`Broker` adapter may declare it supports.
+
+    An adapter's :meth:`Broker.capabilities` returns the **honest subset** of
+    these it actually serves. The engine gates every operation through
+    :func:`require`, so a venue is never asked for an operation it did not
+    declare (which would otherwise surface as an opaque venue error or a silent
+    no-op).
+
+    Members map one-to-one onto the :class:`Broker` surface, plus transport-shape
+    flags that have no single method (``PRIVATE_WS`` for a private/authenticated
+    WebSocket stream of order/fill updates).
+    """
+
+    #: :meth:`Broker.place_order` — submit a new order.
+    PLACE_ORDER = "place_order"
+    #: :meth:`Broker.cancel_order` — cancel a live order by venue id.
+    CANCEL = "cancel"
+    #: :meth:`Broker.open_orders` — list currently open orders.
+    OPEN_ORDERS = "open_orders"
+    #: :meth:`Broker.balances` — per-asset free balances.
+    BALANCES = "balances"
+    #: :meth:`Broker.fills` — historical/recent executions.
+    FILLS = "fills"
+    #: :meth:`Broker.ticker` — public last/mark price.
+    TICKER = "ticker"
+    #: A private/authenticated WebSocket feed of order & fill updates.
+    PRIVATE_WS = "private_ws"
+
+
+@runtime_checkable
+class Broker(Protocol):
+    """The async, venue-neutral execution port every exchange adapter implements.
+
+    A broker submits and cancels orders, reports open orders, balances and
+    fills, and reads a public ticker — all in **domain types**, with money and
+    quantities as exact :class:`~decimal.Decimal`. Concrete adapters wire these
+    to a venue's REST/WebSocket APIs via :mod:`trading_bot.transport`; this
+    module is a pure interface and the next leaf implements Kraken.
+
+    An adapter declares which of these it genuinely serves via
+    :meth:`capabilities`; callers gate through :func:`require` before use.
+
+    Attributes
+    ----------
+    name : str
+        The venue key (e.g. ``"kraken"``). Used as the registry key.
+
+    """
+
+    #: The venue key (e.g. ``"kraken"``); the registry key for this adapter.
+    name: str
+
+    async def place_order(self, order: Order) -> str:
+        """Submit ``order`` to the venue and return its venue order id.
+
+        Parameters
+        ----------
+        order : Order
+            The domain order to submit. Its lifecycle is driven by the caller;
+            the adapter only transmits it and reports the venue's id back.
+
+        Returns
+        -------
+        str
+            The venue's identifier for the now-live order (the value the caller
+            passes to :meth:`Order.open` and later to :meth:`cancel_order`).
+
+        Raises
+        ------
+        BrokerError
+            If the venue rejects or fails the submission.
+
+        """
+        ...
+
+    async def cancel_order(self, venue_order_id: str) -> None:
+        """Cancel the live order identified by ``venue_order_id``.
+
+        Parameters
+        ----------
+        venue_order_id : str
+            The venue's order id (as returned by :meth:`place_order`).
+
+        Raises
+        ------
+        BrokerError
+            If the venue rejects or fails the cancellation.
+
+        """
+        ...
+
+    async def open_orders(self) -> list[Order]:
+        """Return the venue's currently open orders as domain :class:`Order`s.
+
+        Returns
+        -------
+        list of Order
+            The open orders, reconstructed into domain objects (status, fills
+            and ``venue_order_id`` populated from the venue's view).
+
+        """
+        ...
+
+    async def balances(self) -> dict[str, Money]:
+        """Return free balances keyed by canonical asset code.
+
+        Returns
+        -------
+        dict of str to Decimal
+            Asset code (e.g. ``"USD"``, ``"BTC"``) to its **free** (available)
+            balance as an exact :class:`~decimal.Decimal`.
+
+        """
+        ...
+
+    async def fills(self, since_ms: int | None = None) -> list[Fill]:
+        """Return executions as domain :class:`Fill`s, optionally since a time.
+
+        Parameters
+        ----------
+        since_ms : int, optional
+            Lower time bound as **milliseconds since the Unix epoch (UTC)**.
+            ``None`` (default) returns the venue's default recent window.
+
+        Returns
+        -------
+        list of Fill
+            The matching executions as immutable domain fills.
+
+        """
+        ...
+
+    async def ticker(self, instrument: Instrument) -> Money:
+        """Return the public last/mark price for ``instrument``.
+
+        Parameters
+        ----------
+        instrument : Instrument
+            The instrument to price.
+
+        Returns
+        -------
+        Decimal
+            The current last/mark price in quote units, exact.
+
+        """
+        ...
+
+    def capabilities(self) -> set[Capability]:
+        """Return the set of :class:`Capability` this adapter actually serves.
+
+        Declared honestly: the :class:`Broker` surface is the full menu, but a
+        given venue may not serve every operation. Callers gate through
+        :func:`require` before invoking an operation.
+        """
+        ...
+
+
+def require(broker: Broker, capability: Capability) -> None:
+    """Assert ``broker`` declares ``capability``; raise :class:`NoCapability` if not.
+
+    The single gate every caller uses before invoking a :class:`Broker`
+    operation, so a venue is never asked for an operation it has not declared in
+    :meth:`Broker.capabilities`.
+
+    Parameters
+    ----------
+    broker : Broker
+        The adapter to check.
+    capability : Capability
+        The capability the caller is about to use.
+
+    Raises
+    ------
+    NoCapability
+        If ``broker`` does not declare ``capability``. The error names the
+        broker (its ``name``) and the missing capability's value.
+
+    """
+    if capability not in broker.capabilities():
+        raise NoCapability(broker.name, capability.value)

--- a/trading_bot/brokers/registry.py
+++ b/trading_bot/brokers/registry.py
@@ -1,0 +1,86 @@
+"""The :class:`BrokerRegistry` — venue key to :class:`Broker` adapter.
+
+Mirrors dccd's ``SourceRegistry``: a thin, case-insensitive map from a venue
+name to a single registered :class:`~trading_bot.brokers.base.Broker` adapter.
+The trading bot wires one adapter per venue (one Kraken adapter, etc.) rather
+than the fine-grained per-(data-type x mode) lookups dccd needs, so the surface
+is just :meth:`register` / :meth:`get` plus a read-only listing — capability
+gating lives on the adapter (:func:`~trading_bot.brokers.base.require`), not the
+registry.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from trading_bot.brokers.base import Broker
+from trading_bot.domain.errors import BrokerError
+
+__all__ = ["BrokerRegistry"]
+
+logger = logging.getLogger(__name__)
+
+
+class BrokerRegistry:
+    """Maps venue names to :class:`~trading_bot.brokers.base.Broker` adapters.
+
+    Names are matched case-insensitively (stored lower-cased), so ``"Kraken"``
+    and ``"kraken"`` resolve to the same adapter.
+
+    Examples
+    --------
+    >>> reg = BrokerRegistry()
+    >>> # reg.register("kraken", KrakenBroker())
+    >>> # broker = reg.get("kraken")
+    """
+
+    def __init__(self) -> None:
+        self._adapters: dict[str, Broker] = {}
+
+    def register(self, name: str, broker: Broker) -> None:
+        """Register ``broker`` under venue ``name`` (case-insensitive key).
+
+        Parameters
+        ----------
+        name : str
+            The venue key (e.g. ``"kraken"``).
+        broker : Broker
+            The adapter to register. A later registration under the same name
+            replaces the earlier one.
+
+        """
+        self._adapters[name.lower()] = broker
+
+    def get(self, name: str) -> Broker:
+        """Return the adapter registered for ``name``.
+
+        Parameters
+        ----------
+        name : str
+            The venue key (case-insensitive).
+
+        Returns
+        -------
+        Broker
+            The registered adapter.
+
+        Raises
+        ------
+        BrokerError
+            If no adapter is registered under ``name``.
+
+        """
+        key = name.lower()
+        if key not in self._adapters:
+            raise BrokerError(f"no broker registered for venue {name!r}")
+        return self._adapters[key]
+
+    @property
+    def venues(self) -> list[str]:
+        """Names (lower-cased) of all registered venues."""
+        return list(self._adapters.keys())
+
+    @property
+    def adapters(self) -> dict[str, Broker]:
+        """A read-only copy of all registered adapters keyed by venue name."""
+        return dict(self._adapters)

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -28,6 +28,7 @@ Public surface:
 from __future__ import annotations
 
 from trading_bot.domain.errors import (
+    BrokerError,
     InstrumentMismatch,
     InsufficientFunds,
     MissingOrder,
@@ -129,5 +130,6 @@ __all__ = [
     "InsufficientFunds",
     "RiskLimitBreached",
     "NoCapability",
+    "BrokerError",
     "SignalError",
 ]

--- a/trading_bot/domain/errors.py
+++ b/trading_bot/domain/errors.py
@@ -24,12 +24,35 @@ __all__ = [
     "InsufficientFunds",
     "RiskLimitBreached",
     "NoCapability",
+    "BrokerError",
     "SignalError",
 ]
 
 
 class TradingBotError(Exception):
     """Root of every error raised by the trading bot domain."""
+
+
+class BrokerError(TradingBotError):
+    """A broker/venue adapter operation failed.
+
+    The venue-neutral error every :class:`~trading_bot.brokers.base.Broker`
+    adapter raises for a generic failure that is not better described by a more
+    specific member of this hierarchy (e.g. a venue returning an error body, an
+    unknown venue looked up in the registry, an adapter that cannot satisfy a
+    request). It carries plain data only — adapters decode the venue payload and
+    pass a human-readable message; the error never reaches for a client or an
+    I/O object.
+
+    Parameters
+    ----------
+    msg : str
+        Human-readable detail of the failure.
+
+    """
+
+    def __init__(self, msg: str) -> None:
+        super().__init__(msg)
 
 
 class OrderError(TradingBotError):

--- a/trading_bot/tests/brokers/test_base.py
+++ b/trading_bot/tests/brokers/test_base.py
@@ -1,0 +1,245 @@
+"""Tests for the :class:`Broker` port, :class:`Capability` model and registry.
+
+This is the interface layer — there is no live I/O. The contract is proven
+*implementable and coherent* by a :class:`StubBroker` that satisfies the
+:class:`~trading_bot.brokers.base.Broker` :class:`~typing.Protocol` purely with
+domain objects, round-trips an :class:`~trading_bot.domain.order.Order` through
+``place_order`` -> ``open_orders``, and returns ``Decimal``/domain types from
+``balances``/``fills``/``ticker``. The registry and the
+:func:`~trading_bot.brokers.base.require` capability gate are covered too.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from trading_bot.brokers import (
+    Broker,
+    BrokerError,
+    BrokerRegistry,
+    Capability,
+    require,
+)
+from trading_bot.domain import (
+    Fill,
+    Instrument,
+    Money,
+    NoCapability,
+    Order,
+    OrderSide,
+    OrderType,
+    Symbol,
+    money,
+)
+
+# A canonical instrument reused across the stub and assertions.
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+class StubBroker:
+    """An in-memory :class:`Broker` for tests — every method, domain types only.
+
+    Implements the full port without inheriting it (structural typing): a
+    placed order is stored under a synthesised venue id and surfaced again by
+    :meth:`open_orders`, so a round-trip can be asserted. ``balances``,
+    ``fills`` and ``ticker`` return ``Decimal``/domain objects.
+
+    The declared :attr:`_capabilities` is configurable so a test can build a
+    broker that is *missing* a capability and check the :func:`require` gate.
+    """
+
+    def __init__(
+        self,
+        name: str = "stub",
+        capabilities: set[Capability] | None = None,
+    ) -> None:
+        self.name = name
+        self._capabilities = (
+            capabilities
+            if capabilities is not None
+            else set(Capability)  # full menu by default
+        )
+        self._open: dict[str, Order] = {}
+        self._next_id = 0
+
+    async def place_order(self, order: Order) -> str:
+        self._next_id += 1
+        venue_order_id = f"VID-{self._next_id}"
+        # Drive the domain order through its lifecycle so the stored order is a
+        # realistic, live order keyed by the venue id we return.
+        order.submit()
+        order.open(venue_order_id)
+        self._open[venue_order_id] = order
+        return venue_order_id
+
+    async def cancel_order(self, venue_order_id: str) -> None:
+        order = self._open.pop(venue_order_id, None)
+        if order is None:
+            raise BrokerError(f"unknown venue order id {venue_order_id!r}")
+        order.cancel()
+
+    async def open_orders(self) -> list[Order]:
+        return list(self._open.values())
+
+    async def balances(self) -> dict[str, Money]:
+        return {"USD": money("1000.50"), "BTC": money("0.25")}
+
+    async def fills(self, since_ms: int | None = None) -> list[Fill]:
+        fill = Fill(
+            fill_id="T1",
+            client_order_id="cid-1",
+            instrument=BTC_USD,
+            side=OrderSide.BUY,
+            qty=money("1"),
+            price=money("30000"),
+            fee=money("12"),
+            ts=1_700_000_000_000,
+        )
+        if since_ms is not None and fill.ts < since_ms:
+            return []
+        return [fill]
+
+    async def ticker(self, instrument: Instrument) -> Money:
+        return money("30100.5")
+
+    def capabilities(self) -> set[Capability]:
+        return self._capabilities
+
+
+def _make_order(client_order_id: str = "cid-1") -> Order:
+    """Build a fresh limit :class:`Order` for round-trip tests."""
+    return Order(
+        client_order_id=client_order_id,
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("2"),
+        type=OrderType.LIMIT,
+        limit_price=money("30000"),
+    )
+
+
+# --- the port is satisfiable with domain types ----------------------------- #
+
+
+def test_stub_satisfies_broker_protocol() -> None:
+    """The stub is a :class:`Broker` structurally (runtime-checkable Protocol)."""
+    assert isinstance(StubBroker(), Broker)
+
+
+async def test_place_order_returns_venue_id_and_round_trips() -> None:
+    """``place_order`` returns an id; the order resurfaces via ``open_orders``."""
+    broker = StubBroker()
+    order = _make_order()
+
+    venue_order_id = await broker.place_order(order)
+
+    assert isinstance(venue_order_id, str) and venue_order_id
+    assert order.venue_order_id == venue_order_id
+
+    open_orders = await broker.open_orders()
+    assert order in open_orders
+    assert open_orders[0].client_order_id == "cid-1"
+
+
+async def test_cancel_order_removes_it() -> None:
+    """A placed order can be cancelled and then no longer appears as open."""
+    broker = StubBroker()
+    venue_order_id = await broker.place_order(_make_order())
+
+    await broker.cancel_order(venue_order_id)
+
+    assert await broker.open_orders() == []
+
+
+async def test_cancel_unknown_order_raises_broker_error() -> None:
+    """Cancelling an unknown venue id raises :class:`BrokerError`."""
+    broker = StubBroker()
+    with pytest.raises(BrokerError):
+        await broker.cancel_order("VID-does-not-exist")
+
+
+async def test_balances_returns_decimal_per_asset() -> None:
+    """``balances`` returns a per-asset map of exact ``Decimal`` values."""
+    balances = await StubBroker().balances()
+    assert balances == {"USD": Decimal("1000.50"), "BTC": Decimal("0.25")}
+    assert all(isinstance(v, Decimal) for v in balances.values())
+
+
+async def test_fills_returns_domain_fills() -> None:
+    """``fills`` returns domain :class:`Fill` objects with ``Decimal`` amounts."""
+    fills = await StubBroker().fills()
+    assert len(fills) == 1
+    fill = fills[0]
+    assert isinstance(fill, Fill)
+    assert fill.qty == Decimal("1")
+    assert fill.price == Decimal("30000")
+
+
+async def test_fills_since_ms_filters() -> None:
+    """``since_ms`` past the only fill's ``ts`` yields an empty list."""
+    assert await StubBroker().fills(since_ms=1_800_000_000_000) == []
+
+
+async def test_ticker_returns_decimal_price() -> None:
+    """``ticker`` returns an exact ``Decimal`` price for the instrument."""
+    price = await StubBroker().ticker(BTC_USD)
+    assert price == Decimal("30100.5")
+    assert isinstance(price, Decimal)
+
+
+# --- registry -------------------------------------------------------------- #
+
+
+def test_registry_register_get_round_trip() -> None:
+    """A registered broker is returned by ``get`` (case-insensitive key)."""
+    reg = BrokerRegistry()
+    broker = StubBroker(name="kraken")
+    reg.register("kraken", broker)
+
+    assert reg.get("kraken") is broker
+    assert reg.get("KRAKEN") is broker  # case-insensitive
+    assert reg.venues == ["kraken"]
+    assert reg.adapters == {"kraken": broker}
+
+
+def test_registry_get_unknown_raises_broker_error() -> None:
+    """``get`` of an unregistered venue raises :class:`BrokerError`."""
+    reg = BrokerRegistry()
+    with pytest.raises(BrokerError):
+        reg.get("nope")
+
+
+def test_registry_adapters_view_is_a_copy() -> None:
+    """The ``adapters`` view is a copy — mutating it does not touch the registry."""
+    reg = BrokerRegistry()
+    reg.register("kraken", StubBroker(name="kraken"))
+    view = reg.adapters
+    view.clear()
+    assert reg.venues == ["kraken"]
+
+
+# --- capability gate ------------------------------------------------------- #
+
+
+def test_require_passes_when_capability_declared() -> None:
+    """``require`` is a no-op when the broker declares the capability."""
+    broker = StubBroker(capabilities={Capability.PLACE_ORDER})
+    require(broker, Capability.PLACE_ORDER)  # must not raise
+
+
+def test_require_raises_no_capability_when_missing() -> None:
+    """``require`` raises :class:`NoCapability` for an undeclared capability."""
+    broker = StubBroker(name="kraken", capabilities={Capability.TICKER})
+    with pytest.raises(NoCapability) as excinfo:
+        require(broker, Capability.PLACE_ORDER)
+
+    err = excinfo.value
+    assert err.venue == "kraken"
+    assert err.capability == Capability.PLACE_ORDER.value
+
+
+def test_capabilities_default_full_menu() -> None:
+    """The default stub declares every :class:`Capability`."""
+    assert StubBroker().capabilities() == set(Capability)


### PR DESCRIPTION
## Summary
- First leaf of **E3 — Broker port + Kraken adapter**: `trading_bot/brokers/{base,registry}.py`.
- Venue-neutral async `Broker` (runtime-checkable `Protocol`) over domain types: `place_order`/`cancel_order`/`open_orders`/`balances`/`fills`/`ticker`; a `Capability` enum + `require()` gate; `BrokerRegistry`. `BrokerError` added to `domain.errors`.

## Why
- A port has no shared implementation to inherit — structural typing keeps adapters decoupled and registry-friendly; honest support is the declared capability set, not the class hierarchy. See `doc/dev/03-decisions.md`.

## Changes
- `brokers/base.py`, `brokers/registry.py`, exports; `domain/errors.py` (+`BrokerError`); `tests/brokers/test_base.py` (14 tests, StubBroker). Layering verified: `domain/` imports no broker/transport.

## Changelog
Added under [Unreleased]:
- `brokers.Broker` port (runtime-checkable Protocol over domain types) + `Capability` model + `BrokerRegistry`.

## Test plan
- [x] `pytest` (227 passed, 6 skipped)
- [x] `ruff` + `mypy` clean
- [ ] CI green