### PR TITLE
feat: application kernel (AppConfig + EventBus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `brokers.KrakenPrivateWS` — Kraken v2 private-WS `executions` parsing into domain
   `Fill`s / order updates (token-auth, mock-verified; live gated on a key).
   Completes the **E3 Kraken adapter**. (#19)
+- `application` kernel — `AppConfig` (pydantic v2, paper-default) + async `EventBus`
+  (fan-out queues + sync subscribers; `OrderEvent`/`FillEvent`/`LogEvent`). (#22)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,22 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-21 Application kernel: paper-default config + fan-out EventBus (PR #22)
+
+**Decision.** `application/config.py` `AppConfig` is pydantic v2 with
+`mode: Literal["paper","live"] = "paper"` — a fresh/empty config never trades real
+money; going live is an explicit edit. `application/events.py` `EventBus` carries
+frozen `OrderEvent`/`FillEvent`/`LogEvent` (domain objects by reference, so `Decimal`
+money stays intact) to a *set* of per-consumer async queues (fan-out, not steal) plus
+sync subscribers; `emit` never blocks or raises — bad handlers are logged+swallowed,
+full queues drop.
+
+**Why.** Paper-by-default is the live-trading safety invariant made structural.
+Fan-out lets the router, position tracker and a future UI consume the same stream
+independently; a non-blocking `emit` keeps a slow consumer from stalling the engine.
+
+---
+
 ### 2026-06-20 Kraken private WS: token-auth via on_connect, mock-verified (PR #19)
 
 **Decision.** `brokers/kraken_ws.py` `KrakenPrivateWS` streams Kraken v2 `executions`

--- a/doc/dev/plans/execution-engine/00-plan.md
+++ b/doc/dev/plans/execution-engine/00-plan.md
@@ -32,7 +32,7 @@ don't-assume, fills are the PnL truth, all money `Decimal`. Everything is verifi
 
 ## Leaf checklist
 
-- [ ] 01 app-kernel — feat/app-kernel — medium
+- [x] 01 app-kernel — feat/app-kernel — medium
 - [ ] 02 paper-broker — feat/paper-broker — medium
 - [ ] 03 order-router — feat/order-router — high (depends on 01, 02)
 - [ ] 04 position-tracker — feat/position-tracker — medium (depends on 03)

--- a/doc/dev/plans/execution-engine/01-app-kernel.md
+++ b/doc/dev/plans/execution-engine/01-app-kernel.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/app-kernel
-pr: ""
+pr: "#22"
 ---
 
 # Application kernel — AppConfig + EventBus

--- a/doc/dev/plans/execution-engine/01-app-kernel.md
+++ b/doc/dev/plans/execution-engine/01-app-kernel.md
@@ -1,7 +1,7 @@
 ---
 plan: execution-engine/01-app-kernel
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -1,0 +1,51 @@
+"""trading_bot application layer — the engine: use-cases + cross-cutting glue.
+
+This package is the orchestration layer of the hexagon. It may import the inner
+layers (:mod:`trading_bot.domain`, :mod:`trading_bot.transport`,
+:mod:`trading_bot.brokers`) and is itself imported by the outer
+``interfaces`` layer (CLI / API, not yet built). It opens with two
+cross-cutting primitives:
+
+* config — the pydantic :class:`~trading_bot.application.config.AppConfig`
+  (with :class:`~trading_bot.application.config.BrokerConfig`,
+  :class:`~trading_bot.application.config.StrategyConfig` and
+  :class:`~trading_bot.application.config.RiskConfig`): the engine's declared,
+  YAML-loadable shape. ``mode`` defaults to ``"paper"`` — a fresh config never
+  trades real money by accident;
+* events — the async :class:`~trading_bot.application.events.EventBus` and its
+  event taxonomy (:class:`~trading_bot.application.events.OrderEvent`,
+  :class:`~trading_bot.application.events.FillEvent`,
+  :class:`~trading_bot.application.events.LogEvent`): the pub/sub fan-out the
+  router, the position tracker and a future UI consume. Events carry domain
+  objects, so money stays :class:`~decimal.Decimal` end to end.
+"""
+
+from __future__ import annotations
+
+from trading_bot.application.config import (
+    AppConfig,
+    BrokerConfig,
+    RiskConfig,
+    StrategyConfig,
+)
+from trading_bot.application.events import (
+    Event,
+    EventBus,
+    FillEvent,
+    LogEvent,
+    OrderEvent,
+)
+
+__all__ = [
+    # config
+    "AppConfig",
+    "BrokerConfig",
+    "StrategyConfig",
+    "RiskConfig",
+    # events
+    "EventBus",
+    "Event",
+    "OrderEvent",
+    "FillEvent",
+    "LogEvent",
+]

--- a/trading_bot/application/config.py
+++ b/trading_bot/application/config.py
@@ -1,0 +1,192 @@
+"""Application configuration — the engine's declared shape (pydantic v2).
+
+:class:`AppConfig` is the top-level, YAML-loadable declaration of *what the
+engine should run*: which brokers to wire, which strategies to drive, and the
+risk limits to enforce. It mirrors dccd's ``application/config.py`` (a pydantic
+``AppConfig`` with sub-models + validators, loaded from YAML) but speaks this
+package's vocabulary.
+
+Design choices (carried into the ADR):
+
+* **Paper by default.** ``mode`` defaults to ``"paper"`` — a fresh config never
+  trades real money by accident. Switching to ``"live"`` is always an explicit,
+  deliberate edit. ``mode`` is a ``Literal["paper", "live"]`` so any other value
+  is rejected at validation time.
+* **Money stays exact.** Risk limits (:class:`RiskConfig`) are
+  :class:`~decimal.Decimal`, parsed from ``str``/``int`` without ever touching
+  ``float`` — pydantic builds a ``Decimal`` directly from the YAML scalar, so a
+  value like ``0.1`` keeps its exact decimal meaning.
+* **Skeletons that grow.** :class:`StrategyConfig` and :class:`RiskConfig` are
+  intentionally minimal here (just enough to parse a realistic file); they gain
+  fields in later leaves (E5 / E8). :class:`BrokerConfig` carries only the
+  ``name`` (logical id) and ``exchange`` (venue key) needed to resolve an
+  adapter.
+
+This module is the only place the application layer reads YAML; everything
+downstream consumes a validated :class:`AppConfig`.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from decimal import Decimal
+from typing import Literal
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+__all__ = [
+    "BrokerConfig",
+    "StrategyConfig",
+    "RiskConfig",
+    "AppConfig",
+]
+
+
+class BrokerConfig(BaseModel):
+    """One broker the engine should wire up.
+
+    Parameters
+    ----------
+    name : str
+        Logical, config-unique id for this broker instance (how strategies and
+        the router refer to it). Must be non-empty.
+    exchange : str
+        The venue key the broker adapter is resolved by (e.g. ``"kraken"``).
+        Must be non-empty.
+
+    """
+
+    name: str
+    exchange: str
+
+    @field_validator("name", "exchange")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        """Reject blank broker ``name`` / ``exchange`` (whitespace-only too)."""
+        if not v or not v.strip():
+            raise ValueError("must be a non-empty string")
+        return v
+
+
+class StrategyConfig(BaseModel):
+    """One strategy the engine should drive (skeleton — grows in E5/E8).
+
+    Parameters
+    ----------
+    name : str
+        Logical, config-unique id for the strategy instance. Must be non-empty.
+    symbol : str
+        The canonical pair the strategy trades, ``BASE/QUOTE`` (e.g.
+        ``"BTC/USD"``). Kept as a plain string here; later leaves resolve it to
+        a :class:`~trading_bot.domain.instrument.Symbol`. Must be non-empty.
+
+    """
+
+    name: str
+    symbol: str
+
+    @field_validator("name", "symbol")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        """Reject blank strategy ``name`` / ``symbol``."""
+        if not v or not v.strip():
+            raise ValueError("must be a non-empty string")
+        return v
+
+
+class RiskConfig(BaseModel):
+    """Engine-wide risk limits (skeleton — grows in E8).
+
+    Every limit is optional (``None`` = unconstrained) and, when set, a
+    non-negative :class:`~decimal.Decimal`. Values parse exactly from a YAML
+    scalar (``str``/``int``) without going through ``float``.
+
+    Parameters
+    ----------
+    max_position : Decimal, optional
+        Largest absolute net position (base units) any instrument may hold.
+    max_order : Decimal, optional
+        Largest size (base units) a single order may request.
+    max_daily_loss : Decimal, optional
+        Loss (quote units) at which trading halts for the day.
+
+    """
+
+    max_position: Decimal | None = None
+    max_order: Decimal | None = None
+    max_daily_loss: Decimal | None = None
+
+    @field_validator("max_position", "max_order", "max_daily_loss")
+    @classmethod
+    def _non_negative(cls, v: Decimal | None) -> Decimal | None:
+        """Reject a negative risk limit (``None`` and ``0`` are allowed)."""
+        if v is not None and v < 0:
+            raise ValueError(f"risk limit must be non-negative, got {v}")
+        return v
+
+
+class AppConfig(BaseModel):
+    """Top-level engine configuration — brokers, strategies and risk.
+
+    The declared shape of an engine run. Build one from a dict with
+    :meth:`pydantic.BaseModel.model_validate` or from a YAML file with
+    :meth:`from_yaml`; both validate every field and sub-model.
+
+    Parameters
+    ----------
+    mode : {"paper", "live"}, optional
+        Execution mode. Defaults to ``"paper"`` so a fresh config never trades
+        real money by accident; ``"live"`` must be set deliberately. Any other
+        value is rejected.
+    brokers : list of BrokerConfig, optional
+        The brokers to wire up. Empty by default.
+    strategies : list of StrategyConfig, optional
+        The strategies to drive. Empty by default.
+    risk : RiskConfig, optional
+        Engine-wide risk limits. Defaults to all-unconstrained.
+
+    Examples
+    --------
+    >>> cfg = AppConfig.model_validate({
+    ...     "mode": "paper",
+    ...     "brokers": [{"name": "kraken-main", "exchange": "kraken"}],
+    ...     "strategies": [{"name": "ma-cross", "symbol": "BTC/USD"}],
+    ...     "risk": {"max_order": "0.5"},
+    ... })
+    >>> cfg.mode
+    'paper'
+    >>> cfg.risk.max_order
+    Decimal('0.5')
+
+    """
+
+    mode: Literal["paper", "live"] = "paper"
+    brokers: list[BrokerConfig] = Field(default_factory=list)
+    strategies: list[StrategyConfig] = Field(default_factory=list)
+    risk: RiskConfig = Field(default_factory=RiskConfig)
+
+    @classmethod
+    def from_yaml(cls, path: str | pathlib.Path) -> AppConfig:
+        """Load and validate a YAML file into an :class:`AppConfig`.
+
+        Parameters
+        ----------
+        path : str or pathlib.Path
+            Path to the YAML config file. An empty file is treated as an empty
+            mapping (all defaults).
+
+        Returns
+        -------
+        AppConfig
+            The validated configuration.
+
+        Raises
+        ------
+        pydantic.ValidationError
+            If the parsed document violates any field or sub-model invariant.
+
+        """
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        return cls.model_validate(data)

--- a/trading_bot/application/events.py
+++ b/trading_bot/application/events.py
@@ -1,0 +1,189 @@
+"""Event bus — the engine's pub/sub fan-out for order, fill and log events.
+
+The :class:`EventBus` is the cross-cutting nervous system of the application
+layer: use-cases (the router, the position tracker, future UI) *emit* events
+without knowing who consumes them, and consumers *subscribe* (sync handlers) or
+*drain a queue* (async consumers) without knowing who produced them. It mirrors
+dccd's ``application/events.py`` — synchronous handler dispatch plus an
+async fan-out over a *set* of :class:`asyncio.Queue` so several consumers each
+receive every event.
+
+Design choices (carried into the ADR):
+
+* **Event taxonomy.** Three event types, each a frozen value object carrying
+  domain objects / ids (never a re-encoded copy):
+
+  - :class:`OrderEvent` — an order's lifecycle moved (carries the
+    :class:`~trading_bot.domain.order.Order` aggregate);
+  - :class:`FillEvent` — a venue-confirmed execution landed (carries the
+    immutable :class:`~trading_bot.domain.fill.Fill`, the PnL source of truth);
+  - :class:`LogEvent` — a human-readable line (level + message).
+
+  All money stays :class:`~decimal.Decimal`, because the events carry the domain
+  objects themselves — there is no float round-trip.
+
+* **A *set* of queues, not one.** Each async consumer registers its own queue
+  via :meth:`EventBus.add_queue`; :meth:`EventBus.emit` puts the event on every
+  registered queue. A single shared queue would let the last consumer steal
+  events from the others.
+
+* **emit never blocks and never raises.** Sync handler exceptions are logged and
+  swallowed (one bad subscriber must not break the others). Queue puts are
+  non-blocking (:meth:`asyncio.Queue.put_nowait`); a full queue drops the event
+  (a slow consumer must not stall the producer) — see :meth:`EventBus.emit`.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.order import Order
+
+__all__ = [
+    "Event",
+    "OrderEvent",
+    "FillEvent",
+    "LogEvent",
+    "EventBus",
+]
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True, slots=True)
+class OrderEvent:
+    """An order's lifecycle changed — carries the live :class:`Order` aggregate.
+
+    Parameters
+    ----------
+    order : Order
+        The order whose status just moved. Carried by reference: money fields
+        (``qty``, ``avg_fill_price``, ...) stay :class:`~decimal.Decimal`.
+
+    """
+
+    order: Order
+
+
+@dataclass(frozen=True, slots=True)
+class FillEvent:
+    """A venue-confirmed execution landed — carries the immutable :class:`Fill`.
+
+    Parameters
+    ----------
+    fill : Fill
+        The execution record (the PnL source of truth). Its ``qty``, ``price``
+        and ``fee`` are :class:`~decimal.Decimal`, intact.
+
+    """
+
+    fill: Fill
+
+
+@dataclass(frozen=True, slots=True)
+class LogEvent:
+    """A human-readable log line emitted by a use-case.
+
+    Parameters
+    ----------
+    message : str
+        The log message.
+    level : str, optional
+        Severity, lower-case (``"info"`` by default, e.g. ``"warning"``,
+        ``"error"``).
+
+    """
+
+    message: str
+    level: str = "info"
+
+
+#: The union of every event the bus carries.
+Event = OrderEvent | FillEvent | LogEvent
+
+#: A synchronous subscriber: called with each emitted event.
+Handler = Callable[[Event], Any]
+
+
+class EventBus:
+    """Pub/sub bus fanning engine events to handlers and async queues.
+
+    Use-cases :meth:`emit` :class:`OrderEvent` / :class:`FillEvent` /
+    :class:`LogEvent`. Consumers either register a synchronous :meth:`subscribe`
+    handler or, for async consumption, :meth:`add_queue` to get their own
+    :class:`asyncio.Queue` to drain. Every registered handler and queue receives
+    every event.
+
+    Examples
+    --------
+    >>> bus = EventBus()
+    >>> seen = []
+    >>> bus.subscribe(seen.append)
+    >>> bus.emit(LogEvent(message="started"))
+    >>> seen[0].message
+    'started'
+
+    """
+
+    def __init__(self) -> None:
+        """Start with no handlers and no queues."""
+        self._handlers: list[Handler] = []
+        # A *set* of queues so several async consumers (e.g. the position
+        # tracker, a live UI) each receive every event; a single shared queue
+        # would let one consumer steal events from the others.
+        self._queues: set[asyncio.Queue[Event]] = set()
+
+    def subscribe(self, handler: Handler) -> None:
+        """Register a handler called synchronously for every emitted event."""
+        self._handlers.append(handler)
+
+    def unsubscribe(self, handler: Handler) -> None:
+        """Remove a previously registered handler (no-op if not registered)."""
+        self._handlers = [h for h in self._handlers if h != handler]
+
+    def emit(self, event: Event) -> None:
+        """Publish *event* to every handler and every registered queue.
+
+        Never blocks and never propagates: a handler that raises is logged and
+        skipped (one bad subscriber must not break the rest), and a put onto a
+        full queue is dropped (a slow consumer must not stall the producer).
+        """
+        for handler in self._handlers:
+            try:
+                handler(event)
+            except Exception:
+                logger.exception("EventBus handler error")
+        for queue in self._queues:
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                logger.warning("EventBus queue full; dropping event %r", event)
+
+    def add_queue(self, maxsize: int = 1000) -> asyncio.Queue[Event]:
+        """Register and return a fresh queue that receives every event.
+
+        Parameters
+        ----------
+        maxsize : int, optional
+            Bound on the queue. When full, :meth:`emit` drops new events for
+            this queue rather than blocking. ``0`` means unbounded.
+
+        Returns
+        -------
+        asyncio.Queue
+            The newly registered queue. Pass it to :meth:`remove_queue` when the
+            consumer disconnects.
+
+        """
+        queue: asyncio.Queue[Event] = asyncio.Queue(maxsize=maxsize)
+        self._queues.add(queue)
+        return queue
+
+    def remove_queue(self, queue: asyncio.Queue[Event]) -> None:
+        """Unregister a queue (no-op if it was not registered)."""
+        self._queues.discard(queue)

--- a/trading_bot/tests/application/test_config.py
+++ b/trading_bot/tests/application/test_config.py
@@ -1,0 +1,163 @@
+"""Tests for :class:`AppConfig` and its sub-models.
+
+These prove the engine's declared shape parses and validates as intended:
+``mode`` defaults to ``"paper"`` (the never-trade-by-accident invariant), a
+realistic dict round-trips through ``model_validate``, unknown modes and
+negative risk limits are rejected, blank broker names are rejected, risk limits
+land as exact :class:`~decimal.Decimal`, and :meth:`AppConfig.from_yaml`
+round-trips a small YAML file (via ``tmp_path``).
+"""
+
+from __future__ import annotations
+
+import textwrap
+from decimal import Decimal
+
+import pytest
+from pydantic import ValidationError
+
+from trading_bot.application import (
+    AppConfig,
+    BrokerConfig,
+    RiskConfig,
+    StrategyConfig,
+)
+
+# A realistic config dict reused across the round-trip assertions.
+REALISTIC: dict = {
+    "mode": "live",
+    "brokers": [
+        {"name": "kraken-main", "exchange": "kraken"},
+        {"name": "kraken-backup", "exchange": "kraken"},
+    ],
+    "strategies": [
+        {"name": "ma-cross", "symbol": "BTC/USD"},
+        {"name": "mean-rev", "symbol": "ETH/USD"},
+    ],
+    "risk": {
+        "max_position": "1.5",
+        "max_order": "0.25",
+        "max_daily_loss": "500",
+    },
+}
+
+
+def test_mode_defaults_to_paper() -> None:
+    """An empty config is paper — never trade real money by accident."""
+    cfg = AppConfig()
+    assert cfg.mode == "paper"
+    assert cfg.brokers == []
+    assert cfg.strategies == []
+    assert isinstance(cfg.risk, RiskConfig)
+    assert cfg.risk.max_position is None
+
+
+def test_model_validate_realistic_dict() -> None:
+    """A realistic dict parses into fully-typed sub-models."""
+    cfg = AppConfig.model_validate(REALISTIC)
+
+    assert cfg.mode == "live"
+
+    assert [b.name for b in cfg.brokers] == ["kraken-main", "kraken-backup"]
+    assert all(isinstance(b, BrokerConfig) for b in cfg.brokers)
+    assert cfg.brokers[0].exchange == "kraken"
+
+    assert [s.name for s in cfg.strategies] == ["ma-cross", "mean-rev"]
+    assert all(isinstance(s, StrategyConfig) for s in cfg.strategies)
+    assert cfg.strategies[0].symbol == "BTC/USD"
+
+
+def test_risk_limits_are_exact_decimals() -> None:
+    """Risk limits parse to exact ``Decimal`` (no float error)."""
+    cfg = AppConfig.model_validate(REALISTIC)
+    assert cfg.risk.max_position == Decimal("1.5")
+    assert cfg.risk.max_order == Decimal("0.25")
+    assert cfg.risk.max_daily_loss == Decimal("500")
+    assert all(
+        isinstance(v, Decimal)
+        for v in (
+            cfg.risk.max_position,
+            cfg.risk.max_order,
+            cfg.risk.max_daily_loss,
+        )
+    )
+
+
+def test_decimal_parses_from_number_without_float_error() -> None:
+    """A YAML/JSON number for a risk limit keeps its exact decimal meaning."""
+    cfg = AppConfig.model_validate({"risk": {"max_order": 0.1}})
+    assert cfg.risk.max_order == Decimal("0.1")
+
+
+def test_unknown_mode_raises() -> None:
+    """A mode outside {paper, live} is rejected by the Literal."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate({"mode": "shadow"})
+
+
+def test_negative_risk_limit_raises() -> None:
+    """A negative risk limit is rejected."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate({"risk": {"max_position": "-1"}})
+
+
+def test_zero_risk_limit_allowed() -> None:
+    """Zero is a valid (fully-constraining) risk limit."""
+    cfg = AppConfig.model_validate({"risk": {"max_daily_loss": "0"}})
+    assert cfg.risk.max_daily_loss == Decimal("0")
+
+
+def test_blank_broker_name_raises() -> None:
+    """A blank / whitespace-only broker name is rejected."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(
+            {"brokers": [{"name": "  ", "exchange": "kraken"}]}
+        )
+
+
+def test_blank_strategy_symbol_raises() -> None:
+    """A blank strategy symbol is rejected."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(
+            {"strategies": [{"name": "ma", "symbol": ""}]}
+        )
+
+
+def test_from_yaml_round_trips(tmp_path) -> None:
+    """``from_yaml`` parses a small YAML file into the expected shape."""
+    yaml_text = textwrap.dedent(
+        """\
+        mode: paper
+        brokers:
+          - name: kraken-main
+            exchange: kraken
+        strategies:
+          - name: ma-cross
+            symbol: BTC/USD
+        risk:
+          max_position: "2.0"
+          max_order: "0.5"
+          max_daily_loss: "1000"
+        """
+    )
+    path = tmp_path / "config.yml"
+    path.write_text(yaml_text)
+
+    cfg = AppConfig.from_yaml(path)
+
+    assert cfg.mode == "paper"
+    assert cfg.brokers[0].name == "kraken-main"
+    assert cfg.brokers[0].exchange == "kraken"
+    assert cfg.strategies[0].symbol == "BTC/USD"
+    assert cfg.risk.max_position == Decimal("2.0")
+    assert cfg.risk.max_order == Decimal("0.5")
+    assert cfg.risk.max_daily_loss == Decimal("1000")
+
+
+def test_from_yaml_empty_file_is_all_defaults(tmp_path) -> None:
+    """An empty YAML file yields an all-defaults (paper) config."""
+    path = tmp_path / "empty.yml"
+    path.write_text("")
+    cfg = AppConfig.from_yaml(path)
+    assert cfg.mode == "paper"
+    assert cfg.brokers == []

--- a/trading_bot/tests/application/test_events.py
+++ b/trading_bot/tests/application/test_events.py
@@ -1,0 +1,192 @@
+"""Tests for the event taxonomy and the :class:`EventBus` fan-out.
+
+These prove: each event type carries its payload with ``Decimal`` money intact;
+:meth:`EventBus.emit` reaches every subscribed handler; two :meth:`add_queue`
+consumers each receive every event (fan-out, not steal); :meth:`unsubscribe` and
+:meth:`remove_queue` stop delivery; a handler that raises does not break the
+others; and a full queue drops rather than blocking. Queue tests are async
+(``asyncio_mode=auto``).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from trading_bot.application import (
+    EventBus,
+    FillEvent,
+    LogEvent,
+    OrderEvent,
+)
+from trading_bot.domain import (
+    Fill,
+    Instrument,
+    Order,
+    OrderSide,
+    OrderType,
+    Symbol,
+    money,
+)
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+def _make_fill() -> Fill:
+    """A realistic, fully-priced :class:`Fill` for assertions."""
+    return Fill(
+        fill_id="T1",
+        client_order_id="cid-1",
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("0.5"),
+        price=money("30000.10"),
+        fee=money("12.34"),
+        ts=1_700_000_000_000,
+    )
+
+
+def _make_order() -> Order:
+    """A realistic limit :class:`Order` for assertions."""
+    return Order(
+        client_order_id="cid-1",
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("0.5"),
+        type=OrderType.LIMIT,
+        limit_price=money("30000.10"),
+    )
+
+
+# --- event payloads -------------------------------------------------------- #
+
+
+def test_fill_event_carries_decimal_money() -> None:
+    """A FillEvent keeps the fill's ``Decimal`` amounts intact."""
+    fill = _make_fill()
+    ev = FillEvent(fill=fill)
+    assert ev.fill is fill
+    assert ev.fill.price == Decimal("30000.10")
+    assert ev.fill.fee == Decimal("12.34")
+    assert isinstance(ev.fill.qty, Decimal)
+
+
+def test_order_event_carries_the_aggregate() -> None:
+    """An OrderEvent carries the live Order by reference (Decimal qty intact)."""
+    order = _make_order()
+    ev = OrderEvent(order=order)
+    assert ev.order is order
+    assert ev.order.qty == Decimal("0.5")
+    assert isinstance(ev.order.limit_price, Decimal)
+
+
+def test_log_event_fields() -> None:
+    """A LogEvent carries message + level (default info)."""
+    assert LogEvent(message="hello").level == "info"
+    assert LogEvent(message="boom", level="error").level == "error"
+
+
+# --- handler dispatch ------------------------------------------------------ #
+
+
+def test_emit_reaches_every_subscriber() -> None:
+    """emit calls every registered handler with the event."""
+    bus = EventBus()
+    seen_a: list = []
+    seen_b: list = []
+    bus.subscribe(seen_a.append)
+    bus.subscribe(seen_b.append)
+
+    ev = LogEvent(message="started")
+    bus.emit(ev)
+
+    assert seen_a == [ev]
+    assert seen_b == [ev]
+
+
+def test_unsubscribe_stops_delivery() -> None:
+    """An unsubscribed handler receives no further events."""
+    bus = EventBus()
+    seen: list = []
+    bus.subscribe(seen.append)
+    bus.emit(LogEvent(message="first"))
+    bus.unsubscribe(seen.append)
+    bus.emit(LogEvent(message="second"))
+
+    assert [e.message for e in seen] == ["first"]
+
+
+def test_handler_exception_does_not_break_others() -> None:
+    """A raising handler is swallowed; later handlers still run."""
+    bus = EventBus()
+    seen: list = []
+
+    def boom(_event) -> None:
+        raise RuntimeError("bad subscriber")
+
+    bus.subscribe(boom)
+    bus.subscribe(seen.append)
+
+    ev = LogEvent(message="resilient")
+    bus.emit(ev)  # must not raise
+    assert seen == [ev]
+
+
+# --- async fan-out --------------------------------------------------------- #
+
+
+async def test_two_queues_each_receive_the_event() -> None:
+    """Two add_queue consumers each get the event (fan-out, not steal)."""
+    bus = EventBus()
+    q1 = bus.add_queue()
+    q2 = bus.add_queue()
+
+    ev = FillEvent(fill=_make_fill())
+    bus.emit(ev)
+
+    got1 = await q1.get()
+    got2 = await q2.get()
+    assert got1 is ev
+    assert got2 is ev
+    assert got1.fill.price == Decimal("30000.10")
+
+
+async def test_remove_queue_stops_delivery() -> None:
+    """A removed queue receives no further events."""
+    bus = EventBus()
+    q = bus.add_queue()
+    bus.emit(LogEvent(message="first"))
+    bus.remove_queue(q)
+    bus.emit(LogEvent(message="second"))
+
+    assert (await q.get()).message == "first"
+    assert q.empty()
+
+
+async def test_full_queue_drops_without_blocking() -> None:
+    """A full queue drops new events instead of blocking emit."""
+    bus = EventBus()
+    q = bus.add_queue(maxsize=1)
+    bus.emit(LogEvent(message="kept"))
+    bus.emit(LogEvent(message="dropped"))  # must not block / raise
+
+    assert (await q.get()).message == "kept"
+    assert q.empty()
+
+
+def test_subscribers_and_queues_all_receive() -> None:
+    """A FillEvent reaches two subscribers and two queues — four receivers."""
+    bus = EventBus()
+    seen_a: list = []
+    seen_b: list = []
+    bus.subscribe(seen_a.append)
+    bus.subscribe(seen_b.append)
+    q1 = bus.add_queue()
+    q2 = bus.add_queue()
+
+    ev = FillEvent(fill=_make_fill())
+    bus.emit(ev)
+
+    assert seen_a == [ev]
+    assert seen_b == [ev]
+    assert q1.get_nowait() is ev
+    assert q2.get_nowait() is ev


### PR DESCRIPTION
## Summary
- First leaf of **E4 — Execution engine**: opens `trading_bot/application/`.
- `AppConfig` (pydantic v2, `mode` **paper-default**; brokers/strategies/risk skeleton) + async `EventBus` (sync subscribers + per-consumer fan-out queues; `OrderEvent`/`FillEvent`/`LogEvent`).

## Why
- Paper-by-default is the live-trading safety invariant made structural. Fan-out lets the router, position tracker and a future UI consume the same stream independently; `emit` never blocks/raises. See `doc/dev/03-decisions.md`.

## Changes
- `application/config.py`, `application/events.py`, exports; `tests/application/test_{config,events}.py` (21 tests). Verified via the project `.venv` (fynance/dccd present).

## Changelog
Added under [Unreleased]:
- `application` kernel — `AppConfig` (pydantic v2, paper-default) + async `EventBus`.

## Test plan
- [x] `.venv/bin/python -m pytest` (281 passed, **0 skipped**)
- [x] `ruff` + `mypy` clean
- [ ] CI green