### PR TITLE
fix: KrakenBroker order-mapping docstring + venue-idempotency gap

### DIFF
--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,26 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-21 Venue-level order idempotency deferred (PR #XX)
+
+**Decision.** `KrakenBroker` does **not** forward the domain `client_order_id` to
+Kraken (its `cl_ord_id` needs a UUID, `userref` a 32-bit int — neither fits an
+arbitrary id). Idempotent submission is enforced **engine-side** by the
+`OrderRouter` (client-order-id dedup). The transport's blanket POST retry means an
+`AddOrder` lost-response could still double-submit at the venue; that risk is
+**accepted for now** (no live trading; private path mock-only) and recorded as a
+go-live gap.
+
+**Why.** The MVP runs paper-only, so venue double-submit cannot lose real money
+yet, and a correct fix (a Kraken-acceptable `userref` mapping + not retrying a
+non-idempotent `AddOrder`, reconciling on ambiguous failure instead) is go-live
+hardening (E10), with groundwork in the E4 order-router. Surfacing the risk now —
+honest docstring + a `06-status.md` known gap — beats a silent false claim that the
+client id was sent. **Rejected:** sending the raw `client_order_id` as `cl_ord_id`
+(Kraken rejects non-UUID values).
+
+---
+
 ### 2026-06-21 Application kernel: paper-default config + fan-out EventBus (PR #22)
 
 **Decision.** `application/config.py` `AppConfig` is pydantic v2 with

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -43,3 +43,9 @@ risk, the CLI, the orchestration layer, and (later) the UI and go-live hardening
 - **dccd↔trading_bot orchestration depth** (library import vs driving a service) —
   decided when the orchestration epic (E8) is planned.
 - **`trading-bot` console script** — not declared until the CLI module exists (E7).
+- **`AddOrder` idempotency at the venue** — the transport retries POSTs on
+  5xx/network errors, but `AddOrder` carries no venue idempotency key, so a retry
+  after an *ambiguous* failure (order placed, response lost) could double-submit.
+  Today idempotency is engine-side only (`OrderRouter` client-order-id dedup);
+  venue-level idempotency / reconcile-on-ambiguous-failure is go-live hardening
+  (groundwork in E4's order-router, finished in E10).

--- a/trading_bot/brokers/kraken.py
+++ b/trading_bot/brokers/kraken.py
@@ -419,9 +419,14 @@ class KrakenBroker(Broker):
 
         Pure (no I/O), so the order-to-payload mapping is unit-testable on its
         own. ``price`` is the limit price for limit orders and the stop price
-        for stop-loss orders; market orders carry no price. The
-        ``client_order_id`` rides along as Kraken's ``userref`` is numeric-only,
-        so it is sent as ``cl_ord_id`` (Kraken's string client-order-id field).
+        for stop-loss orders; market orders carry no price.
+
+        The domain ``client_order_id`` is **not** forwarded to Kraken here:
+        Kraken's ``cl_ord_id`` requires a UUID and ``userref`` is a 32-bit int,
+        neither of which fits an arbitrary id. Idempotency is enforced
+        engine-side by the ``OrderRouter`` (client-order-id dedup); venue-level
+        idempotency — and *not* blindly retrying a non-idempotent ``AddOrder``
+        POST — is a deferred go-live hardening item (see ``doc/dev/06-status.md``).
         """
         params: dict[str, str] = {
             "pair": order.instrument.symbol.to_venue_symbol(self.name),


### PR DESCRIPTION
Review finding on the merged E3 Kraken adapter (docstring + docs; no behaviour change).

- `_add_order_params` docstring falsely claimed the domain `client_order_id` is sent to Kraken as `cl_ord_id`. It is **not** (Kraken's `cl_ord_id` needs a UUID, `userref` a 32-bit int). Corrected — idempotency is engine-side (`OrderRouter` dedup).
- **Known gap recorded**: the transport retries POSTs, but `AddOrder` has no venue idempotency key → a retry after an *ambiguous* failure could double-submit. Accepted for now (paper-only); go-live hardening (E10), groundwork in E4's order-router. See `06-status.md` + a new `03-decisions.md` ADR.

## Test plan
- [x] `ruff` + `pytest` green (281 passed; docstring/docs only)