### PR TITLE
docs: plan execution-engine (E4)

### DIFF
--- a/doc/dev/plans/execution-engine/00-plan.md
+++ b/doc/dev/plans/execution-engine/00-plan.md
@@ -1,0 +1,53 @@
+---
+plan: execution-engine
+kind: global
+status: planning
+roadmap: "- [ ] **E4 — Order router + PaperBroker.** Idempotent submit (client-order-id), routing, reconciliation; `PaperBroker` simulation behind the same port; `PositionTracker` from confirmed fills."
+release_on_done: false
+---
+
+# E4 — Execution engine
+
+## Goal
+
+Open `trading_bot/application/` — the engine that turns intent into managed orders.
+A small **kernel** (`AppConfig` + async `EventBus`), a **`PaperBroker`** (in-process
+fill simulation behind the E3 `Broker` port — the default), an **`OrderRouter`**
+(idempotent submit, drives the domain `Order` state machine, emits events), a
+**`PositionTracker`** (net positions from confirmed fills), and **reconciliation**
+(converge local state with the broker on startup/reconnect). Mirrors dccd's
+`application/` (`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/application/`).
+
+**Invariants** (from `CLAUDE.md`): idempotent submit (client-order-id), reconcile-
+don't-assume, fills are the PnL truth, all money `Decimal`. Everything is verifiable
+**in-process** (PaperBroker) — no network/key needed.
+
+## Decomposition
+
+1. **app-kernel** — `application/config.py` (`AppConfig` pydantic) + `events.py` (async `EventBus`).
+2. **paper-broker** — `brokers/paper.py` `PaperBroker` (fill simulation, the default broker).
+3. **order-router** — `application/order_router.py` (idempotent submit, drives Order, emits events).
+4. **position-tracker** — `application/position_tracker.py` (positions from fills).
+5. **reconciliation** — `application/reconcile.py` (converge local state with the broker).
+
+## Leaf checklist
+
+- [ ] 01 app-kernel — feat/app-kernel — medium
+- [ ] 02 paper-broker — feat/paper-broker — medium
+- [ ] 03 order-router — feat/order-router — high (depends on 01, 02)
+- [ ] 04 position-tracker — feat/position-tracker — medium (depends on 03)
+- [ ] 05 reconciliation — feat/reconciliation — high (depends on 03, 04)
+
+## Dependencies
+
+- 03 depends on 01 + 02; 04 depends on 03; 05 depends on 03 + 04.
+- 01 and 02 are independent (run serially, the safe default).
+
+## Done criteria
+
+- `application/` exposes the kernel, router, tracker, reconciliation; `PaperBroker`
+  in `brokers/`. `ruff`/`mypy`/`pytest` green (via `.venv`).
+- Idempotent submit proven (duplicate client-order-id → one broker order); a routed
+  order flows order→fill→position end-to-end through the PaperBroker; reconciliation
+  converges a diverged local state to the broker with no lost/duplicated orders.
+- Last leaf (05) removes the E4 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/execution-engine/01-app-kernel.md
+++ b/doc/dev/plans/execution-engine/01-app-kernel.md
@@ -1,0 +1,61 @@
+---
+plan: execution-engine/01-app-kernel
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/app-kernel
+pr: ""
+---
+
+# Application kernel — AppConfig + EventBus
+
+## Goal
+
+The cross-cutting glue `application/` opens with: a pydantic **`AppConfig`** (the
+engine's declared shape) and an async **`EventBus`** (pub/sub fan-out the router /
+tracker / future UI consume). Mirrors dccd's `application/config.py` + `events.py`.
+
+## Files to change
+
+- `trading_bot/application/__init__.py` — new; export `AppConfig`, `EventBus`, event types.
+- `trading_bot/application/config.py` — new.
+- `trading_bot/application/events.py` — new.
+- `trading_bot/tests/application/__init__.py` — new (empty).
+- `trading_bot/tests/application/test_config.py`, `test_events.py` — new.
+
+## Steps
+
+1. Read dccd's `application/config.py` + `events.py`.
+2. **config.py** (`pydantic` v2): `AppConfig` with `mode: Literal["paper","live"] = "paper"`
+   (default paper — invariant), `brokers: list[BrokerConfig]` (`name`, `exchange`),
+   `strategies: list[StrategyConfig]` (skeleton: `name`, `instrument`/`symbol`),
+   `risk: RiskConfig` (skeleton: optional `max_position`/`max_order`/`max_daily_loss`
+   as `Decimal`, non-negative). YAML-loadable (`from_yaml(path)` / `model_validate`).
+   Validators: reject unknown mode; non-negative risk limits; non-empty broker names.
+3. **events.py**: a small `Event` base + `OrderEvent`, `FillEvent`, `LogEvent`
+   (carry domain objects / ids; money `Decimal`). `EventBus`: `subscribe(handler)`,
+   `unsubscribe`, `emit(event)` (sync handlers), and **async fan-out** `add_queue()`
+   /`remove_queue()` returning `asyncio.Queue` (mirror dccd) so multiple async
+   consumers can read concurrently.
+
+## Tests
+
+- `AppConfig`: default `mode=="paper"`; load from a realistic YAML dict; reject an
+  unknown mode; negative risk limit raises.
+- `EventBus`: `emit` reaches every subscriber; `add_queue` consumers each receive
+  the event (fan-out); `unsubscribe`/`remove_queue` stop delivery.
+- Event types carry their payload (Decimal money intact).
+
+## Verification on real data
+
+In-process (no I/O). Build an `AppConfig` from a realistic YAML and assert the parsed
+shape; emit a realistic `FillEvent` to two subscribers + two queues and assert all
+four receive it. Run gates via **`.venv`**: `.venv/bin/python -m pytest trading_bot/tests/application -q`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application` kernel — `AppConfig` (pydantic) + async `EventBus`."
+- ADR: the event taxonomy + paper-default mode, if worth noting.
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/execution-engine/02-paper-broker.md
+++ b/doc/dev/plans/execution-engine/02-paper-broker.md
@@ -1,0 +1,60 @@
+---
+plan: execution-engine/02-paper-broker
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/paper-broker
+pr: ""
+---
+
+# PaperBroker — in-process fill simulation
+
+## Goal
+
+`PaperBroker` implements the E3 `Broker` port entirely in-process: it accepts
+orders, simulates fills, and tracks balances/open-orders/fills — the **default**
+broker so the whole engine runs without touching a venue. Pure-ish (no network),
+deterministic, money `Decimal`.
+
+## Files to change
+
+- `trading_bot/brokers/paper.py` — new; `PaperBroker(Broker)`.
+- `trading_bot/brokers/__init__.py` — export `PaperBroker`.
+- `trading_bot/tests/brokers/test_paper.py` — new.
+
+## Steps
+
+1. Read `brokers/base.py` (the `Broker` port + `Capability`) and the domain
+   `Order`/`Fill`/`Position`/`Money`.
+2. `PaperBroker(*, prices=None, fee_bps=money("10"), fill_model="immediate", starting_balances=None)`:
+   - `place_order(order)`: assign a synthetic `venue_order_id`; under `fill_model`
+     `"immediate"` fully fill at the order's limit price (or an injected mark price
+     for market orders) producing a `Fill` (with fee = `price*qty*fee_bps/10000`);
+     support a `"partial"` model that fills in chunks. Record the fill + update
+     balances; keep unfilled orders in `open_orders`.
+   - `cancel_order(venue_order_id)`, `open_orders()`, `balances()`, `fills(since_ms)`,
+     `ticker(instrument)` (from the injected `prices`), `capabilities()`.
+   - A `set_price(instrument, price)` test hook to drive marks.
+3. Deterministic ids/timestamps (injectable clock/counter seams) so tests are exact.
+
+## Tests
+
+- Immediate-fill limit order → one `Fill` at the limit price; `open_orders` empty;
+  balances move by qty/price ± fee (exact Decimal).
+- Market order fills at the injected mark price.
+- Partial-fill model → multiple fills summing to qty; order closes when full.
+- `cancel_order` removes an open order; fee applied as configured.
+
+## Verification on real data
+
+In-process simulation **is** the engine's "real data". Run a realistic order sequence
+(buy, partial, sell-to-flat) through `PaperBroker`, read back `fills()`/`balances()`,
+and assert they match hand-computed Decimal expectations. Gates via **`.venv`**.
+
+## Closeout
+
+- CHANGELOG (Added): "`brokers.PaperBroker` — in-process fill simulation (the default broker)."
+- ADR: the fill model(s) + fee model, if worth noting.
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/execution-engine/03-order-router.md
+++ b/doc/dev/plans/execution-engine/03-order-router.md
@@ -1,0 +1,61 @@
+---
+plan: execution-engine/03-order-router
+kind: leaf
+status: planned
+complexity: high
+depends: [01, 02]
+parallel: false
+branch: feat/order-router
+pr: ""
+---
+
+# OrderRouter — idempotent submit + state-machine driving
+
+## Goal
+
+`OrderRouter` is the engine's write path: it submits domain `Order`s to a `Broker`
+**idempotently** (client-order-id dedup), drives the order through its state machine
+from the broker's responses, and emits events on the `EventBus`. The safety core of
+execution.
+
+## Files to change
+
+- `trading_bot/application/order_router.py` — new; `OrderRouter`.
+- `trading_bot/application/__init__.py` — export `OrderRouter`.
+- `trading_bot/tests/application/test_order_router.py` — new.
+
+## Steps
+
+1. Read `application/events.py` (EventBus + OrderEvent), `brokers/base.py`, domain
+   `Order`/`OrderStatus`/`errors`.
+2. `OrderRouter(broker, event_bus)`:
+   - `async submit(order: Order) -> Order`: **idempotency** — if `order.client_order_id`
+     was already submitted, return the existing tracked order and do **not** call the
+     broker again (dedup map keyed by client-order-id). Otherwise `order.submit()`,
+     `venue_id = await broker.place_order(order)`, `order.open(venue_id)`, track it,
+     emit an `OrderEvent`. On `BrokerError`/`OrderError` → `order.reject(reason)` +
+     emit, and surface a clear error.
+   - `async cancel(order_or_id)`: `await broker.cancel_order(...)`, `order.cancel()`, emit.
+   - `apply_fill(...)` / consume broker fills to advance the order (or leave fill
+     ingestion to the tracker — document the split).
+   - Keep money `Decimal`; never lose/duplicate an order.
+
+## Tests
+
+- **Idempotent submit**: submitting the same `client_order_id` twice → broker
+  `place_order` called **once**; second call returns the same tracked order.
+- Submit drives `Order` `NEW→SUBMITTED→OPEN` (venue id set) and emits one `OrderEvent`.
+- A `BrokerError` on submit → `Order` `REJECTED` + a reject event; the error surfaces.
+- `cancel` cancels on the broker and transitions the order.
+
+## Verification on real data
+
+Route a realistic order sequence through `OrderRouter` → **`PaperBroker`** (leaf 02);
+assert (a) a duplicate client-order-id produces exactly one paper order/fill, and
+(b) the emitted events match the order lifecycle. Gates via **`.venv`**.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.OrderRouter` — idempotent order submission + lifecycle driving + events."
+- ADR: the idempotency mechanism (client-order-id dedup) + where fill ingestion lives.
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/execution-engine/04-position-tracker.md
+++ b/doc/dev/plans/execution-engine/04-position-tracker.md
@@ -1,0 +1,55 @@
+---
+plan: execution-engine/04-position-tracker
+kind: leaf
+status: planned
+complexity: medium
+depends: [03]
+parallel: false
+branch: feat/position-tracker
+pr: ""
+---
+
+# PositionTracker — live positions from confirmed fills
+
+## Goal
+
+`PositionTracker` maintains the live net `Position` per instrument by consuming
+broker-confirmed **fills** (the PnL source of truth), reusing
+`domain.position.Position.from_fills`. Subscribes to the `EventBus`.
+
+## Files to change
+
+- `trading_bot/application/position_tracker.py` — new; `PositionTracker`.
+- `trading_bot/application/__init__.py` — export `PositionTracker`.
+- `trading_bot/tests/application/test_position_tracker.py` — new.
+
+## Steps
+
+1. Read `domain/position.py` (`Position.from_fills`), `domain/fill.py`, and
+   `application/events.py` (`FillEvent`).
+2. `PositionTracker(event_bus=None)`:
+   - `apply(fill: Fill)` — fold the fill into the running per-instrument position
+     (keep an ordered fill list per instrument and recompute via `Position.from_fills`,
+     or maintain an incremental fold consistent with it).
+   - `position(instrument) -> Position | None`, `all_positions() -> dict[..., Position]`.
+   - If given an `EventBus`, subscribe to `FillEvent` and `apply` automatically.
+3. Money `Decimal`; one instrument per `Position`; deterministic in fill order.
+
+## Tests
+
+- Feed fills (buy, add, partial close, **flip**) → `position(instrument)` matches
+  `Position.from_fills` on the same sequence exactly (net_qty, avg, realised_pnl, fees).
+- Subscribed to an `EventBus`: emitting `FillEvent`s updates the tracked positions.
+- Multiple instruments tracked independently.
+
+## Verification on real data
+
+Drive `PaperBroker` fills (via `OrderRouter`) onto the `EventBus`; assert the
+`PositionTracker`'s positions equal `Position.from_fills` over the same fills.
+Gates via **`.venv`**.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.PositionTracker` — live positions from confirmed fills."
+- ADR: none (delegates to `domain.Position`) unless the incremental fold is non-trivial.
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/execution-engine/05-reconciliation.md
+++ b/doc/dev/plans/execution-engine/05-reconciliation.md
@@ -1,0 +1,60 @@
+---
+plan: execution-engine/05-reconciliation
+kind: leaf
+status: planned
+complexity: high
+depends: [03, 04]
+parallel: false
+branch: feat/reconciliation
+pr: ""
+---
+
+# Reconciliation — converge local state with the broker
+
+## Goal
+
+On startup and after any disconnect, **reconcile-don't-assume**: refetch the
+broker's open orders, balances and fills, and converge the engine's local state
+(tracked orders + positions) to the venue's truth — never leaving a duplicated or
+lost order. The last E4 leaf — closes the E4 roadmap line.
+
+## Files to change
+
+- `trading_bot/application/reconcile.py` — new; `reconcile(...)` (+ a small `ReconResult`).
+- `trading_bot/application/__init__.py` — export it.
+- `trading_bot/tests/application/test_reconcile.py` — new.
+- `doc/dev/07-roadmap.md` — remove the E4 line. `doc/dev/06-status.md` — mark E4 done.
+
+## Steps
+
+1. Read `OrderRouter` (its tracked-order map), `PositionTracker`, `brokers/base.py`.
+2. `async reconcile(broker, router, tracker) -> ReconResult`:
+   - Fetch `broker.open_orders()`, `broker.balances()`, `broker.fills(since)`.
+   - **Orders**: adopt the venue's open orders as truth; a locally-tracked order the
+     venue doesn't know about (and that isn't terminal) is flagged/closed per a clear
+     rule (document it); a venue order the engine doesn't track is ingested.
+   - **Positions**: rebuild the `PositionTracker` from the broker's confirmed fills
+     (fills are the truth) so local positions equal the venue's.
+   - Return a `ReconResult` summarising what was adopted/closed/ingested (and emit a
+     `LogEvent`).
+3. Idempotent: running `reconcile` twice with no venue change is a no-op.
+
+## Tests
+
+- Local state diverges from a **stub/PaperBroker** (extra local order not on venue;
+  a venue order/fill the engine missed) → after `reconcile`, local orders + positions
+  match the broker exactly; `ReconResult` reports the diffs.
+- Positions are rebuilt from broker fills (match `Position.from_fills`).
+- Running `reconcile` twice is a no-op the second time.
+
+## Verification on real data
+
+Simulate a disconnect: give the `PaperBroker` orders/fills the local engine doesn't
+know about, run `reconcile`, and assert local state **converges** to the broker with
+**no duplicated or lost orders** (the core safety property). Gates via **`.venv`**.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.reconcile` — converge local order/position state with the broker."
+- ADR: the reconciliation rules (orphan-order policy, positions-from-broker-fills, idempotency).
+- Status/roadmap: **remove the E4 line** from `07-roadmap.md`; mark E4 done in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E4 — Order router + PaperBroker** (opens `application/`).

## Goal
The engine that turns intent into managed orders: kernel (`AppConfig` + async `EventBus`),
`PaperBroker` (in-process fill simulation, the default), `OrderRouter` (idempotent submit,
drives the Order state machine, emits events), `PositionTracker` (positions from fills),
and reconciliation (converge local state with the broker). All verifiable in-process — no key/network.

## Leaves
- [ ] 01 app-kernel — feat/app-kernel — medium
- [ ] 02 paper-broker — feat/paper-broker — medium
- [ ] 03 order-router — feat/order-router — high (depends on 01, 02)
- [ ] 04 position-tracker — feat/position-tracker — medium (depends on 03)
- [ ] 05 reconciliation — feat/reconciliation — high (depends on 03, 04)

Invariants: idempotent submit, reconcile-don't-assume, fills are PnL truth, money Decimal.
After merge: `/execute-leaf execution-engine next`.