### PR TITLE
feat: KrakenPrivateWS (executions/fills) — closes E3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brokers.KrakenBroker` — Kraken REST adapter: HMAC-SHA512 request signing
   (verified vs Kraken's published vector), signed orders/balances/fills, public
   market data. Credentials via env; public data works key-free. (#18)
+- `brokers.KrakenPrivateWS` — Kraken v2 private-WS `executions` parsing into domain
+  `Fill`s / order updates (token-auth, mock-verified; live gated on a key).
+  Completes the **E3 Kraken adapter**. (#19)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,22 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-20 Kraken private WS: token-auth via on_connect, mock-verified (PR #19)
+
+**Decision.** `brokers/kraken_ws.py` `KrakenPrivateWS` streams Kraken v2 `executions`
+on `transport.WebSocketBase`, parsing frames into domain `Fill`s (trade execs) and
+`OrderUpdate`s. Kraken's private WS is not per-frame signed: `on_connect` fetches a
+short-lived **WebSocket token** (private REST `GetWebSocketsToken`, signed) via an
+injected `token_provider` seam and subscribes with it; re-running on reconnect
+re-fetches/re-subscribes (self-heal). **No key here** — token fetch + parsing are
+verified against realistic canned v2 frames; the live private connection is deferred.
+
+**Why.** Token-in-`on_connect` makes the private subscription idempotent across drops;
+the seam keeps the whole path offline-testable without credentials. Tokens are secrets
+and are never logged.
+
+---
+
 ### 2026-06-20 KrakenBroker REST: signing verified, env credentials, mock+public posture (PR #18)
 
 **Decision.** `brokers/kraken.py` implements the `Broker` port over Kraken REST.

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,12 +10,15 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**E1 (domain) and E2 (transport) are complete.** `trading_bot/domain/` (money,
-instrument, errors, order, fill, position, signal, performance — pure, mypy-strict)
-and `trading_bot/transport/` (`AsyncHTTPClient`, `WebSocketBase`, `RateLimiter` +
-`KrakenCallCounter` — async, with real Kraken REST/WS smokes under `-m network`)
-are in. The later layers (`brokers`, `storage`, `application`, `interfaces`) are
-pending — next is **E3 (broker port + Kraken adapter)**. See `07-roadmap.md` /
+**E1 (domain), E2 (transport) and E3 (brokers) are complete** — the whole
+**Foundation** block. `trading_bot/domain/` (money, instrument, errors, order, fill,
+position, signal, performance — pure, mypy-strict), `trading_bot/transport/`
+(`AsyncHTTPClient`, `WebSocketBase`, `RateLimiter` + `KrakenCallCounter`), and
+`trading_bot/brokers/` (the `Broker` port + registry + `KrakenBroker` REST +
+`KrakenPrivateWS` — signing verified vs Kraken's vector; private endpoints
+mock-tested, real private verification gated on a key) are in. The later layers
+(`storage`, `application`, `interfaces`) are pending — next is **E4 (execution
+engine)**. See `07-roadmap.md` /
 `08-program-plan.md`.
 
 ## Done

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -10,13 +10,6 @@ The single source *index* of open work. Each unchecked item is a candidate for
 > **Full decomposition** — every epic broken into its leaves, branches,
 > complexity and dependencies: [`08-program-plan.md`](08-program-plan.md).
 
-## Foundation
-
-- [ ] **E3 — Broker port + Kraken adapter.** `Broker` protocol (place/cancel/
-  replace, open orders, balances, fills, market data) + registry; `KrakenBroker`
-  (REST first, WS fills next). Other venues declared, not implemented.
-  _(depends on E1, E2)_
-
 ## Execution engine
 
 - [ ] **E4 — Order router + PaperBroker.** Idempotent submit (client-order-id),

--- a/doc/dev/plans/broker-kraken/00-plan.md
+++ b/doc/dev/plans/broker-kraken/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: broker-kraken
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E3 — Broker port + Kraken adapter.** `Broker` protocol (place/cancel/replace, open orders, balances, fills, market data) + registry; `KrakenBroker` (REST first, WS fills next). Other venues declared, not implemented."
 release_on_done: false
 ---
@@ -35,7 +35,7 @@ logged or committed.
 
 - [x] 01 broker-port — feat/broker-port — high
 - [x] 02 kraken-rest — feat/broker-kraken-rest — high (depends on 01)
-- [ ] 03 kraken-ws — feat/broker-kraken-ws — high (depends on 02)
+- [x] 03 kraken-ws — feat/broker-kraken-ws — high (depends on 02)
 
 ## Dependencies
 

--- a/doc/dev/plans/broker-kraken/03-kraken-ws.md
+++ b/doc/dev/plans/broker-kraken/03-kraken-ws.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [02]
 parallel: false
 branch: feat/broker-kraken-ws
-pr: ""
+pr: "#19"
 ---
 
 # KrakenBroker — private WebSocket (fills / order updates)

--- a/doc/dev/plans/broker-kraken/03-kraken-ws.md
+++ b/doc/dev/plans/broker-kraken/03-kraken-ws.md
@@ -1,7 +1,7 @@
 ---
 plan: broker-kraken/03-kraken-ws
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [02]
 parallel: false

--- a/trading_bot/brokers/__init__.py
+++ b/trading_bot/brokers/__init__.py
@@ -25,13 +25,18 @@ Public surface:
 * :class:`~trading_bot.domain.errors.BrokerError` — the venue-neutral broker
   failure (re-exported for convenience);
 * :class:`~trading_bot.brokers.kraken.KrakenBroker` — the concrete Kraken REST
-  adapter (signed orders/balances/fills + public market data).
+  adapter (signed orders/balances/fills + public market data);
+* :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS` — the Kraken v2 private
+  WebSocket adapter streaming ``executions`` (own trades / order updates) into
+  domain :class:`~trading_bot.domain.fill.Fill`s (auth-token flow; live private
+  connection gated on credentials, parse path mock-verified).
 """
 
 from __future__ import annotations
 
 from trading_bot.brokers.base import Broker, BrokerError, Capability, require
 from trading_bot.brokers.kraken import KrakenBroker
+from trading_bot.brokers.kraken_ws import KrakenPrivateWS
 from trading_bot.brokers.registry import BrokerRegistry
 
 __all__ = [
@@ -41,4 +46,5 @@ __all__ = [
     "BrokerError",
     "BrokerRegistry",
     "KrakenBroker",
+    "KrakenPrivateWS",
 ]

--- a/trading_bot/brokers/kraken_ws.py
+++ b/trading_bot/brokers/kraken_ws.py
@@ -1,0 +1,421 @@
+"""The :class:`KrakenPrivateWS` — Kraken v2 private WebSocket (executions/fills).
+
+This is the **live, authenticated** counterpart to the REST
+:class:`~trading_bot.brokers.kraken.KrakenBroker`: it streams Kraken's v2
+``executions`` channel (own trades + order-status changes) on top of the
+venue-neutral :class:`~trading_bot.transport.ws.WebSocketBase`, parsing each
+frame into **domain types** — a :class:`~trading_bot.domain.fill.Fill` for every
+executed trade and an :class:`OrderUpdate` for every order-status change. It is
+the feed the order router / position tracker (E4) consume.
+
+Auth-token flow
+---------------
+Kraken's private WebSocket is not signed per-frame; instead the client first
+fetches a short-lived **WebSocket token** from the *private REST* endpoint
+``GetWebSocketsToken`` (which is HMAC-signed with the API key/secret, exactly
+like every other private REST call — see
+:func:`trading_bot.brokers.kraken._sign`) and then presents that token in the
+``subscribe`` message. Because :meth:`~trading_bot.transport.ws.WebSocketBase.on_connect`
+re-runs on every reconnect, the token is re-fetched and the subscription
+re-established automatically after a drop (self-healing).
+
+The token fetch is injected as the ``token_provider`` seam — an ``async``
+callable returning the token string. The default
+(:func:`_broker_token_provider`) calls a :class:`KrakenBroker`'s private REST;
+tests inject a fake that returns a dummy token, so the whole parse path is
+exercised **offline with no API key**.
+
+Posture
+-------
+**No API key is used here.** The live private connection is *deferred* until a
+key is provided: the auth-token fetch and the frame parsing are proven against
+**realistic canned private frames** (shape from Kraken's v2 private docs) that
+parse to the expected domain :class:`Fill`s. Tokens are credentials and are
+**never logged**. The public WS path is already proven against a real Kraken
+frame (E2).
+
+Money
+-----
+Every amount Kraken reports on the wire is a number/decimal string; it is parsed
+with ``money(str(...))`` so qty/price/fee stay exact :class:`~decimal.Decimal`
+and never round-trip through ``float``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, parse_kraken_pair
+from trading_bot.domain.money import money
+from trading_bot.domain.order import OrderSide
+from trading_bot.transport.ws import WebSocketBase
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from trading_bot.brokers.kraken import KrakenBroker
+    from trading_bot.domain.money import Money
+
+__all__ = [
+    "KrakenPrivateWS",
+    "OrderUpdate",
+    "TokenProvider",
+]
+
+logger = logging.getLogger(__name__)
+
+_WS_AUTH_URL = "wss://ws-auth.kraken.com/v2"
+
+#: An ``async`` callable returning a fresh Kraken WebSocket auth token.
+TokenProvider = Callable[[], Awaitable[str]]
+
+# Kraken v2 ``exec_type`` values that correspond to an executed trade (the only
+# exec types that carry ``last_qty`` / ``last_price`` and so map to a Fill).
+# Everything else (``new``, ``filled``, ``canceled``, ``expired``, ...) is an
+# order-status change, surfaced as an :class:`OrderUpdate`.
+_TRADE_EXEC_TYPES: frozenset[str] = frozenset({"trade"})
+
+
+@dataclass(frozen=True, slots=True)
+class OrderUpdate:
+    """An order-status change parsed from the Kraken v2 ``executions`` channel.
+
+    A lightweight, immutable view of a non-trade execution event (``new``,
+    ``filled``, ``canceled``, ``expired``, ...): just enough to tie the venue's
+    order back to the originating order and reflect its new status. Unlike a
+    :class:`~trading_bot.domain.fill.Fill` (which is an executed slice), an
+    update carries no executed qty/price of its own.
+
+    Parameters
+    ----------
+    client_order_id : str
+        The caller-assigned order id (Kraken ``order_userref`` / ``cl_ord_id``),
+        falling back to the venue order id when absent.
+    venue_order_id : str
+        Kraken's order id (``order_id``).
+    exec_type : str
+        The Kraken ``exec_type`` (``"new"``, ``"filled"``, ``"canceled"``, ...).
+    status : str or None
+        Kraken's ``order_status`` for the order, if the frame carried one.
+    instrument : Instrument or None
+        The instrument, when the frame named a ``symbol``.
+    ts : int
+        Event timestamp as **milliseconds since the Unix epoch (UTC)**.
+    """
+
+    client_order_id: str
+    venue_order_id: str
+    exec_type: str
+    status: str | None
+    instrument: Instrument | None
+    ts: int
+
+
+def _broker_token_provider(broker: KrakenBroker) -> Callable[[], Awaitable[str]]:
+    """Build the default :data:`TokenProvider` from a :class:`KrakenBroker`.
+
+    Returns an ``async`` callable that fetches a fresh WebSocket token via the
+    broker's signed private REST (``GetWebSocketsToken``). This needs API
+    credentials, so it is **only** wired up when the caller supplies a
+    credentialed broker; the offline tests inject a fake provider instead.
+    """
+
+    async def _provider() -> str:
+        # GetWebSocketsToken is a private (signed) endpoint; the broker raises a
+        # clear BrokerError if it lacks credentials, before any I/O.
+        result = await broker._private_post("GetWebSocketsToken", {})
+        token = result.get("token")
+        if not token:
+            from trading_bot.domain.errors import BrokerError
+
+            raise BrokerError(
+                "Kraken GetWebSocketsToken: no token in response"
+            )
+        return str(token)
+
+    return _provider
+
+
+def _parse_iso_ms(ts_str: str) -> int:
+    """Parse a Kraken ISO-8601 timestamp to milliseconds since the epoch (UTC).
+
+    Kraken v2 stamps events as e.g. ``"2024-01-02T03:04:05.123456Z"``. Returns
+    ``0`` for a missing/unparseable value (callers carry ``ts`` for record-keeping
+    only; it never re-sorts fills).
+    """
+    if not ts_str:
+        return 0
+    try:
+        dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return 0
+    return int(dt.timestamp() * 1000)
+
+
+def _fee_of(entry: dict[str, Any]) -> Money:
+    """Extract the quote-currency fee from a Kraken v2 execution entry.
+
+    Kraken v2 reports fees either as a scalar ``fee`` / ``fee_usd_equiv`` or as a
+    ``fees`` list of ``{"asset": ..., "qty": ...}`` objects (one per fee
+    currency). We sum the ``qty`` of the ``fees`` list when present (the fee in
+    the order's quote currency), else fall back to the scalar ``fee`` field.
+    Returns an exact :class:`~decimal.Decimal`, defaulting to ``0``.
+    """
+    fees = entry.get("fees")
+    if isinstance(fees, list) and fees:
+        total = money("0")
+        for f in fees:
+            qty = f.get("qty") if isinstance(f, dict) else None
+            if qty is not None:
+                total += money(str(qty))
+        return total
+    scalar = entry.get("fee")
+    if scalar is not None:
+        return money(str(scalar))
+    return money("0")
+
+
+class KrakenPrivateWS(WebSocketBase):
+    """Kraken v2 private WebSocket adapter — streams executions as domain events.
+
+    Subscribes to Kraken's v2 ``executions`` channel (own trades + order-status
+    changes) using a WebSocket auth token, and parses inbound frames into domain
+    :class:`~trading_bot.domain.fill.Fill`s (executed trades) and
+    :class:`OrderUpdate`s (order-status changes). Heartbeats, ``status`` frames
+    and subscription acks are ignored.
+
+    The auth token is obtained on every (re)connect via the injected
+    ``token_provider`` and presented in the ``subscribe`` message, so the
+    subscription self-heals after a reconnect. The ``connect`` / ``sleep`` seams
+    are inherited from :class:`~trading_bot.transport.ws.WebSocketBase`, so the
+    whole path is offline-testable.
+
+    Parameters
+    ----------
+    token_provider : callable
+        An ``async`` callable returning a fresh Kraken WebSocket token string.
+        Use :meth:`from_broker` to build one from a credentialed
+        :class:`~trading_bot.brokers.kraken.KrakenBroker`; tests inject a fake.
+    snap_trades : bool, default True
+        Request a snapshot of recent trades on subscribe (Kraken ``snap_trades``).
+    snap_orders : bool, default True
+        Request a snapshot of open orders on subscribe (Kraken ``snap_orders``).
+    url : str, optional
+        The WS endpoint. Defaults to Kraken's v2 auth endpoint.
+    **ws_kwargs
+        Forwarded to :class:`~trading_bot.transport.ws.WebSocketBase`
+        (``max_backoff``, ``backoff_base``, ``connect``, ``sleep``).
+
+    Notes
+    -----
+    The auth token is a credential and is **never logged**. The live private
+    connection is deferred until a key is provided (parse path proven via mocks).
+    """
+
+    def __init__(
+        self,
+        token_provider: Callable[[], Awaitable[str]],
+        *,
+        snap_trades: bool = True,
+        snap_orders: bool = True,
+        url: str = _WS_AUTH_URL,
+        **ws_kwargs: Any,
+    ) -> None:
+        super().__init__(url, **ws_kwargs)
+        self._token_provider = token_provider
+        self._snap_trades = snap_trades
+        self._snap_orders = snap_orders
+
+    @classmethod
+    def from_broker(
+        cls,
+        broker: KrakenBroker,
+        *,
+        snap_trades: bool = True,
+        snap_orders: bool = True,
+        url: str = _WS_AUTH_URL,
+        **ws_kwargs: Any,
+    ) -> KrakenPrivateWS:
+        """Build a :class:`KrakenPrivateWS` whose token comes from ``broker``.
+
+        Wires the default :data:`TokenProvider` to ``broker``'s signed private
+        REST (``GetWebSocketsToken``). Requires the broker to carry credentials;
+        the token fetch raises :class:`~trading_bot.domain.errors.BrokerError`
+        without them, before any I/O.
+        """
+        return cls(
+            _broker_token_provider(broker),
+            snap_trades=snap_trades,
+            snap_orders=snap_orders,
+            url=url,
+            **ws_kwargs,
+        )
+
+    async def on_connect(self, ws: Any) -> None:
+        """Fetch the auth token and subscribe to ``executions`` (re-runs on reconnect).
+
+        Obtains a fresh token via the injected ``token_provider`` and sends the
+        v2 ``subscribe`` for the ``executions`` channel with the token in
+        ``params``. Because the base re-runs this on every reconnect, the token
+        is refreshed and the subscription re-established automatically.
+        """
+        token = await self._token_provider()
+        sub: dict[str, Any] = {
+            "method": "subscribe",
+            "params": {
+                "channel": "executions",
+                "token": token,
+                "snap_trades": self._snap_trades,
+                "snap_orders": self._snap_orders,
+            },
+        }
+        await ws.send(json.dumps(sub))
+
+    async def events(self) -> AsyncIterator[Fill | OrderUpdate]:
+        """Yield domain :class:`Fill`s and :class:`OrderUpdate`s from the feed.
+
+        Consumes :meth:`~trading_bot.transport.ws.WebSocketBase.stream_raw`,
+        parsing each ``executions`` frame (snapshot or update). A ``trade``
+        execution becomes a :class:`~trading_bot.domain.fill.Fill`; any other
+        ``exec_type`` becomes an :class:`OrderUpdate`. Heartbeats, ``status``
+        frames and subscription acks are ignored. A rejected subscription raises
+        :class:`~trading_bot.domain.errors.BrokerError`.
+
+        Yields
+        ------
+        Fill or OrderUpdate
+            One event per execution entry, in arrival order.
+        """
+        async for raw in self.stream_raw():
+            data = json.loads(raw)
+            if not isinstance(data, dict):
+                continue
+            self._check_sub_ack(data)
+            if data.get("channel") != "executions":
+                # Ignore heartbeats, status frames, subscription acks, etc.
+                continue
+            for entry in data.get("data", []):
+                event = self._parse_entry(entry)
+                if event is not None:
+                    yield event
+
+    async def fills(self) -> AsyncIterator[Fill]:
+        """Yield only the executed-trade :class:`Fill`s (drops order updates).
+
+        A convenience filter over :meth:`events` for callers (e.g. the position
+        tracker) that care only about executed trades, not order-status changes.
+
+        Yields
+        ------
+        Fill
+            One fill per ``trade`` execution, in arrival order.
+        """
+        async for event in self.events():
+            if isinstance(event, Fill):
+                yield event
+
+    @staticmethod
+    def _check_sub_ack(data: dict[str, Any]) -> None:
+        """Raise on a rejected subscription instead of silently filtering it.
+
+        Kraken v2 answers a failed subscribe with ``{"method": "subscribe",
+        "success": false, "error": ...}``; dropping that frame would leave a
+        "live" stream that never produces anything. The error string is a venue
+        diagnostic (never the token), so it is safe to surface.
+        """
+        if data.get("method") == "subscribe" and data.get("success") is False:
+            from trading_bot.domain.errors import BrokerError
+
+            raise BrokerError(
+                f"Kraken executions subscription rejected: "
+                f"{data.get('error', 'unknown error')}"
+            )
+
+    def _parse_entry(self, entry: Any) -> Fill | OrderUpdate | None:
+        """Parse one Kraken v2 ``executions`` data entry into a domain event.
+
+        A ``trade`` execution (carrying ``last_qty`` / ``last_price``) becomes a
+        :class:`~trading_bot.domain.fill.Fill`; any other ``exec_type`` becomes an
+        :class:`OrderUpdate`. Returns ``None`` for an entry we cannot make sense
+        of (e.g. a malformed/empty object), so the stream is resilient to
+        unexpected shapes.
+        """
+        if not isinstance(entry, dict):
+            return None
+        exec_type = str(entry.get("exec_type", ""))
+        if exec_type in _TRADE_EXEC_TYPES:
+            return self._build_fill(entry)
+        return self._build_order_update(entry, exec_type)
+
+    @staticmethod
+    def _instrument_of(entry: dict[str, Any]) -> Instrument | None:
+        """Build an :class:`Instrument` from the entry's ``symbol``, if present."""
+        symbol_str = entry.get("symbol")
+        if not symbol_str:
+            return None
+        return Instrument(parse_kraken_pair(str(symbol_str)))
+
+    def _build_fill(self, entry: dict[str, Any]) -> Fill | None:
+        """Build a domain :class:`Fill` from a ``trade`` execution entry.
+
+        Maps Kraken v2 ``executions`` trade fields to the domain fill:
+        ``exec_id``/``trade_id`` → ``fill_id``, ``order_userref`` (else
+        ``order_id``) → ``client_order_id``, ``last_qty`` → ``qty``,
+        ``last_price`` → ``price``, the fee (see :func:`_fee_of`) → ``fee``, and
+        the ISO ``timestamp`` → ``ts`` (ms). Returns ``None`` if the entry lacks
+        the symbol/qty/price a fill requires.
+        """
+        instrument = self._instrument_of(entry)
+        if instrument is None:
+            return None
+        last_qty = entry.get("last_qty")
+        last_price = entry.get("last_price")
+        if last_qty is None or last_price is None:
+            return None
+
+        venue_order_id = str(entry.get("order_id", ""))
+        # Kraken v2 carries the caller's id as ``order_userref`` (numeric) or
+        # ``cl_ord_id`` (string); fall back to the venue order id so the fill
+        # always ties back to *some* order identity.
+        userref = entry.get("cl_ord_id") or entry.get("order_userref")
+        client_order_id = str(userref) if userref else venue_order_id
+
+        fill_id = str(
+            entry.get("exec_id")
+            or entry.get("trade_id")
+            or entry.get("order_id", "")
+        )
+        side = OrderSide(str(entry.get("side", "buy")))
+        return Fill(
+            fill_id=fill_id,
+            client_order_id=client_order_id,
+            instrument=instrument,
+            side=side,
+            qty=money(str(last_qty)),
+            price=money(str(last_price)),
+            fee=_fee_of(entry),
+            ts=_parse_iso_ms(str(entry.get("timestamp", ""))),
+        )
+
+    def _build_order_update(
+        self, entry: dict[str, Any], exec_type: str
+    ) -> OrderUpdate:
+        """Build an :class:`OrderUpdate` from a non-trade execution entry."""
+        venue_order_id = str(entry.get("order_id", ""))
+        userref = entry.get("cl_ord_id") or entry.get("order_userref")
+        client_order_id = str(userref) if userref else venue_order_id
+        status = entry.get("order_status")
+        return OrderUpdate(
+            client_order_id=client_order_id,
+            venue_order_id=venue_order_id,
+            exec_type=exec_type,
+            status=str(status) if status is not None else None,
+            instrument=self._instrument_of(entry),
+            ts=_parse_iso_ms(str(entry.get("timestamp", ""))),
+        )

--- a/trading_bot/tests/brokers/test_kraken_ws.py
+++ b/trading_bot/tests/brokers/test_kraken_ws.py
@@ -1,0 +1,445 @@
+"""Tests for :mod:`trading_bot.brokers.kraken_ws` (Kraken v2 private WS).
+
+Offline-only: a fake ``connect`` seam (mirroring
+:mod:`trading_bot.tests.transport.test_ws`) feeds a canned sequence of realistic
+Kraken v2 private frames (a ``status`` frame and a ``heartbeat`` to ignore, an
+``executions`` snapshot, then an ``executions`` update carrying a trade), and an
+injected fake ``token_provider`` returns a dummy token — so the whole
+auth-token + parse path is exercised with **no API key and no real connection**.
+The live private connection is deferred until a key is provided.
+
+The canned frame shapes follow Kraken's v2 private ``executions`` docs.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from trading_bot.brokers import KrakenPrivateWS
+from trading_bot.brokers.kraken_ws import OrderUpdate
+from trading_bot.domain.errors import BrokerError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Symbol
+from trading_bot.domain.order import OrderSide
+
+# --- fakes (mirror transport/test_ws.py) ----------------------------------- #
+
+
+class RecordingSleep:
+    """Async ``asyncio.sleep`` stand-in that records every requested delay."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, delay: float) -> None:
+        self.calls.append(delay)
+
+
+class FakeWS:
+    """A fake live connection: async-iterates *frames* and records sends.
+
+    An optional *on_exhaust* callback fires once the scripted frames are drained
+    — used to :meth:`~KrakenPrivateWS.stop` the stream from tests that expect no
+    events (so the reconnect loop terminates instead of spinning).
+    """
+
+    def __init__(
+        self, frames: list[str], on_exhaust: Any = None
+    ) -> None:
+        self._frames = frames
+        self._on_exhaust = on_exhaust
+        self.sent: list[Any] = []
+
+    async def send(self, message: Any) -> None:
+        self.sent.append(message)
+
+    def __aiter__(self) -> AsyncIterator[str]:
+        async def _gen() -> AsyncIterator[str]:
+            for frame in self._frames:
+                yield frame
+            if self._on_exhaust is not None:
+                self._on_exhaust()
+
+        return _gen()
+
+
+class _Conn:
+    """Async context manager standing in for ``websockets.connect(url)``."""
+
+    def __init__(self, result: BaseException | FakeWS) -> None:
+        self._result = result
+
+    async def __aenter__(self) -> FakeWS:
+        if isinstance(self._result, BaseException):
+            raise self._result
+        return self._result
+
+    async def __aexit__(self, *exc: object) -> None:
+        return None
+
+
+class FakeConnector:
+    """Injectable ``connect`` seam yielding a scripted sequence of attempts."""
+
+    def __init__(self, results: list[BaseException | FakeWS]) -> None:
+        self._results = list(results)
+        self.urls: list[str] = []
+
+    def __call__(self, url: str) -> _Conn:
+        self.urls.append(url)
+        if not self._results:
+            raise AssertionError("FakeConnector called more times than scripted")
+        return _Conn(self._results.pop(0))
+
+
+class FakeTokenProvider:
+    """Async token-provider seam: returns a dummy token, counts awaits."""
+
+    def __init__(self, token: str = "dummy-ws-token") -> None:
+        self.token = token
+        self.calls = 0
+
+    async def __call__(self) -> str:
+        self.calls += 1
+        return self.token
+
+
+# --- canned Kraken v2 private frames (shape from the v2 private docs) ------- #
+
+# A status frame (connection metadata) — ignored.
+_STATUS_FRAME = json.dumps(
+    {
+        "channel": "status",
+        "type": "update",
+        "data": [{"system": "online", "api_version": "v2", "version": "2.0.0"}],
+    }
+)
+
+# A heartbeat frame — ignored.
+_HEARTBEAT_FRAME = json.dumps({"channel": "heartbeat"})
+
+# The subscription ack (success) — ignored.
+_SUB_ACK_FRAME = json.dumps(
+    {
+        "method": "subscribe",
+        "success": True,
+        "result": {"channel": "executions", "snapshot": True},
+        "time_in": "2024-01-02T03:04:05.000000Z",
+        "time_out": "2024-01-02T03:04:05.000100Z",
+    }
+)
+
+# An executions snapshot: one open order (exec_type "new", no trade) — surfaces
+# as an OrderUpdate, not a Fill.
+_SNAPSHOT_FRAME = json.dumps(
+    {
+        "channel": "executions",
+        "type": "snapshot",
+        "data": [
+            {
+                "exec_type": "new",
+                "order_id": "OABCDE-12345-FGHIJK",
+                "order_userref": 1001,
+                "symbol": "BTC/USD",
+                "side": "buy",
+                "order_status": "new",
+                "order_qty": 1.5,
+                "timestamp": "2024-01-02T03:04:00.000000Z",
+            }
+        ],
+    }
+)
+
+# An executions update carrying a trade execution (exec_type "trade") — the Fill.
+_TRADE_UPDATE_FRAME = json.dumps(
+    {
+        "channel": "executions",
+        "type": "update",
+        "data": [
+            {
+                "exec_type": "trade",
+                "exec_id": "TXXXXX-EXEC1-AAAAAA",
+                "trade_id": 42,
+                "order_id": "OABCDE-12345-FGHIJK",
+                "order_userref": 1001,
+                "symbol": "BTC/USD",
+                "side": "buy",
+                "last_qty": 0.5,
+                "last_price": 42000.10,
+                "cost": 21000.05,
+                "fees": [{"asset": "USD", "qty": 33.60}],
+                "liquidity_ind": "t",
+                "order_status": "partially_filled",
+                "timestamp": "2024-01-02T03:04:05.123000Z",
+            }
+        ],
+    }
+)
+
+# An order-status update (exec_type "filled", no trade payload) — OrderUpdate.
+_ORDER_STATUS_FRAME = json.dumps(
+    {
+        "channel": "executions",
+        "type": "update",
+        "data": [
+            {
+                "exec_type": "filled",
+                "order_id": "OABCDE-12345-FGHIJK",
+                "order_userref": 1001,
+                "symbol": "BTC/USD",
+                "side": "buy",
+                "order_status": "filled",
+                "timestamp": "2024-01-02T03:04:06.000000Z",
+            }
+        ],
+    }
+)
+
+
+def _make_ws(
+    frames: list[str],
+    *,
+    token: FakeTokenProvider | None = None,
+    extra_results: list[BaseException | FakeWS] | None = None,
+) -> tuple[KrakenPrivateWS, FakeConnector, FakeTokenProvider]:
+    """Build a KrakenPrivateWS wired to a fake connect yielding *frames*."""
+    provider = token or FakeTokenProvider()
+    ws = FakeWS(frames)
+    results: list[BaseException | FakeWS] = [ws, *(extra_results or [])]
+    connector = FakeConnector(results)
+    private = KrakenPrivateWS(
+        provider,
+        connect=connector,
+        sleep=RecordingSleep(),
+    )
+    return private, connector, provider
+
+
+async def _drain(
+    private: KrakenPrivateWS, *, limit: int
+) -> list[Fill | OrderUpdate]:
+    """Collect up to *limit* events, then stop the stream."""
+    out: list[Fill | OrderUpdate] = []
+    async for event in private.events():
+        out.append(event)
+        if len(out) >= limit:
+            private.stop()
+            break
+    return out
+
+
+# --- tests ----------------------------------------------------------------- #
+
+
+async def test_canned_sequence_parses_snapshot_and_trade() -> None:
+    # status + heartbeat (ignored) → snapshot (OrderUpdate) → trade (Fill).
+    private, _, _ = _make_ws(
+        [
+            _STATUS_FRAME,
+            _HEARTBEAT_FRAME,
+            _SUB_ACK_FRAME,
+            _SNAPSHOT_FRAME,
+            _TRADE_UPDATE_FRAME,
+        ]
+    )
+    events = await _drain(private, limit=2)
+
+    # Two domain events emitted: the snapshot order-update, then the trade fill.
+    assert len(events) == 2
+    update, fill = events
+
+    assert isinstance(update, OrderUpdate)
+    assert update.exec_type == "new"
+    assert update.venue_order_id == "OABCDE-12345-FGHIJK"
+    assert update.client_order_id == "1001"
+    assert update.status == "new"
+    assert update.instrument is not None
+    assert update.instrument.symbol == Symbol("BTC", "USD")
+
+    assert isinstance(fill, Fill)
+    # Exact Decimal fields — no float round-trip.
+    assert fill.qty == Decimal("0.5")
+    assert fill.price == Decimal("42000.10")
+    assert fill.fee == Decimal("33.60")
+    assert fill.side is OrderSide.BUY
+    assert fill.instrument.symbol == Symbol("BTC", "USD")
+    # Identity / linkage: exec id → fill_id, userref → client_order_id,
+    # order_id → carried via client_order_id fallback (here userref wins).
+    assert fill.fill_id == "TXXXXX-EXEC1-AAAAAA"
+    assert fill.client_order_id == "1001"
+    # ISO timestamp → ms since epoch (2024-01-02T03:04:05.123Z).
+    assert fill.ts == 1_704_164_645_123
+
+
+async def test_fills_filter_drops_order_updates() -> None:
+    private, _, _ = _make_ws([_SNAPSHOT_FRAME, _TRADE_UPDATE_FRAME])
+    fills: list[Fill] = []
+    async for f in private.fills():
+        fills.append(f)
+        private.stop()
+        break
+    # The snapshot's OrderUpdate is dropped; the first yielded item is the Fill.
+    assert len(fills) == 1
+    assert isinstance(fills[0], Fill)
+    assert fills[0].fill_id == "TXXXXX-EXEC1-AAAAAA"
+
+
+async def test_order_status_update_frame_yields_order_update() -> None:
+    private, _, _ = _make_ws([_ORDER_STATUS_FRAME])
+    events = await _drain(private, limit=1)
+
+    assert len(events) == 1
+    (update,) = events
+    assert isinstance(update, OrderUpdate)
+    assert update.exec_type == "filled"
+    assert update.status == "filled"
+    assert update.venue_order_id == "OABCDE-12345-FGHIJK"
+    assert update.client_order_id == "1001"
+    assert update.instrument is not None
+    assert update.instrument.symbol == Symbol("BTC", "USD")
+
+
+async def test_on_connect_fetches_token_and_subscribe_includes_it() -> None:
+    provider = FakeTokenProvider(token="secret-token-xyz")
+    ws = FakeWS([_TRADE_UPDATE_FRAME])
+    connector = FakeConnector([ws])
+    private = KrakenPrivateWS(
+        provider, connect=connector, sleep=RecordingSleep()
+    )
+
+    await _drain(private, limit=1)
+
+    # The token provider was awaited exactly once for the single connect.
+    assert provider.calls == 1
+    # Exactly one subscribe frame was sent, carrying the token + executions chan.
+    assert len(ws.sent) == 1
+    sub = json.loads(ws.sent[0])
+    assert sub["method"] == "subscribe"
+    assert sub["params"]["channel"] == "executions"
+    assert sub["params"]["token"] == "secret-token-xyz"
+    assert sub["params"]["snap_trades"] is True
+    assert sub["params"]["snap_orders"] is True
+    # The auth endpoint URL was used.
+    assert connector.urls == ["wss://ws-auth.kraken.com/v2"]
+
+
+async def test_reconnect_refetches_token_and_resubscribes() -> None:
+    # First connect drops after one frame; reconnect yields the trade. on_connect
+    # must re-run: token re-fetched, subscribe re-sent (self-heal).
+    provider = FakeTokenProvider(token="tok")
+    ws1 = FakeWS([_SNAPSHOT_FRAME])
+    ws2 = FakeWS([_TRADE_UPDATE_FRAME])
+    connector = FakeConnector([ws1, ConnectionError("drop"), ws2])
+    private = KrakenPrivateWS(
+        provider, connect=connector, sleep=RecordingSleep()
+    )
+
+    events = await _drain(private, limit=2)
+
+    # One OrderUpdate (first connect) + one Fill (after reconnect).
+    assert isinstance(events[0], OrderUpdate)
+    assert isinstance(events[1], Fill)
+    # Token fetched once per successful connect (two connects → two fetches).
+    assert provider.calls == 2
+    # Both sockets received a subscribe carrying the token (re-subscribe).
+    assert len(ws1.sent) == 1
+    assert len(ws2.sent) == 1
+    assert json.loads(ws1.sent[0])["params"]["token"] == "tok"
+    assert json.loads(ws2.sent[0])["params"]["token"] == "tok"
+
+
+async def test_heartbeat_and_status_frames_emit_no_fill() -> None:
+    # No executions frame at all → no events. The fake stops the stream once its
+    # frames drain so the reconnect loop terminates.
+    provider = FakeTokenProvider()
+    private = KrakenPrivateWS(
+        provider, connect=FakeConnector([]), sleep=RecordingSleep()
+    )
+    ws = FakeWS(
+        [_STATUS_FRAME, _HEARTBEAT_FRAME, _SUB_ACK_FRAME],
+        on_exhaust=private.stop,
+    )
+    private._connect = FakeConnector([ws])  # type: ignore[attr-defined]
+
+    events: list[Fill | OrderUpdate] = []
+    async for event in private.events():
+        events.append(event)
+    assert events == []
+
+
+async def test_rejected_subscription_raises_broker_error() -> None:
+    reject = json.dumps(
+        {
+            "method": "subscribe",
+            "success": False,
+            "error": "EAuth:Invalid token",
+        }
+    )
+    private, _, _ = _make_ws([reject])
+    with pytest.raises(BrokerError, match="subscription rejected"):
+        async for _ in private.events():
+            pass
+
+
+async def test_fee_falls_back_to_scalar_fee_field() -> None:
+    # A trade frame whose fee is a scalar ``fee`` (not a ``fees`` list).
+    frame = json.dumps(
+        {
+            "channel": "executions",
+            "type": "update",
+            "data": [
+                {
+                    "exec_type": "trade",
+                    "exec_id": "EXEC-SCALAR",
+                    "order_id": "O-1",
+                    "symbol": "ETH/USD",
+                    "side": "sell",
+                    "last_qty": 2,
+                    "last_price": 2500,
+                    "fee": 5.0,
+                    "timestamp": "2024-01-02T03:04:05.000000Z",
+                }
+            ],
+        }
+    )
+    private, _, _ = _make_ws([frame])
+    events = await _drain(private, limit=1)
+    (fill,) = events
+    assert isinstance(fill, Fill)
+    assert fill.fee == Decimal("5.0")
+    assert fill.side is OrderSide.SELL
+    assert fill.instrument.symbol == Symbol("ETH", "USD")
+    # No userref/cl_ord_id → client_order_id falls back to the venue order id.
+    assert fill.client_order_id == "O-1"
+
+
+async def test_from_broker_builds_token_provider_from_signed_rest() -> None:
+    # The default provider routes through the broker's signed private REST. We
+    # stub _private_post so no real I/O / key is needed, and assert it is the
+    # GetWebSocketsToken endpoint that is called and its token forwarded.
+    calls: list[str] = []
+
+    class FakeBroker:
+        async def _private_post(
+            self, endpoint: str, data: dict[str, Any]
+        ) -> dict[str, Any]:
+            calls.append(endpoint)
+            return {"token": "from-rest-token", "expires": 900}
+
+    ws = FakeWS([_TRADE_UPDATE_FRAME])
+    connector = FakeConnector([ws])
+    private = KrakenPrivateWS.from_broker(
+        FakeBroker(),  # type: ignore[arg-type]
+        connect=connector,
+        sleep=RecordingSleep(),
+    )
+
+    await _drain(private, limit=1)
+
+    assert calls == ["GetWebSocketsToken"]
+    assert json.loads(ws.sent[0])["params"]["token"] == "from-rest-token"


### PR DESCRIPTION
## Summary
- **Final leaf of E3**: `trading_bot/brokers/kraken_ws.py` — `KrakenPrivateWS`.
- Streams Kraken v2 private `executions` on `transport.WebSocketBase`, parsing into domain `Fill`s (trade execs) + `OrderUpdate`s. Token-auth via `on_connect` (self-heals on reconnect).
- Closes E3 — the Foundation block (E1+E2+E3) is complete; `07-roadmap.md` E3 line removed, `06-status.md` updated.

## Why
- Kraken's private WS isn't per-frame signed: a short-lived WS token (private REST `GetWebSocketsToken`, signed) is presented in the subscribe; `on_connect` re-fetches on reconnect. The `token_provider` seam keeps it offline-testable. See `doc/dev/03-decisions.md`.

## Posture (per decision)
- **No API key**: token fetch + frame parsing verified against realistic canned v2 frames (mocks). Live private connection **deferred** until a key is provided (public WS already proven in E2). Tokens never logged.

## Changes
- `brokers/kraken_ws.py` (`KrakenPrivateWS`, `OrderUpdate`) + export; `tests/brokers/test_kraken_ws.py` (9 tests).

## Changelog
Added under [Unreleased]:
- `brokers.KrakenPrivateWS` — Kraken v2 private-WS executions parsing into domain Fills / order updates.

## Test plan
- [x] `pytest` (254 passed, 6 skipped)
- [x] `ruff` + `mypy` clean
- [ ] CI green