### PR TITLE
chore: dev venv (fynance/dccd) + venv-wired workflow

### DIFF
--- a/.claude/workflow.json
+++ b/.claude/workflow.json
@@ -7,7 +7,7 @@
   "changelog": "CHANGELOG.md",
   "plans_dir": "doc/dev/plans",
   "plans_archive": "doc/dev/_archive/plans",
-  "test_cmd": "pytest",
-  "lint_cmd": "ruff check trading_bot/",
+  "test_cmd": ".venv/bin/python -m pytest",
+  "lint_cmd": ".venv/bin/ruff check trading_bot/",
   "docs_src": "doc/source"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,13 @@ from PyPI for the integration code (see Dependencies).
 ## Commands
 
 ```bash
-# Dev install (Python 3.11+)
+# Dev env (Python 3.11+) — use a project venv (.venv/, gitignored) so the triptych
+# deps are present. Without fynance the domain/performance KPI tests SKIP; without
+# dccd the E5+ data-feed tests skip.
+python -m venv .venv && . .venv/bin/activate
 pip install -e ".[dev]"
-
-# Add the triptych deps (fynance from PyPI; dccd editable from its repo)
-pip install -e ".[dev,triptych]"
-pip install -e ../Download_Crypto_Currencies_Data   # dccd (not on PyPI)
+pip install -e ../Fynance                            # fynance — enables the KPI tests
+pip install -e ../Download_Crypto_Currencies_Data    # dccd — market data (E5+)
 
 # Run the full unit suite (legacy excluded; network E2E excluded by default)
 pytest


### PR DESCRIPTION
Sets up a reproducible dev environment so the triptych deps are present — fixing the
KPI tests that were *skipping* (no fynance) in the bare interpreter.

- `CLAUDE.md` Commands: documents the project `.venv/` and installing `fynance`
  (enables the `domain/performance` KPI tests) + `dccd` (market data, E5+) editable.
- `.claude/workflow.json`: `test_cmd`/`lint_cmd` now use `.venv/bin/...` so the
  workflow's gates run against the full env (fynance present → KPI parity actually runs).

Verified locally: `.venv` with `trading_bot[dev]` + `fynance` + `dccd` editable →
**260 passed, 0 skipped** (was 254 passed, 6 skipped); ruff + mypy clean.