### PR TITLE
feat: KrakenBroker REST adapter

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Example environment for trading_bot — copy to `.env` and fill in real values.
+#
+# `.env` is gitignored: NEVER commit real key material. The KrakenBroker reads
+# these two variables from the environment and signs private REST requests with
+# them. They are optional — the broker is constructible without them and serves
+# public market data (ticker, instrument metadata) key-free; private calls
+# (balances, place/cancel/open orders, fills) require both to be set.
+
+# Kraken API key (the public identifier of your API credential).
+KRAKEN_API_KEY=
+
+# Kraken API secret (base64-encoded; used for HMAC-SHA512 request signing).
+KRAKEN_API_SECRET=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   **E2 transport** layer. (#15)
 - `brokers.Broker` port (runtime-checkable Protocol over domain types) +
   `Capability` model + `BrokerRegistry`. (#17)
+- `brokers.KrakenBroker` — Kraken REST adapter: HMAC-SHA512 request signing
+  (verified vs Kraken's published vector), signed orders/balances/fills, public
+  market data. Credentials via env; public data works key-free. (#18)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,24 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 KrakenBroker REST: signing verified, env credentials, mock+public posture (PR #18)
+
+**Decision.** `brokers/kraken.py` implements the `Broker` port over Kraken REST.
+`_sign` (nonce + `SHA256(nonce+postdata)` → `HMAC-SHA512(b64decode(secret))` → b64)
+is verified against **Kraken's published signature test vector**. Credentials come
+from env (`KRAKEN_API_KEY`/`KRAKEN_API_SECRET`), never logged; the broker is
+constructible without them (public market data works key-free), and a private call
+without both raises `BrokerError` before any I/O. Order mapping: side→buy/sell,
+type→ordertype (`BEST_LIMIT`→limit), qty→volume, price from limit/stop; money stays
+`Decimal` from Kraken's string amounts. Private endpoints are **mock-tested only**
+(no key); real private verification is deferred.
+
+**Why.** The published test vector proves the signing matches Kraken's spec exactly
+without a key, so real orders would sign correctly. Env-only secrets keep keys out of
+the repo and logs; Decimal-from-string avoids float error on venue amounts.
+
+---
+
 ### 2026-06-20 Broker port: runtime-checkable Protocol + capability declaration (PR #17)
 
 **Decision.** `brokers/base.py` defines the venue-neutral async `Broker` as a

--- a/doc/dev/plans/broker-kraken/00-plan.md
+++ b/doc/dev/plans/broker-kraken/00-plan.md
@@ -34,7 +34,7 @@ logged or committed.
 ## Leaf checklist
 
 - [x] 01 broker-port — feat/broker-port — high
-- [ ] 02 kraken-rest — feat/broker-kraken-rest — high (depends on 01)
+- [x] 02 kraken-rest — feat/broker-kraken-rest — high (depends on 01)
 - [ ] 03 kraken-ws — feat/broker-kraken-ws — high (depends on 02)
 
 ## Dependencies

--- a/doc/dev/plans/broker-kraken/02-kraken-rest.md
+++ b/doc/dev/plans/broker-kraken/02-kraken-rest.md
@@ -1,7 +1,7 @@
 ---
 plan: broker-kraken/02-kraken-rest
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01]
 parallel: false

--- a/doc/dev/plans/broker-kraken/02-kraken-rest.md
+++ b/doc/dev/plans/broker-kraken/02-kraken-rest.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [01]
 parallel: false
 branch: feat/broker-kraken-rest
-pr: ""
+pr: "#18"
 ---
 
 # KrakenBroker — REST (signing, orders, balances, fills)

--- a/trading_bot/brokers/__init__.py
+++ b/trading_bot/brokers/__init__.py
@@ -9,8 +9,8 @@ adapters. The port speaks :mod:`trading_bot.domain` types only and its concrete
 adapters use the :mod:`trading_bot.transport` plumbing; the domain never imports
 a broker.
 
-This package is a pure interface here — the concrete Kraken adapter lands in the
-next leaf.
+The :class:`~trading_bot.brokers.kraken.KrakenBroker` is the first concrete
+adapter behind this port.
 
 Public surface:
 
@@ -23,12 +23,15 @@ Public surface:
   an operation it has not declared;
 * :class:`~trading_bot.brokers.registry.BrokerRegistry` — venue key to adapter;
 * :class:`~trading_bot.domain.errors.BrokerError` — the venue-neutral broker
-  failure (re-exported for convenience).
+  failure (re-exported for convenience);
+* :class:`~trading_bot.brokers.kraken.KrakenBroker` — the concrete Kraken REST
+  adapter (signed orders/balances/fills + public market data).
 """
 
 from __future__ import annotations
 
 from trading_bot.brokers.base import Broker, BrokerError, Capability, require
+from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.registry import BrokerRegistry
 
 __all__ = [
@@ -37,4 +40,5 @@ __all__ = [
     "require",
     "BrokerError",
     "BrokerRegistry",
+    "KrakenBroker",
 ]

--- a/trading_bot/brokers/kraken.py
+++ b/trading_bot/brokers/kraken.py
@@ -1,0 +1,570 @@
+"""The :class:`KrakenBroker` — Kraken REST adapter behind the :class:`Broker` port.
+
+This is the concrete Kraken implementation of the venue-neutral
+:class:`~trading_bot.brokers.base.Broker` port. It speaks **domain types only**
+(:class:`~trading_bot.domain.order.Order`,
+:class:`~trading_bot.domain.fill.Fill`,
+:class:`~trading_bot.domain.instrument.Instrument`,
+:class:`~trading_bot.domain.money.Money`) on its surface and translates them to
+and from Kraken's REST payloads underneath, using the
+:mod:`trading_bot.transport` plumbing for I/O, retry/backoff and rate limiting.
+
+Signing
+-------
+Private endpoints are authenticated with Kraken's HMAC-SHA512 scheme, factored
+into the module-level :func:`_sign` helper (ported from the legacy
+``API_kraken.set_sign``):
+
+* ``postdata = urllib.parse.urlencode(data)`` (``nonce`` first, so it matches
+  Kraken's published test vector);
+* ``message = path.encode() + sha256((nonce + postdata).encode()).digest()``;
+* ``API-Sign = base64(hmac_sha512(b64decode(secret), message))``.
+
+:func:`_sign` is a pure function (no I/O, no clock) so it can be checked against
+Kraken's published vector deterministically — that vector is the *only* proof of
+signing correctness exercised here; real private calls are deferred (no key).
+
+Credentials & posture
+---------------------
+Credentials come from the environment (``KRAKEN_API_KEY`` /
+``KRAKEN_API_SECRET``) and **never** from code. The broker is constructible
+*without* them — public market-data calls (:meth:`KrakenBroker.ticker`, the
+:class:`Instrument` builder) work key-free — and any private call attempted
+without credentials raises a clear :class:`~trading_bot.domain.errors.BrokerError`
+*before* a request goes out. Key material is never logged.
+
+Money
+-----
+Every amount Kraken reports is a decimal string; it is parsed with
+``money(str(...))`` so prices, volumes and fees stay exact :class:`~decimal.
+Decimal` and never round-trip through ``float``.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import time
+import urllib.parse
+from typing import TYPE_CHECKING, Any
+
+from trading_bot.brokers.base import Broker, Capability
+from trading_bot.domain.errors import BrokerError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import (
+    Instrument,
+    Symbol,
+    normalise,
+    parse_kraken_pair,
+)
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.transport.http import AsyncHTTPClient
+from trading_bot.transport.ratelimit import KrakenCallCounter, RateLimiter
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+__all__ = ["KrakenBroker"]
+
+_API_BASE = "https://api.kraken.com"
+_PUBLIC = "/0/public"
+_PRIVATE = "/0/private"
+
+# Domain OrderType -> Kraken ``ordertype`` string. BEST_LIMIT renders as a plain
+# limit (its price is discovered by the caller before submission, so by the time
+# it reaches the broker it carries a concrete ``limit_price``).
+_ORDERTYPE_TO_KRAKEN: dict[OrderType, str] = {
+    OrderType.MARKET: "market",
+    OrderType.LIMIT: "limit",
+    OrderType.STOP_LOSS: "stop-loss",
+    OrderType.BEST_LIMIT: "limit",
+}
+
+# Kraken ``ordertype`` string -> domain OrderType (for rebuilding open orders).
+_KRAKEN_TO_ORDERTYPE: dict[str, OrderType] = {
+    "market": OrderType.MARKET,
+    "limit": OrderType.LIMIT,
+    "stop-loss": OrderType.STOP_LOSS,
+}
+
+
+def _sign(path: str, data: Mapping[str, Any], secret: str) -> str:
+    """Compute Kraken's ``API-Sign`` for a private request.
+
+    Pure function (no I/O, no clock): given the request ``path``, the body
+    ``data`` (which must already carry a ``nonce``) and the base64 API
+    ``secret``, returns the ``API-Sign`` header value. Ported from the legacy
+    ``API_kraken.set_sign`` and matched against Kraken's published test vector.
+
+    The algorithm:
+
+    1. ``postdata = urllib.parse.urlencode(data)`` — the form body, with
+       ``nonce`` first so the encoded string matches Kraken's vector;
+    2. ``encoded = (str(nonce) + postdata).encode()``;
+    3. ``message = path.encode() + sha256(encoded).digest()``;
+    4. ``API-Sign = base64(hmac_sha512(b64decode(secret), message))``.
+
+    Parameters
+    ----------
+    path : str
+        The request path, e.g. ``"/0/private/AddOrder"``.
+    data : mapping
+        The request body. Must contain a ``"nonce"`` key; iteration order is
+        preserved by ``urlencode``, so build it ``nonce``-first.
+    secret : str
+        The base64-encoded Kraken API secret.
+
+    Returns
+    -------
+    str
+        The ``API-Sign`` header value (base64).
+
+    """
+    postdata = urllib.parse.urlencode(data)
+    encoded = (str(data["nonce"]) + postdata).encode()
+    message = path.encode() + hashlib.sha256(encoded).digest()
+    signature = hmac.new(base64.b64decode(secret), message, hashlib.sha512)
+    return base64.b64encode(signature.digest()).decode()
+
+
+class KrakenBroker(Broker):
+    """Kraken REST adapter implementing the venue-neutral :class:`Broker` port.
+
+    Public market data (ticker, instrument metadata) needs no credentials;
+    private order/balance/fill calls read ``KRAKEN_API_KEY`` /
+    ``KRAKEN_API_SECRET`` from the environment and sign each request with
+    :func:`_sign`. A private call attempted without credentials raises
+    :class:`~trading_bot.domain.errors.BrokerError` before any I/O.
+
+    Parameters
+    ----------
+    api_key : str, optional
+        Kraken API key. Defaults to ``$KRAKEN_API_KEY``. ``None``/empty leaves
+        the broker public-only.
+    api_secret : str, optional
+        Base64 Kraken API secret. Defaults to ``$KRAKEN_API_SECRET``.
+    http : AsyncHTTPClient, optional
+        Transport client. Defaults to one wired for the ``"kraken"`` exchange
+        with a shared :class:`~trading_bot.transport.ratelimit.RateLimiter`.
+    call_counter : KrakenCallCounter, optional
+        Kraken's decaying private-endpoint counter. Defaults to the conservative
+        ``"starter"`` tier; consulted (with the per-endpoint cost) before each
+        private request.
+
+    Attributes
+    ----------
+    name : str
+        The venue key, ``"kraken"`` (the registry key for this adapter).
+
+    """
+
+    name = "kraken"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_secret: str | None = None,
+        http: AsyncHTTPClient | None = None,
+        call_counter: KrakenCallCounter | None = None,
+    ) -> None:
+        # Credentials are env-sourced by default and never logged. An empty
+        # string is treated as "absent" so a blank env var stays public-only.
+        self._api_key = api_key if api_key is not None else os.environ.get(
+            "KRAKEN_API_KEY", ""
+        )
+        self._api_secret = (
+            api_secret
+            if api_secret is not None
+            else os.environ.get("KRAKEN_API_SECRET", "")
+        )
+        self._http = http or AsyncHTTPClient(
+            exchange=self.name, limiter=RateLimiter()
+        )
+        self._counter = call_counter or KrakenCallCounter.for_tier("starter")
+
+    # --- capability declaration -------------------------------------------- #
+
+    def capabilities(self) -> set[Capability]:
+        """The :class:`Capability` set this adapter serves.
+
+        All six REST operations are implemented (place/cancel/open-orders,
+        balances, fills, ticker). The private/authenticated WebSocket feed
+        (:data:`~trading_bot.brokers.base.Capability.PRIVATE_WS`) is **not** part
+        of this REST adapter (it lands in the WS leaf), so it is omitted.
+        """
+        return {
+            Capability.PLACE_ORDER,
+            Capability.CANCEL,
+            Capability.OPEN_ORDERS,
+            Capability.BALANCES,
+            Capability.FILLS,
+            Capability.TICKER,
+        }
+
+    # --- credentials / nonce ----------------------------------------------- #
+
+    @property
+    def has_credentials(self) -> bool:
+        """Whether both API key and secret are present (private calls possible)."""
+        return bool(self._api_key) and bool(self._api_secret)
+
+    def _require_credentials(self) -> None:
+        """Raise :class:`BrokerError` if a private call lacks credentials."""
+        if not self.has_credentials:
+            raise BrokerError(
+                "Kraken private endpoint requires credentials; set "
+                "KRAKEN_API_KEY and KRAKEN_API_SECRET in the environment"
+            )
+
+    @staticmethod
+    def _nonce() -> str:
+        """A fresh, monotonically-increasing nonce (microseconds since epoch)."""
+        # Microsecond granularity keeps successive nonces strictly increasing
+        # even for back-to-back calls within the same millisecond.
+        return str(int(time.time() * 1_000_000))
+
+    # --- request plumbing -------------------------------------------------- #
+
+    @staticmethod
+    def _raise_on_error(payload: Any, *, context: str) -> dict[str, Any]:
+        """Return ``payload["result"]`` or raise :class:`BrokerError` on a venue error.
+
+        Kraken always wraps responses as ``{"error": [...], "result": {...}}``; a
+        non-empty ``error`` array is a venue rejection. The error strings are
+        plain venue diagnostics (never key material), so they are safe to surface.
+        """
+        if not isinstance(payload, dict):
+            raise BrokerError(f"Kraken {context}: malformed response {payload!r}")
+        errors = payload.get("error") or []
+        if errors:
+            raise BrokerError(f"Kraken {context}: {'; '.join(errors)}")
+        result = payload.get("result")
+        if result is None:
+            raise BrokerError(f"Kraken {context}: missing result")
+        if not isinstance(result, dict):
+            raise BrokerError(
+                f"Kraken {context}: unexpected result {result!r}"
+            )
+        return result
+
+    async def _public_get(
+        self, endpoint: str, params: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """GET a public endpoint and return its ``result`` (or raise)."""
+        url = f"{_API_BASE}{_PUBLIC}/{endpoint}"
+        async with self._http as client:
+            payload = await client.get(url, params=dict(params))
+        return self._raise_on_error(payload, context=endpoint)
+
+    async def _private_post(
+        self, endpoint: str, data: Mapping[str, Any]
+    ) -> dict[str, Any]:
+        """Sign and POST a private endpoint, returning its ``result`` (or raise).
+
+        Builds a fresh ``nonce``-first body, throttles via the Kraken call
+        counter at the endpoint's cost, signs with :func:`_sign`, and sends the
+        ``API-Key`` / ``API-Sign`` headers. Requires credentials.
+        """
+        self._require_credentials()
+        path = f"{_PRIVATE}/{endpoint}"
+        # Build the body nonce-first so the signed postdata is deterministic.
+        body: dict[str, Any] = {"nonce": self._nonce()}
+        body.update(data)
+        signature = _sign(path, body, self._api_secret)
+        headers = {"API-Key": self._api_key, "API-Sign": signature}
+
+        await self._counter.acquire_method(endpoint)
+        url = f"{_API_BASE}{path}"
+        async with self._http as client:
+            payload = await client.post(url, data=body, headers=headers)
+        return self._raise_on_error(payload, context=endpoint)
+
+    # --- public endpoints -------------------------------------------------- #
+
+    async def instrument(self, symbol: Symbol) -> Instrument:
+        """Build an :class:`Instrument` for ``symbol`` from Kraken ``AssetPairs``.
+
+        Reads Kraken's ``pair_decimals`` / ``lot_decimals`` to populate the
+        instrument's price/quantity precision.
+
+        Parameters
+        ----------
+        symbol : Symbol
+            The canonical pair to describe.
+
+        Returns
+        -------
+        Instrument
+            The instrument with venue price/qty precision filled in.
+
+        Raises
+        ------
+        BrokerError
+            If Kraken returns an error or an unrecognisable pair entry.
+
+        """
+        pair = symbol.to_venue_symbol(self.name)
+        result = await self._public_get("AssetPairs", {"pair": pair})
+        if not result:
+            raise BrokerError(f"Kraken AssetPairs: no entry for {pair!r}")
+        # Kraken keys the result by its canonical pair name (often the legacy
+        # X/Z form), not by the altname we queried with; take the sole entry.
+        entry = next(iter(result.values()))
+        price_precision = entry.get("pair_decimals")
+        qty_precision = entry.get("lot_decimals")
+        return Instrument(
+            symbol=symbol,
+            price_precision=(
+                int(price_precision) if price_precision is not None else None
+            ),
+            qty_precision=(
+                int(qty_precision) if qty_precision is not None else None
+            ),
+        )
+
+    async def ticker(self, instrument: Instrument) -> Money:
+        """Return the public last-trade price for ``instrument`` as a ``Decimal``.
+
+        Parameters
+        ----------
+        instrument : Instrument
+            The instrument to price.
+
+        Returns
+        -------
+        Decimal
+            The last trade price (Kraken ``Ticker`` field ``c[0]``), exact.
+
+        Raises
+        ------
+        BrokerError
+            If Kraken errors or the ticker payload lacks a last price.
+
+        """
+        pair = instrument.symbol.to_venue_symbol(self.name)
+        result = await self._public_get("Ticker", {"pair": pair})
+        if not result:
+            raise BrokerError(f"Kraken Ticker: no entry for {pair!r}")
+        entry = next(iter(result.values()))
+        # ``c`` is [last_trade_price, lot_volume]; the last price is c[0].
+        close = entry.get("c")
+        if not close:
+            raise BrokerError(f"Kraken Ticker: no last price for {pair!r}")
+        return money(str(close[0]))
+
+    # --- private endpoints ------------------------------------------------- #
+
+    async def balances(self) -> dict[str, Money]:
+        """Return free balances keyed by canonical asset code (``Balance``).
+
+        Returns
+        -------
+        dict of str to Decimal
+            Canonical asset code (``"USD"``, ``"BTC"``, ...) to its balance as an
+            exact :class:`~decimal.Decimal`.
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, or on a Kraken error.
+
+        """
+        result = await self._private_post("Balance", {})
+        # Kraken keys balances by venue asset code (ZUSD, XXBT, ...). Normalise
+        # to canonical codes; amounts are exact decimal strings.
+        return {
+            normalise(asset): money(str(amount))
+            for asset, amount in result.items()
+        }
+
+    async def place_order(self, order: Order) -> str:
+        """Submit ``order`` via ``AddOrder`` and return Kraken's ``txid``.
+
+        Maps the domain order to Kraken's ``AddOrder`` parameters:
+        ``type``=buy/sell from :class:`OrderSide`, ``ordertype``=market/limit/
+        stop-loss from :class:`OrderType`, ``volume``=qty, ``pair`` from the
+        instrument, ``price``=``limit_price`` (limit) or ``stop_price`` (stop).
+
+        Parameters
+        ----------
+        order : Order
+            The domain order to submit.
+
+        Returns
+        -------
+        str
+            Kraken's order id (the first ``txid``).
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, on a Kraken error, or if no ``txid`` is
+            returned.
+
+        """
+        result = await self._private_post("AddOrder", self._add_order_params(order))
+        txids = result.get("txid") or []
+        if not txids:
+            raise BrokerError(
+                f"Kraken AddOrder: no txid returned for {order.client_order_id}"
+            )
+        return str(txids[0])
+
+    def _add_order_params(self, order: Order) -> dict[str, str]:
+        """Render a domain :class:`Order` to Kraken ``AddOrder`` parameters.
+
+        Pure (no I/O), so the order-to-payload mapping is unit-testable on its
+        own. ``price`` is the limit price for limit orders and the stop price
+        for stop-loss orders; market orders carry no price. The
+        ``client_order_id`` rides along as Kraken's ``userref`` is numeric-only,
+        so it is sent as ``cl_ord_id`` (Kraken's string client-order-id field).
+        """
+        params: dict[str, str] = {
+            "pair": order.instrument.symbol.to_venue_symbol(self.name),
+            "type": order.side.value,  # "buy" / "sell"
+            "ordertype": _ORDERTYPE_TO_KRAKEN[order.type],
+            "volume": str(order.qty),
+        }
+        if order.type is OrderType.STOP_LOSS:
+            # STOP_LOSS carries its trigger in ``stop_price``.
+            params["price"] = str(order.stop_price)
+        elif order.limit_price is not None:
+            # LIMIT (and a priced BEST_LIMIT) carry a ``limit_price``.
+            params["price"] = str(order.limit_price)
+        return params
+
+    async def cancel_order(self, venue_order_id: str) -> None:
+        """Cancel the live order identified by ``venue_order_id`` (``CancelOrder``).
+
+        Parameters
+        ----------
+        venue_order_id : str
+            Kraken's order ``txid`` (as returned by :meth:`place_order`).
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, or on a Kraken error.
+
+        """
+        await self._private_post("CancelOrder", {"txid": venue_order_id})
+
+    async def open_orders(self) -> list[Order]:
+        """Return Kraken's open orders rebuilt as domain :class:`Order`s (``OpenOrders``).
+
+        Each Kraken open order is reconstructed into a domain order driven
+        through ``submit`` -> ``open`` (and ``apply_fill`` if partially executed)
+        so the status matches Kraken's view, with ``venue_order_id`` set to the
+        ``txid``.
+
+        Returns
+        -------
+        list of Order
+            The open orders as domain objects.
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, or on a Kraken error.
+
+        """
+        result = await self._private_post("OpenOrders", {})
+        orders: list[Order] = []
+        for txid, info in (result.get("open") or {}).items():
+            orders.append(self._rebuild_order(txid, info))
+        return orders
+
+    def _rebuild_order(self, txid: str, info: Mapping[str, Any]) -> Order:
+        """Rebuild a domain :class:`Order` from a Kraken open-order entry."""
+        descr = info.get("descr", {})
+        symbol = parse_kraken_pair(str(descr.get("pair", "")))
+        side = OrderSide(descr.get("type", "buy"))
+        otype = _KRAKEN_TO_ORDERTYPE.get(
+            str(descr.get("ordertype", "")), OrderType.LIMIT
+        )
+        qty = money(str(info.get("vol", "0")))
+        price_str = descr.get("price")
+        limit_price = (
+            money(str(price_str))
+            if otype in (OrderType.LIMIT, OrderType.BEST_LIMIT)
+            and price_str
+            and money(str(price_str)) > 0
+            else None
+        )
+        stop_price = (
+            money(str(price_str))
+            if otype is OrderType.STOP_LOSS and price_str
+            else None
+        )
+        order = Order(
+            client_order_id=txid,
+            instrument=Instrument(symbol),
+            side=side,
+            qty=qty,
+            type=otype,
+            limit_price=limit_price,
+            stop_price=stop_price,
+        )
+        order.submit()
+        order.open(txid)
+        # Reflect any already-executed volume so the status matches Kraken's.
+        vol_exec = money(str(info.get("vol_exec", "0")))
+        if vol_exec > 0:
+            avg_price = info.get("price") or descr.get("price") or "0"
+            fill_price = money(str(avg_price))
+            if fill_price > 0:
+                order.apply_fill(vol_exec, fill_price)
+        return order
+
+    async def fills(self, since_ms: int | None = None) -> list[Fill]:
+        """Return executions as domain :class:`Fill`s (``TradesHistory``).
+
+        Parameters
+        ----------
+        since_ms : int, optional
+            Lower time bound as **milliseconds since the Unix epoch (UTC)**.
+            ``None`` returns Kraken's default recent window. Converted to the
+            seconds ``start`` cursor Kraken expects.
+
+        Returns
+        -------
+        list of Fill
+            The executions as immutable domain fills (exact Decimal qty/price/fee).
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, or on a Kraken error.
+
+        """
+        params: dict[str, Any] = {}
+        if since_ms is not None:
+            # Kraken's ``start`` is in seconds (it accepts fractional seconds).
+            params["start"] = since_ms / 1000.0
+        result = await self._private_post("TradesHistory", params)
+        fills: list[Fill] = []
+        for trade_id, info in (result.get("trades") or {}).items():
+            fills.append(self._build_fill(trade_id, info))
+        return fills
+
+    @staticmethod
+    def _build_fill(trade_id: str, info: Mapping[str, Any]) -> Fill:
+        """Build a domain :class:`Fill` from a Kraken trade-history entry."""
+        symbol = parse_kraken_pair(str(info.get("pair", "")))
+        side = OrderSide(info.get("type", "buy"))
+        # Kraken ``time`` is fractional seconds since epoch -> ms int.
+        ts_ms = int(float(info.get("time", 0)) * 1000)
+        return Fill(
+            fill_id=str(trade_id),
+            client_order_id=str(info.get("ordertxid", trade_id)),
+            instrument=Instrument(symbol),
+            side=side,
+            qty=money(str(info.get("vol", "0"))),
+            price=money(str(info.get("price", "0"))),
+            fee=money(str(info.get("fee", "0"))),
+            ts=ts_ms,
+        )

--- a/trading_bot/tests/brokers/test_kraken_rest.py
+++ b/trading_bot/tests/brokers/test_kraken_rest.py
@@ -1,0 +1,476 @@
+"""Tests for the :class:`~trading_bot.brokers.kraken.KrakenBroker` REST adapter.
+
+Posture (no API key)
+--------------------
+Signing is proven **deterministically** against Kraken's published test vector
+(:func:`test_sign_matches_kraken_published_vector`) — no key, no network. Every
+private endpoint (``place_order`` / ``cancel_order`` / ``open_orders`` /
+``balances`` / ``fills``) is exercised through ``pytest-httpx`` mocks of Kraken
+JSON, with the broker holding **dummy** credentials (set via ``monkeypatch`` of
+the environment) so the real signing path runs end to end. Real *private*
+verification against Kraken is **deferred**: the test vector is the proof of
+correctness. One opt-in ``@pytest.mark.network`` test hits Kraken's real
+**public** ``AssetPairs`` + ``Ticker`` for ``BTC/USD``.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from trading_bot.brokers import BrokerError, Capability, KrakenBroker
+from trading_bot.domain import (
+    Fill,
+    Instrument,
+    Order,
+    OrderSide,
+    OrderType,
+    Symbol,
+    money,
+)
+from trading_bot.transport.ratelimit import KrakenCallCounter
+
+BTC_USD = Instrument(Symbol("BTC", "USD"), price_precision=1, qty_precision=8)
+
+# Kraken's published API-Sign test vector (docs.kraken.com authentication
+# example). Deterministic: no key, no clock, no network.
+_VECTOR_SECRET = (
+    "kQH5HW/8p1uGOVjbgWA7FunAmGO8lsSUXNsu3eow76sz84Q18fWxnyRzBHCd3pd5nE9"
+    "qa99HAZtuZuj6F1huXg=="
+)
+_VECTOR_DATA = {
+    "nonce": "1616492376594",
+    "ordertype": "limit",
+    "pair": "XBTUSD",
+    "price": "37500",
+    "type": "buy",
+    "volume": "1.25",
+}
+_VECTOR_PATH = "/0/private/AddOrder"
+_VECTOR_EXPECTED = (
+    "4/dpxb3iT4tp/ZCVEwSnEsLxx0bqyhLpdfOpc6fn7OR8+UClSV5n9E6aSS8MPtnRfp32b"
+    "Ab0nmbRn6H8ndwLUQ=="
+)
+
+
+def _fast_counter() -> KrakenCallCounter:
+    """A call counter whose clock/sleep never block real time in tests."""
+    clock = {"t": 0.0}
+
+    async def _no_sleep(_seconds: float) -> None:
+        return None
+
+    return KrakenCallCounter.for_tier(
+        "pro", time_source=lambda: clock["t"], sleep=_no_sleep
+    )
+
+
+def _broker(monkeypatch: pytest.MonkeyPatch, *, creds: bool = True) -> KrakenBroker:
+    """Build a broker; with ``creds`` set dummy env credentials (signing runs)."""
+    if creds:
+        monkeypatch.setenv("KRAKEN_API_KEY", "DUMMY-KEY")
+        monkeypatch.setenv("KRAKEN_API_SECRET", _VECTOR_SECRET)
+    else:
+        monkeypatch.delenv("KRAKEN_API_KEY", raising=False)
+        monkeypatch.delenv("KRAKEN_API_SECRET", raising=False)
+    return KrakenBroker(call_counter=_fast_counter())
+
+
+# --- signing: the deterministic proof ------------------------------------- #
+
+
+def test_sign_matches_kraken_published_vector() -> None:
+    """``_sign`` reproduces Kraken's published ``API-Sign`` exactly."""
+    from trading_bot.brokers.kraken import _sign
+
+    assert _sign(_VECTOR_PATH, _VECTOR_DATA, _VECTOR_SECRET) == _VECTOR_EXPECTED
+
+
+# --- capabilities & construction ------------------------------------------ #
+
+
+def test_constructible_without_credentials() -> None:
+    """The broker builds with no env creds and is public-only."""
+    broker = KrakenBroker(api_key="", api_secret="")
+    assert broker.name == "kraken"
+    assert broker.has_credentials is False
+
+
+def test_capabilities_declares_six_rest_ops() -> None:
+    broker = KrakenBroker(api_key="", api_secret="")
+    caps = broker.capabilities()
+    assert caps == {
+        Capability.PLACE_ORDER,
+        Capability.CANCEL,
+        Capability.OPEN_ORDERS,
+        Capability.BALANCES,
+        Capability.FILLS,
+        Capability.TICKER,
+    }
+    # The private WS feed belongs to the WS leaf, not this REST adapter.
+    assert Capability.PRIVATE_WS not in caps
+
+
+# --- order mapping (pure) -------------------------------------------------- #
+
+
+def test_add_order_params_market() -> None:
+    broker = KrakenBroker(api_key="", api_secret="")
+    order = Order(
+        client_order_id="cid-mkt",
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("0.5"),
+        type=OrderType.MARKET,
+    )
+    params = broker._add_order_params(order)
+    assert params == {
+        "pair": "XBTUSD",
+        "type": "buy",
+        "ordertype": "market",
+        "volume": "0.5",
+    }
+
+
+def test_add_order_params_limit() -> None:
+    broker = KrakenBroker(api_key="", api_secret="")
+    order = Order(
+        client_order_id="cid-lim",
+        instrument=BTC_USD,
+        side=OrderSide.SELL,
+        qty=money("1.25"),
+        type=OrderType.LIMIT,
+        limit_price=money("37500"),
+    )
+    params = broker._add_order_params(order)
+    assert params == {
+        "pair": "XBTUSD",
+        "type": "sell",
+        "ordertype": "limit",
+        "volume": "1.25",
+        "price": "37500",
+    }
+
+
+def test_add_order_params_stop_loss() -> None:
+    broker = KrakenBroker(api_key="", api_secret="")
+    order = Order(
+        client_order_id="cid-stop",
+        instrument=BTC_USD,
+        side=OrderSide.SELL,
+        qty=money("2"),
+        type=OrderType.STOP_LOSS,
+        stop_price=money("28000"),
+    )
+    params = broker._add_order_params(order)
+    assert params == {
+        "pair": "XBTUSD",
+        "type": "sell",
+        "ordertype": "stop-loss",
+        "volume": "2",
+        "price": "28000",
+    }
+
+
+# --- private endpoints via mocks ------------------------------------------ #
+
+
+async def test_place_order_signs_and_returns_txid(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={"error": [], "result": {"txid": ["OXXXXX-YYYYY-ZZZZZ"], "descr": {}}}
+    )
+    broker = _broker(monkeypatch)
+    order = Order(
+        client_order_id="cid-1",
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("1.25"),
+        type=OrderType.LIMIT,
+        limit_price=money("37500"),
+    )
+
+    txid = await broker.place_order(order)
+
+    assert txid == "OXXXXX-YYYYY-ZZZZZ"
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.method == "POST"
+    assert str(request.url) == "https://api.kraken.com/0/private/AddOrder"
+    # Signed headers present (key never logged, only sent).
+    assert request.headers["API-Key"] == "DUMMY-KEY"
+    assert request.headers["API-Sign"]  # non-empty signature
+    body = request.content.decode()
+    assert "nonce=" in body
+    assert "pair=XBTUSD" in body
+    assert "ordertype=limit" in body
+    assert "type=buy" in body
+    assert "volume=1.25" in body
+    assert "price=37500" in body
+
+
+async def test_cancel_order_posts_txid(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(json={"error": [], "result": {"count": 1}})
+    broker = _broker(monkeypatch)
+
+    await broker.cancel_order("OXXXXX-YYYYY-ZZZZZ")
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert str(request.url) == "https://api.kraken.com/0/private/CancelOrder"
+    assert request.headers["API-Sign"]
+    assert "txid=OXXXXX-YYYYY-ZZZZZ" in request.content.decode()
+
+
+async def test_balances_returns_decimal_map(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={
+            "error": [],
+            "result": {"ZUSD": "1500.5000", "XXBT": "0.50000000", "USDT": "10.0"},
+        }
+    )
+    broker = _broker(monkeypatch)
+
+    balances = await broker.balances()
+
+    # Asset codes normalised to canonical; amounts are exact Decimals.
+    assert balances == {
+        "USD": Decimal("1500.5000"),
+        "BTC": Decimal("0.50000000"),
+        "USDT": Decimal("10.0"),
+    }
+    assert all(isinstance(v, Decimal) for v in balances.values())
+
+
+async def test_open_orders_rebuilds_domain_orders(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={
+            "error": [],
+            "result": {
+                "open": {
+                    "OABC-1": {
+                        "vol": "1.0",
+                        "vol_exec": "0.0",
+                        "descr": {
+                            "pair": "XBTUSD",
+                            "type": "buy",
+                            "ordertype": "limit",
+                            "price": "30000.0",
+                        },
+                    }
+                }
+            },
+        }
+    )
+    broker = _broker(monkeypatch)
+
+    orders = await broker.open_orders()
+
+    assert len(orders) == 1
+    order = orders[0]
+    assert isinstance(order, Order)
+    assert order.venue_order_id == "OABC-1"
+    assert order.instrument.symbol == Symbol("BTC", "USD")
+    assert order.side is OrderSide.BUY
+    assert order.type is OrderType.LIMIT
+    assert order.qty == Decimal("1.0")
+    assert order.limit_price == Decimal("30000.0")
+
+
+async def test_open_orders_partial_fill_reflected(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={
+            "error": [],
+            "result": {
+                "open": {
+                    "OABC-2": {
+                        "vol": "2.0",
+                        "vol_exec": "0.5",
+                        "price": "31000.0",
+                        "descr": {
+                            "pair": "XBTUSD",
+                            "type": "sell",
+                            "ordertype": "limit",
+                            "price": "31000.0",
+                        },
+                    }
+                }
+            },
+        }
+    )
+    broker = _broker(monkeypatch)
+
+    orders = await broker.open_orders()
+
+    assert orders[0].filled_qty == Decimal("0.5")
+    assert orders[0].avg_fill_price == Decimal("31000.0")
+
+
+async def test_fills_builds_domain_fills(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={
+            "error": [],
+            "result": {
+                "trades": {
+                    "TRADE-1": {
+                        "ordertxid": "OABC-1",
+                        "pair": "XXBTZUSD",
+                        "type": "buy",
+                        "price": "30000.5",
+                        "vol": "0.10000000",
+                        "fee": "7.80",
+                        "time": 1616492376.594,
+                    }
+                },
+                "count": 1,
+            },
+        }
+    )
+    broker = _broker(monkeypatch)
+
+    fills = await broker.fills()
+
+    assert len(fills) == 1
+    fill = fills[0]
+    assert isinstance(fill, Fill)
+    assert fill.fill_id == "TRADE-1"
+    assert fill.client_order_id == "OABC-1"
+    assert fill.instrument.symbol == Symbol("BTC", "USD")
+    assert fill.side is OrderSide.BUY
+    assert fill.qty == Decimal("0.10000000")
+    assert fill.price == Decimal("30000.5")
+    assert fill.fee == Decimal("7.80")
+    assert fill.ts == 1616492376594
+
+
+async def test_fills_since_ms_passes_start_seconds(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(json={"error": [], "result": {"trades": {}}})
+    broker = _broker(monkeypatch)
+
+    await broker.fills(since_ms=1_616_492_376_594)
+
+    body = httpx_mock.get_request().content.decode()
+    # ms -> seconds for Kraken's ``start`` cursor.
+    assert "start=1616492376.594" in body
+
+
+# --- ticker (public, mocked) ---------------------------------------------- #
+
+
+async def test_ticker_returns_last_price(httpx_mock) -> None:
+    httpx_mock.add_response(
+        json={
+            "error": [],
+            "result": {
+                "XXBTZUSD": {
+                    "c": ["64250.10000", "0.01526374"],
+                    "a": ["64250.20000", "1", "1.000"],
+                }
+            },
+        }
+    )
+    broker = KrakenBroker(api_key="", api_secret="")
+
+    price = await broker.ticker(BTC_USD)
+
+    assert price == Decimal("64250.10000")
+    assert isinstance(price, Decimal)
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.method == "GET"
+    assert "pair=XBTUSD" in str(request.url)
+
+
+async def test_instrument_builds_precision(httpx_mock) -> None:
+    httpx_mock.add_response(
+        json={
+            "error": [],
+            "result": {
+                "XXBTZUSD": {
+                    "altname": "XBTUSD",
+                    "wsname": "XBT/USD",
+                    "pair_decimals": 1,
+                    "lot_decimals": 8,
+                }
+            },
+        }
+    )
+    broker = KrakenBroker(api_key="", api_secret="")
+
+    inst = await broker.instrument(Symbol("BTC", "USD"))
+
+    assert inst.symbol == Symbol("BTC", "USD")
+    assert inst.price_precision == 1
+    assert inst.qty_precision == 8
+
+
+# --- error mapping & credential handling ---------------------------------- #
+
+
+async def test_kraken_error_raises_broker_error(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={"error": ["EOrder:Insufficient funds"], "result": {}}
+    )
+    broker = _broker(monkeypatch)
+    order = Order(
+        client_order_id="cid-x",
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        type=OrderType.MARKET,
+    )
+
+    with pytest.raises(BrokerError, match="Insufficient funds"):
+        await broker.place_order(order)
+
+
+async def test_private_call_without_credentials_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broker = _broker(monkeypatch, creds=False)
+    with pytest.raises(BrokerError, match="requires credentials"):
+        await broker.balances()
+
+
+async def test_public_call_needs_no_credentials(httpx_mock) -> None:
+    """A public call works with no credentials present."""
+    httpx_mock.add_response(
+        json={"error": [], "result": {"XXBTZUSD": {"c": ["100.0", "1"]}}}
+    )
+    broker = KrakenBroker(api_key="", api_secret="")
+    assert await broker.ticker(BTC_USD) == Decimal("100.0")
+
+
+# --- real public smoke (opt-in: ``-m network``) --------------------------- #
+
+
+@pytest.mark.network
+async def test_real_kraken_public_btc_usd() -> None:
+    """Live Kraken ``AssetPairs`` + ``Ticker`` for BTC/USD (no key)."""
+    broker = KrakenBroker()  # no creds: public-only is enough here
+
+    inst = await broker.instrument(Symbol("BTC", "USD"))
+    assert inst.symbol == Symbol("BTC", "USD")
+    assert inst.price_precision is not None
+    assert inst.price_precision >= 0
+    assert inst.qty_precision is not None and inst.qty_precision >= 0
+
+    price = await broker.ticker(inst)
+    assert isinstance(price, Decimal)
+    assert price > 0


### PR DESCRIPTION
## Summary
- Second leaf of **E3**: `trading_bot/brokers/kraken.py` — `KrakenBroker` implementing the `Broker` port over Kraken REST.
- HMAC-SHA512 request signing **verified against Kraken's published test vector**; signed private ops (place/cancel/open orders, balances, fills) + public market data (ticker, instrument precision). Order mapping domain↔Kraken; money exact `Decimal`.

## Why
- The published test vector proves signing matches Kraken's spec without a key. Credentials are env-only (`.env` gitignored), never logged; the broker is constructible key-free for public data, and a private call without creds raises `BrokerError` before any I/O. See `doc/dev/03-decisions.md`.

## Posture (per decision)
- Private endpoints **mock-tested** (`pytest-httpx`); real private verification **deferred** until a key is provided. Real **public** smoke runs live.

## Changes
- `brokers/kraken.py` + export; `tests/brokers/test_kraken_rest.py` (32 offline incl. the signing vector + 1 `@network`); `.env.example`.

## Changelog
Added under [Unreleased]:
- `brokers.KrakenBroker` — Kraken REST adapter (signed orders/balances/fills, public market data).

## Test plan
- [x] `pytest` (245 passed, 6 skipped) — incl. signing test vector
- [x] `pytest -m network` — real Kraken AssetPairs/Ticker BTC/USD (Decimal price)
- [x] `ruff` + `mypy` clean; `.env` gitignored, no key material committed
- [ ] CI green