### PR TITLE
feat: PaperBroker (in-process fill simulation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Completes the **E3 Kraken adapter**. (#19)
 - `application` kernel — `AppConfig` (pydantic v2, paper-default) + async `EventBus`
   (fan-out queues + sync subscribers; `OrderEvent`/`FillEvent`/`LogEvent`). (#22)
+- `brokers.PaperBroker` — in-process fill simulation (immediate/partial fill
+  models, fee model), the default broker so the engine runs with no venue. (#XX)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,7 +6,23 @@ rejected approaches as tombstones.
 
 ---
 
-### 2026-06-21 Venue-level order idempotency deferred (PR #XX)
+### 2026-06-21 PaperBroker: the default in-process broker (PR #XX)
+
+**Decision.** `brokers/paper.py` `PaperBroker` (`name="paper"`) implements the
+`Broker` port entirely in-process — the **default** broker so the engine runs with
+no venue or key. `fill_model="immediate"` fully fills on placement at the order's
+limit (or an injected mark for market); `"partial"` slices into equal chunks (the
+last absorbing the remainder, so slices sum exactly). Fee = `price*qty*fee_bps/10000`
+(Decimal, quote units). Balances thread buy/sell and may go negative (a simulator,
+not a funding gate). Ids/clock are seamed so tests are exact.
+
+**Why.** A behind-the-port simulator lets the whole order→fill→position path be
+verified end-to-end with no network — the basis for testing the router,
+reconciliation and strategies before any live broker is wired.
+
+---
+
+### 2026-06-21 Venue-level order idempotency deferred (PR #23)
 
 **Decision.** `KrakenBroker` does **not** forward the domain `client_order_id` to
 Kraken (its `cl_ord_id` needs a UUID, `userref` a 32-bit int — neither fits an

--- a/doc/dev/plans/execution-engine/00-plan.md
+++ b/doc/dev/plans/execution-engine/00-plan.md
@@ -33,7 +33,7 @@ don't-assume, fills are the PnL truth, all money `Decimal`. Everything is verifi
 ## Leaf checklist
 
 - [x] 01 app-kernel — feat/app-kernel — medium
-- [ ] 02 paper-broker — feat/paper-broker — medium
+- [x] 02 paper-broker — feat/paper-broker — medium
 - [ ] 03 order-router — feat/order-router — high (depends on 01, 02)
 - [ ] 04 position-tracker — feat/position-tracker — medium (depends on 03)
 - [ ] 05 reconciliation — feat/reconciliation — high (depends on 03, 04)

--- a/doc/dev/plans/execution-engine/02-paper-broker.md
+++ b/doc/dev/plans/execution-engine/02-paper-broker.md
@@ -1,7 +1,7 @@
 ---
 plan: execution-engine/02-paper-broker
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false

--- a/doc/dev/plans/execution-engine/02-paper-broker.md
+++ b/doc/dev/plans/execution-engine/02-paper-broker.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/paper-broker
-pr: ""
+pr: "#XX"
 ---
 
 # PaperBroker — in-process fill simulation

--- a/trading_bot/brokers/__init__.py
+++ b/trading_bot/brokers/__init__.py
@@ -9,8 +9,9 @@ adapters. The port speaks :mod:`trading_bot.domain` types only and its concrete
 adapters use the :mod:`trading_bot.transport` plumbing; the domain never imports
 a broker.
 
-The :class:`~trading_bot.brokers.kraken.KrakenBroker` is the first concrete
-adapter behind this port.
+The :class:`~trading_bot.brokers.paper.PaperBroker` is the in-process default
+(paper-trading) adapter; :class:`~trading_bot.brokers.kraken.KrakenBroker` is the
+first live venue adapter behind this port.
 
 Public surface:
 
@@ -29,7 +30,9 @@ Public surface:
 * :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS` — the Kraken v2 private
   WebSocket adapter streaming ``executions`` (own trades / order updates) into
   domain :class:`~trading_bot.domain.fill.Fill`s (auth-token flow; live private
-  connection gated on credentials, parse path mock-verified).
+  connection gated on credentials, parse path mock-verified);
+* :class:`~trading_bot.brokers.paper.PaperBroker` — the in-process, deterministic
+  fill simulator and **default** broker (no venue, no key, no network).
 """
 
 from __future__ import annotations
@@ -37,6 +40,7 @@ from __future__ import annotations
 from trading_bot.brokers.base import Broker, BrokerError, Capability, require
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.kraken_ws import KrakenPrivateWS
+from trading_bot.brokers.paper import PaperBroker
 from trading_bot.brokers.registry import BrokerRegistry
 
 __all__ = [
@@ -47,4 +51,5 @@ __all__ = [
     "BrokerRegistry",
     "KrakenBroker",
     "KrakenPrivateWS",
+    "PaperBroker",
 ]

--- a/trading_bot/brokers/paper.py
+++ b/trading_bot/brokers/paper.py
@@ -1,0 +1,470 @@
+"""The :class:`PaperBroker` — an in-process, deterministic fill simulator.
+
+This is the **default** :class:`~trading_bot.brokers.base.Broker` adapter: it
+implements the venue-neutral port entirely in memory so the whole engine runs
+with **no venue, no API key and no network**. Where
+:class:`~trading_bot.brokers.kraken.KrakenBroker` translates the port to a live
+REST API, :class:`PaperBroker` *simulates* the venue — it accepts orders, fills
+them against an injected mark/limit price, accrues a fee, mutates internal
+balances and records :class:`~trading_bot.domain.fill.Fill`s — speaking
+**domain types only**, with every amount an exact
+:class:`~decimal.Decimal`.
+
+Determinism
+-----------
+The simulation is fully deterministic so tests assert exact values:
+
+* **Synthetic order ids** are ``"PAPER-{n}"`` from a monotonic counter, so the
+  *k*-th placed order always gets the same id within a run.
+* **Fill ids** are ``"PAPER-FILL-{n}"`` from a second counter.
+* **Timestamps** come from an injectable ``clock`` callable returning
+  milliseconds since the Unix epoch (UTC). The default clock is *not* the wall
+  clock — it returns a fixed base time and advances by one millisecond per call,
+  so a run is reproducible without freezing real time.
+
+Fill model
+----------
+Two fill models, selected at construction by ``fill_model``:
+
+* ``"immediate"`` — an order is **fully** filled the moment it is placed, at its
+  ``limit_price`` (LIMIT, or a priced BEST_LIMIT) or, for a MARKET order, at the
+  injected mark price for its instrument. Exactly one :class:`Fill` is produced
+  and ``open_orders`` is left empty.
+* ``"partial"`` — the order is filled in ``partial_chunks`` equal slices (the
+  last slice absorbs any rounding remainder so the slices sum **exactly** to the
+  filled quantity). By default the whole quantity is consumed (the order closes
+  to ``FILLED`` and ``open_orders`` is empty); set ``partial_fill_ratio`` below
+  ``1`` to fill only that fraction on placement and leave the remainder *open*
+  (so :meth:`cancel_order` has a live, partially-filled order to cancel).
+
+The execution price is the same in both models (limit price, or the mark for a
+MARKET order); only the *slicing* differs.
+
+Fee model
+---------
+The fee for a slice of ``qty`` at ``price`` is, in quote units::
+
+    fee = price * qty * fee_bps / 10000
+
+i.e. ``fee_bps`` basis points of the slice notional (``10`` bps = 0.10% by
+default). Fees are exact :class:`~decimal.Decimal`; they are *not* quantised
+here (the simulation has no tick metadata) — callers wanting venue-tick rounding
+quantise at the boundary.
+
+Balances
+--------
+Balances start from ``starting_balances`` (canonical asset code -> Decimal) and
+move on every fill, consistently with the fee model:
+
+* a **BUY** debits the quote asset by ``price*qty + fee`` and credits the base
+  asset by ``qty``;
+* a **SELL** credits the quote asset by ``price*qty - fee`` and debits the base
+  asset by ``qty``.
+
+Balances may go negative — the paper broker does **not** enforce funding (it is a
+simulator, not a risk gate); margin/funding checks live in the engine.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from itertools import count
+
+from trading_bot.brokers.base import Broker, Capability
+from trading_bot.domain.errors import BrokerError, MissingOrder
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.order import Order, OrderSide
+
+__all__ = ["PaperBroker"]
+
+#: Basis-point denominator: ``fee = notional * fee_bps / _BPS_DENOMINATOR``.
+_BPS_DENOMINATOR: Money = money("10000")
+
+#: The default clock's base timestamp (ms since the Unix epoch, UTC):
+#: 2024-01-01T00:00:00Z. The clock advances one millisecond per call.
+_DEFAULT_CLOCK_BASE_MS = 1_704_067_200_000
+
+
+def _default_clock() -> Callable[[], int]:
+    """Build a deterministic clock: a fixed base time, +1ms per call."""
+    ticker = count(_DEFAULT_CLOCK_BASE_MS)
+    return lambda: next(ticker)
+
+
+class PaperBroker(Broker):
+    """In-process, deterministic :class:`Broker` that simulates fills.
+
+    The default (paper-trading) broker: it serves the full :class:`Broker` port
+    in memory, with no network and exact :class:`~decimal.Decimal` money. See the
+    module docstring for the fill, fee and balance models.
+
+    Parameters
+    ----------
+    prices : dict of Instrument to Decimal, optional
+        Seed mark prices keyed by instrument; used to price MARKET orders and to
+        answer :meth:`ticker`. Drive them at runtime with :meth:`set_price`.
+        Copied defensively. Defaults to empty.
+    fee_bps : Decimal, optional
+        Fee in basis points of the fill notional. Defaults to ``money("10")``
+        (10 bps = 0.10%). Must be non-negative.
+    fill_model : {"immediate", "partial"}, optional
+        How a placed order is filled. ``"immediate"`` (default) fully fills in
+        one :class:`Fill`; ``"partial"`` slices into ``partial_chunks`` fills.
+    starting_balances : dict of str to Decimal, optional
+        Initial free balances by canonical asset code. Copied defensively.
+        Defaults to empty. Balances may go negative (no funding gate).
+    clock : callable, optional
+        Zero-arg callable returning the current time as **milliseconds since the
+        Unix epoch (UTC)**, stamped onto every :class:`Fill`. Defaults to a
+        deterministic clock (fixed base, +1ms per call) so runs are reproducible.
+    partial_chunks : int, optional
+        Number of equal slices for ``fill_model="partial"``. Defaults to ``2``.
+        Must be ``>= 1``.
+    partial_fill_ratio : Decimal, optional
+        Fraction of the order quantity consumed on placement under
+        ``fill_model="partial"``. ``1`` (default) fully fills (order closes);
+        a value in ``(0, 1)`` leaves the remainder *open*. Must be in ``(0, 1]``.
+
+    Attributes
+    ----------
+    name : str
+        The venue key, ``"paper"`` (the registry key for this adapter).
+
+    """
+
+    name = "paper"
+
+    def __init__(
+        self,
+        *,
+        prices: dict[Instrument, Money] | None = None,
+        fee_bps: Money = money("10"),
+        fill_model: str = "immediate",
+        starting_balances: dict[str, Money] | None = None,
+        clock: Callable[[], int] | None = None,
+        partial_chunks: int = 2,
+        partial_fill_ratio: Money = money("1"),
+    ) -> None:
+        if fill_model not in ("immediate", "partial"):
+            raise BrokerError(
+                f"unknown fill_model {fill_model!r}; "
+                "expected 'immediate' or 'partial'"
+            )
+        if fee_bps < 0:
+            raise BrokerError(f"fee_bps must be non-negative, got {fee_bps}")
+        if partial_chunks < 1:
+            raise BrokerError(
+                f"partial_chunks must be >= 1, got {partial_chunks}"
+            )
+        if not (0 < partial_fill_ratio <= 1):
+            raise BrokerError(
+                f"partial_fill_ratio must be in (0, 1], got {partial_fill_ratio}"
+            )
+
+        self._prices: dict[Instrument, Money] = dict(prices or {})
+        self._fee_bps = fee_bps
+        self._fill_model = fill_model
+        self._balances: dict[str, Money] = dict(starting_balances or {})
+        self._clock = clock if clock is not None else _default_clock()
+        self._partial_chunks = partial_chunks
+        self._partial_fill_ratio = partial_fill_ratio
+
+        # Deterministic id seams.
+        self._order_ids = count(1)
+        self._fill_ids = count(1)
+        # Live orders keyed by their synthetic venue id.
+        self._open: dict[str, Order] = {}
+        # Every fill ever produced, in execution order.
+        self._fills: list[Fill] = []
+        # One-shot override of the placement fill ratio (see ``arm_partial``),
+        # consumed by the next ``place_order``. ``None`` means "use the model".
+        self._armed_ratio: Money | None = None
+
+    # --- capability declaration -------------------------------------------- #
+
+    def capabilities(self) -> set[Capability]:
+        """The :class:`Capability` set this adapter serves.
+
+        All six in-process operations are implemented (place/cancel/open-orders,
+        balances, fills, ticker). There is no private WebSocket feed for a
+        simulator, so :data:`~trading_bot.brokers.base.Capability.PRIVATE_WS` is
+        omitted.
+        """
+        return {
+            Capability.PLACE_ORDER,
+            Capability.CANCEL,
+            Capability.OPEN_ORDERS,
+            Capability.BALANCES,
+            Capability.FILLS,
+            Capability.TICKER,
+        }
+
+    # --- price hooks ------------------------------------------------------- #
+
+    def set_price(self, instrument: Instrument, price: Money) -> None:
+        """Set the mark price for ``instrument`` (drives MARKET fills & ticker).
+
+        Parameters
+        ----------
+        instrument : Instrument
+            The instrument to mark.
+        price : Decimal
+            Its mark price in quote units. Must be strictly positive.
+
+        Raises
+        ------
+        BrokerError
+            If ``price`` is not strictly positive.
+
+        """
+        if price <= 0:
+            raise BrokerError(f"mark price must be positive, got {price}")
+        self._prices[instrument] = price
+
+    def arm_partial(self, ratio: Money) -> None:
+        """Arm the **next** :meth:`place_order` to fill only ``ratio`` of qty.
+
+        A one-shot driver seam (reset after the next placement) for simulating a
+        single partial fill regardless of the broker's ``fill_model`` — the
+        placed order fills ``ratio * qty`` (sliced per ``partial_chunks``) and
+        keeps the remainder *open*. Lets a realistic mixed sequence (full buy ->
+        partial -> sell) run against one balance-threaded broker.
+
+        Parameters
+        ----------
+        ratio : Decimal
+            Fraction of the next order's quantity to fill on placement. Must be
+            in ``(0, 1)`` — use the normal models for a full fill.
+
+        Raises
+        ------
+        BrokerError
+            If ``ratio`` is not strictly inside ``(0, 1)``.
+
+        """
+        if not (0 < ratio < 1):
+            raise BrokerError(
+                f"arm_partial ratio must be in (0, 1), got {ratio}"
+            )
+        self._armed_ratio = ratio
+
+    # --- order lifecycle --------------------------------------------------- #
+
+    async def place_order(self, order: Order) -> str:
+        """Submit ``order`` to the simulator and return its synthetic venue id.
+
+        Drives the domain ``order`` through ``submit`` -> ``open`` under a fresh
+        ``"PAPER-{n}"`` id, then simulates fills per the configured fill model
+        (see the module docstring). Each fill is recorded, mutates internal
+        balances, and is applied to the domain order. Any unfilled remainder is
+        kept live and surfaced by :meth:`open_orders`.
+
+        Parameters
+        ----------
+        order : Order
+            The domain order to simulate. Must be in ``NEW`` status (freshly
+            constructed); its lifecycle is driven here.
+
+        Returns
+        -------
+        str
+            The synthetic venue order id (``"PAPER-{n}"``).
+
+        Raises
+        ------
+        BrokerError
+            If a MARKET (or unpriced BEST_LIMIT) order has no mark price for its
+            instrument.
+
+        """
+        venue_order_id = f"PAPER-{next(self._order_ids)}"
+        order.submit()
+        order.open(venue_order_id)
+
+        # A one-shot armed ratio (if any) wins over the model; reset it now so
+        # it only affects this placement.
+        armed = self._armed_ratio
+        self._armed_ratio = None
+
+        price = self._execution_price(order)
+        fill_qty = self._placement_fill_qty(order.qty, armed)
+        for slice_qty in self._slice(fill_qty):
+            self._execute(order, slice_qty, price)
+
+        # Keep the order live only if a quantity remains unfilled.
+        if not order.is_terminal:
+            self._open[venue_order_id] = order
+        return venue_order_id
+
+    def _execution_price(self, order: Order) -> Money:
+        """Resolve the price an order fills at (limit price, or the mark).
+
+        A LIMIT (or priced BEST_LIMIT) fills at its ``limit_price``; a MARKET
+        order (or an unpriced BEST_LIMIT) fills at the injected mark price.
+        """
+        if order.limit_price is not None:
+            return order.limit_price
+        # MARKET / unpriced BEST_LIMIT: take the injected mark.
+        price = self._prices.get(order.instrument)
+        if price is None:
+            raise BrokerError(
+                f"no mark price for {order.instrument} to fill "
+                f"{order.type.name} order {order.client_order_id}"
+            )
+        return price
+
+    def _placement_fill_qty(self, qty: Money, armed: Money | None) -> Money:
+        """The quantity filled on placement (the whole qty, or a partial slice).
+
+        A one-shot ``armed`` ratio (from :meth:`arm_partial`) wins if present;
+        otherwise ``"immediate"`` and a unit ``partial_fill_ratio`` fill the
+        whole ``qty`` while a sub-unit ratio under ``"partial"`` fills only that
+        fraction.
+        """
+        if armed is not None:
+            return qty * armed
+        if self._fill_model == "partial" and self._partial_fill_ratio < 1:
+            return qty * self._partial_fill_ratio
+        return qty
+
+    def _slice(self, qty: Money) -> list[Money]:
+        """Split ``qty`` into the fill slices for the configured model.
+
+        ``"immediate"`` yields a single slice; ``"partial"`` yields
+        ``partial_chunks`` slices whose sum is exactly ``qty`` (the last slice
+        absorbs any division remainder).
+        """
+        if self._fill_model == "immediate" or self._partial_chunks == 1:
+            return [qty]
+        n = self._partial_chunks
+        base = qty / n
+        slices = [base for _ in range(n - 1)]
+        slices.append(qty - base * (n - 1))  # last absorbs the remainder
+        return slices
+
+    def _execute(self, order: Order, qty: Money, price: Money) -> None:
+        """Record one fill of ``qty`` at ``price`` and move balances/order state."""
+        fee = self._fee(qty, price)
+        fill = Fill(
+            fill_id=f"PAPER-FILL-{next(self._fill_ids)}",
+            client_order_id=order.client_order_id,
+            instrument=order.instrument,
+            side=order.side,
+            qty=qty,
+            price=price,
+            fee=fee,
+            ts=self._clock(),
+        )
+        self._fills.append(fill)
+        order.apply_fill(qty, price)
+        self._apply_to_balances(fill)
+
+    def _fee(self, qty: Money, price: Money) -> Money:
+        """Fee for a slice: ``price * qty * fee_bps / 10000`` in quote units."""
+        return price * qty * self._fee_bps / _BPS_DENOMINATOR
+
+    def _apply_to_balances(self, fill: Fill) -> None:
+        """Move base/quote balances for ``fill`` (see the module balance model)."""
+        base = fill.instrument.symbol.base
+        quote = fill.instrument.symbol.quote
+        notional = fill.price * fill.qty
+        if fill.side is OrderSide.BUY:
+            # Pay quote (notional + fee), receive base.
+            self._balances[quote] = self._balance(quote) - notional - fill.fee
+            self._balances[base] = self._balance(base) + fill.qty
+        else:
+            # Deliver base, receive quote (notional - fee).
+            self._balances[base] = self._balance(base) - fill.qty
+            self._balances[quote] = self._balance(quote) + notional - fill.fee
+
+    def _balance(self, asset: str) -> Money:
+        """Current balance of ``asset``, defaulting to zero if untracked."""
+        return self._balances.get(asset, money("0"))
+
+    async def cancel_order(self, venue_order_id: str) -> None:
+        """Cancel the live (open / partially-filled) order ``venue_order_id``.
+
+        Parameters
+        ----------
+        venue_order_id : str
+            The synthetic id returned by :meth:`place_order`.
+
+        Raises
+        ------
+        MissingOrder
+            If no live order is tracked under ``venue_order_id`` (already filled,
+            already cancelled, or never placed).
+
+        """
+        order = self._open.pop(venue_order_id, None)
+        if order is None:
+            raise MissingOrder(venue_order_id)
+        order.cancel()
+
+    async def open_orders(self) -> list[Order]:
+        """Return the still-live (open / partially-filled) orders.
+
+        Returns
+        -------
+        list of Order
+            The live domain orders, in placement order.
+
+        """
+        return list(self._open.values())
+
+    async def balances(self) -> dict[str, Money]:
+        """Return free balances keyed by canonical asset code.
+
+        Returns
+        -------
+        dict of str to Decimal
+            A copy of the current per-asset balances (exact ``Decimal``).
+
+        """
+        return dict(self._balances)
+
+    async def fills(self, since_ms: int | None = None) -> list[Fill]:
+        """Return recorded fills, optionally only those at/after ``since_ms``.
+
+        Parameters
+        ----------
+        since_ms : int, optional
+            Lower time bound as **milliseconds since the Unix epoch (UTC)**,
+            inclusive. ``None`` (default) returns every recorded fill.
+
+        Returns
+        -------
+        list of Fill
+            The matching fills, in execution order.
+
+        """
+        if since_ms is None:
+            return list(self._fills)
+        return [f for f in self._fills if f.ts >= since_ms]
+
+    async def ticker(self, instrument: Instrument) -> Money:
+        """Return the injected mark price for ``instrument``.
+
+        Parameters
+        ----------
+        instrument : Instrument
+            The instrument to price.
+
+        Returns
+        -------
+        Decimal
+            Its injected mark price, exact.
+
+        Raises
+        ------
+        BrokerError
+            If no price has been injected for ``instrument`` (via the constructor
+            ``prices`` or :meth:`set_price`).
+
+        """
+        price = self._prices.get(instrument)
+        if price is None:
+            raise BrokerError(f"no ticker price for {instrument}")
+        return price

--- a/trading_bot/tests/brokers/test_paper.py
+++ b/trading_bot/tests/brokers/test_paper.py
@@ -1,0 +1,448 @@
+"""Tests for the in-process :class:`~trading_bot.brokers.paper.PaperBroker`.
+
+The paper broker *is* the engine's "real data": there is no network, the
+simulation is fully deterministic, and every amount is an exact
+:class:`~decimal.Decimal`. These tests assert the fill, fee and balance models
+exactly (hand-computed), exercise both fill models, cover the capability set and
+ticker, and run a realistic buy -> partial -> sell-to-flat sequence end to end.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from trading_bot.brokers import Broker, BrokerError, Capability, PaperBroker
+from trading_bot.domain import (
+    Fill,
+    Instrument,
+    MissingOrder,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Symbol,
+    money,
+)
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+ETH_USD = Instrument(Symbol("ETH", "USD"))
+
+
+def _limit_buy(
+    qty: str = "1", price: str = "30000", cid: str = "cid-1"
+) -> Order:
+    return Order(
+        client_order_id=cid,
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money(qty),
+        type=OrderType.LIMIT,
+        limit_price=money(price),
+    )
+
+
+def _limit_sell(
+    qty: str = "1", price: str = "30000", cid: str = "cid-s"
+) -> Order:
+    return Order(
+        client_order_id=cid,
+        instrument=BTC_USD,
+        side=OrderSide.SELL,
+        qty=money(qty),
+        type=OrderType.LIMIT,
+        limit_price=money(price),
+    )
+
+
+def _market_buy(qty: str = "1", cid: str = "cid-m") -> Order:
+    return Order(
+        client_order_id=cid,
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money(qty),
+        type=OrderType.MARKET,
+    )
+
+
+# --- the adapter satisfies the port ---------------------------------------- #
+
+
+def test_paper_satisfies_broker_protocol() -> None:
+    """:class:`PaperBroker` is a :class:`Broker` structurally."""
+    assert isinstance(PaperBroker(), Broker)
+
+
+def test_name_is_paper() -> None:
+    """The venue key is ``"paper"``."""
+    assert PaperBroker().name == "paper"
+
+
+def test_capabilities_declares_six_ops() -> None:
+    """The declared capabilities are exactly the six in-process operations."""
+    assert PaperBroker().capabilities() == {
+        Capability.PLACE_ORDER,
+        Capability.CANCEL,
+        Capability.OPEN_ORDERS,
+        Capability.BALANCES,
+        Capability.FILLS,
+        Capability.TICKER,
+    }
+    assert Capability.PRIVATE_WS not in PaperBroker().capabilities()
+
+
+# --- immediate-fill LIMIT buy ---------------------------------------------- #
+
+
+async def test_immediate_limit_buy_one_fill_at_limit_price() -> None:
+    """A LIMIT buy fully fills in one :class:`Fill` at the limit price."""
+    broker = PaperBroker(starting_balances={"USD": money("100000")})
+    order = _limit_buy(qty="2", price="30000")
+
+    venue_order_id = await broker.place_order(order)
+
+    assert venue_order_id == "PAPER-1"
+    assert order.status is OrderStatus.FILLED
+    assert await broker.open_orders() == []
+
+    fills = await broker.fills()
+    assert len(fills) == 1
+    fill = fills[0]
+    assert isinstance(fill, Fill)
+    assert fill.side is OrderSide.BUY
+    assert fill.qty == Decimal("2")
+    assert fill.price == Decimal("30000")
+    # 30000 * 2 * 10 / 10000 = 60.
+    assert fill.fee == Decimal("60")
+
+
+async def test_immediate_limit_buy_moves_balances_exactly() -> None:
+    """Balances move by +qty (base) and -(notional + fee) (quote), exact."""
+    broker = PaperBroker(starting_balances={"USD": money("100000")})
+    await broker.place_order(_limit_buy(qty="2", price="30000"))
+
+    balances = await broker.balances()
+    # USD: 100000 - (30000*2) - 60 = 39940. BTC: 0 + 2 = 2.
+    assert balances["USD"] == Decimal("39940")
+    assert balances["BTC"] == Decimal("2")
+    assert all(isinstance(v, Decimal) for v in balances.values())
+
+
+async def test_immediate_limit_sell_moves_balances_exactly() -> None:
+    """A SELL credits quote (notional - fee) and debits base, exact."""
+    broker = PaperBroker(
+        starting_balances={"USD": money("0"), "BTC": money("5")}
+    )
+    await broker.place_order(_limit_sell(qty="2", price="30000"))
+
+    balances = await broker.balances()
+    # USD: 0 + 30000*2 - 60 = 59940. BTC: 5 - 2 = 3.
+    assert balances["USD"] == Decimal("59940")
+    assert balances["BTC"] == Decimal("3")
+
+
+# --- MARKET fills at the injected mark ------------------------------------- #
+
+
+async def test_market_order_fills_at_injected_mark_price() -> None:
+    """A MARKET order fills at the injected mark price for its instrument."""
+    broker = PaperBroker(
+        prices={BTC_USD: money("31000")},
+        starting_balances={"USD": money("100000")},
+    )
+    order = _market_buy(qty="1")
+
+    await broker.place_order(order)
+
+    fills = await broker.fills()
+    assert len(fills) == 1
+    assert fills[0].price == Decimal("31000")
+    # 31000 * 1 * 10 / 10000 = 31.
+    assert fills[0].fee == Decimal("31")
+    assert order.status is OrderStatus.FILLED
+
+
+async def test_market_order_uses_set_price_hook() -> None:
+    """:meth:`set_price` drives the mark a later MARKET order fills at."""
+    broker = PaperBroker(starting_balances={"USD": money("100000")})
+    broker.set_price(BTC_USD, money("28000"))
+
+    await broker.place_order(_market_buy(qty="1"))
+
+    assert (await broker.fills())[0].price == Decimal("28000")
+
+
+async def test_market_order_without_mark_raises() -> None:
+    """A MARKET order with no injected mark raises :class:`BrokerError`."""
+    broker = PaperBroker()
+    with pytest.raises(BrokerError):
+        await broker.place_order(_market_buy())
+
+
+# --- partial fill model ----------------------------------------------------- #
+
+
+async def test_partial_model_multiple_fills_summing_to_qty_and_closes() -> None:
+    """``"partial"`` emits multiple fills summing to qty; the order closes."""
+    broker = PaperBroker(
+        fill_model="partial",
+        partial_chunks=2,
+        starting_balances={"USD": money("100000")},
+    )
+    order = _limit_buy(qty="2", price="30000")
+
+    await broker.place_order(order)
+
+    fills = await broker.fills()
+    assert len(fills) == 2
+    assert sum((f.qty for f in fills), Decimal("0")) == Decimal("2")
+    # Equal slices of 1.0 each.
+    assert [f.qty for f in fills] == [Decimal("1"), Decimal("1")]
+    assert order.status is OrderStatus.FILLED
+    assert await broker.open_orders() == []
+
+
+async def test_partial_model_remainder_left_open() -> None:
+    """A sub-unit ``partial_fill_ratio`` leaves a partially-filled order open."""
+    broker = PaperBroker(
+        fill_model="partial",
+        partial_chunks=2,
+        partial_fill_ratio=money("0.5"),
+        starting_balances={"USD": money("100000")},
+    )
+    order = _limit_buy(qty="2", price="30000")
+
+    venue_order_id = await broker.place_order(order)
+
+    # Half of 2.0 = 1.0 filled, across 2 chunks of 0.5.
+    fills = await broker.fills()
+    assert sum((f.qty for f in fills), Decimal("0")) == Decimal("1")
+    assert order.status is OrderStatus.PARTIALLY_FILLED
+    assert order.filled_qty == Decimal("1")
+    assert order.remaining_qty == Decimal("1")
+
+    open_orders = await broker.open_orders()
+    assert len(open_orders) == 1
+    assert open_orders[0].venue_order_id == venue_order_id
+
+
+async def test_partial_slices_sum_exactly_with_remainder_chunk() -> None:
+    """Slices sum *exactly* to qty even when it does not divide evenly."""
+    broker = PaperBroker(
+        fill_model="partial",
+        partial_chunks=3,
+        starting_balances={"USD": money("100000")},
+    )
+    order = _limit_buy(qty="1", price="30000")
+
+    await broker.place_order(order)
+
+    fills = await broker.fills()
+    assert len(fills) == 3
+    assert sum((f.qty for f in fills), Decimal("0")) == Decimal("1")
+    assert order.status is OrderStatus.FILLED
+
+
+# --- cancel ----------------------------------------------------------------- #
+
+
+async def test_cancel_removes_open_partial_order() -> None:
+    """:meth:`cancel_order` removes a live (partially-filled) open order."""
+    broker = PaperBroker(
+        fill_model="partial",
+        partial_fill_ratio=money("0.5"),
+        starting_balances={"USD": money("100000")},
+    )
+    venue_order_id = await broker.place_order(_limit_buy(qty="2", price="30000"))
+    assert len(await broker.open_orders()) == 1
+
+    await broker.cancel_order(venue_order_id)
+
+    assert await broker.open_orders() == []
+
+
+async def test_cancel_unknown_order_raises_missing_order() -> None:
+    """Cancelling an unknown id raises :class:`MissingOrder`."""
+    broker = PaperBroker()
+    with pytest.raises(MissingOrder):
+        await broker.cancel_order("PAPER-404")
+
+
+async def test_cancel_filled_order_raises_missing_order() -> None:
+    """A fully-filled order is not open, so cancelling it raises."""
+    broker = PaperBroker(starting_balances={"USD": money("100000")})
+    venue_order_id = await broker.place_order(_limit_buy(qty="1", price="30000"))
+
+    with pytest.raises(MissingOrder):
+        await broker.cancel_order(venue_order_id)
+
+
+# --- ticker ----------------------------------------------------------------- #
+
+
+async def test_ticker_returns_injected_price() -> None:
+    """:meth:`ticker` returns the injected price as an exact ``Decimal``."""
+    broker = PaperBroker(prices={BTC_USD: money("30100.5")})
+    price = await broker.ticker(BTC_USD)
+    assert price == Decimal("30100.5")
+    assert isinstance(price, Decimal)
+
+
+async def test_ticker_unknown_instrument_raises() -> None:
+    """:meth:`ticker` for an un-priced instrument raises :class:`BrokerError`."""
+    broker = PaperBroker(prices={BTC_USD: money("30000")})
+    with pytest.raises(BrokerError):
+        await broker.ticker(ETH_USD)
+
+
+# --- fee model -------------------------------------------------------------- #
+
+
+async def test_fee_is_configured_basis_points() -> None:
+    """The fee is exactly ``fee_bps`` of the fill notional (e.g. 25 bps)."""
+    broker = PaperBroker(
+        fee_bps=money("25"), starting_balances={"USD": money("100000")}
+    )
+    await broker.place_order(_limit_buy(qty="1", price="40000"))
+
+    # 40000 * 1 * 25 / 10000 = 100.
+    assert (await broker.fills())[0].fee == Decimal("100")
+
+
+async def test_zero_fee_model() -> None:
+    """``fee_bps=0`` produces fee-free fills."""
+    broker = PaperBroker(
+        fee_bps=money("0"), starting_balances={"USD": money("100000")}
+    )
+    await broker.place_order(_limit_buy(qty="1", price="30000"))
+
+    fills = await broker.fills()
+    assert fills[0].fee == Decimal("0")
+    # USD: 100000 - 30000 - 0 = 70000.
+    assert (await broker.balances())["USD"] == Decimal("70000")
+
+
+# --- determinism & fills filtering ----------------------------------------- #
+
+
+async def test_order_ids_are_deterministic_and_monotonic() -> None:
+    """Synthetic order ids are ``PAPER-1``, ``PAPER-2``, ... in placement order."""
+    broker = PaperBroker(starting_balances={"USD": money("1000000")})
+    id1 = await broker.place_order(_limit_buy(qty="1", price="30000", cid="a"))
+    id2 = await broker.place_order(_limit_buy(qty="1", price="30000", cid="b"))
+    assert (id1, id2) == ("PAPER-1", "PAPER-2")
+
+
+async def test_fills_since_ms_filters() -> None:
+    """``fills(since_ms=...)`` returns only fills at/after the bound."""
+    broker = PaperBroker(starting_balances={"USD": money("1000000")})
+    await broker.place_order(_limit_buy(qty="1", price="30000", cid="a"))
+    await broker.place_order(_limit_buy(qty="1", price="30000", cid="b"))
+
+    all_fills = await broker.fills()
+    assert len(all_fills) == 2
+    # The default clock advances +1ms per fill, so filtering on the 2nd fill's
+    # ts drops the 1st.
+    second_ts = all_fills[1].ts
+    later = await broker.fills(since_ms=second_ts)
+    assert [f.fill_id for f in later] == [all_fills[1].fill_id]
+
+
+async def test_injected_clock_stamps_fills() -> None:
+    """An injected clock supplies the fill timestamps deterministically."""
+    broker = PaperBroker(
+        starting_balances={"USD": money("100000")},
+        clock=lambda: 1_700_000_000_000,
+    )
+    await broker.place_order(_limit_buy(qty="1", price="30000"))
+    assert (await broker.fills())[0].ts == 1_700_000_000_000
+
+
+# --- construction validation ------------------------------------------------ #
+
+
+def test_unknown_fill_model_raises() -> None:
+    """An unknown ``fill_model`` raises at construction."""
+    with pytest.raises(BrokerError):
+        PaperBroker(fill_model="instant")
+
+
+def test_negative_fee_bps_raises() -> None:
+    """A negative ``fee_bps`` raises at construction."""
+    with pytest.raises(BrokerError):
+        PaperBroker(fee_bps=money("-1"))
+
+
+def test_bad_partial_fill_ratio_raises() -> None:
+    """A ``partial_fill_ratio`` outside ``(0, 1]`` raises at construction."""
+    with pytest.raises(BrokerError):
+        PaperBroker(partial_fill_ratio=money("0"))
+    with pytest.raises(BrokerError):
+        PaperBroker(partial_fill_ratio=money("1.5"))
+
+
+# --- verification on "real data": buy -> partial -> sell-to-flat ----------- #
+
+
+async def test_realistic_sequence_matches_hand_computed_decimals() -> None:
+    """A realistic order sequence reconciles to hand-computed Decimal values.
+
+    One balance-threaded ``immediate`` broker (BTC/USD, 10 bps fee, start
+    USD=100000, BTC=0). The middle leg is armed (``arm_partial``) to fill only
+    half its quantity, leaving a live remainder — exactly the buy -> partial ->
+    sell-to-flat shape the engine sees:
+
+    1. BUY 1.0 @ limit 30000 (fully filled):
+       notional 30000, fee 30000*1*10/10000 = 30.
+       USD -> 100000 - 30000 - 30 = 69970 ; BTC -> 1.0
+    2. BUY 2.0 @ limit 31000, armed partial ratio 0.5 (fills 1.0; the immediate
+       model slices it as one fill): notional 31000, fee 31.
+       USD -> 69970 - 31000 - 31 = 38939 ; BTC -> 2.0 ; 1.0 left open.
+    3. SELL 2.0 @ limit 29000 (sell-to-flat):
+       notional 58000, fee 58000*10/10000 = 58.
+       USD -> 38939 + 58000 - 58 = 96881 ; BTC -> 0.0
+
+    Final: USD = 96881, BTC = 0. Total fees = 30 + 31 + 58 = 119.
+    """
+    broker = PaperBroker(
+        fill_model="immediate",
+        starting_balances={"USD": money("100000"), "BTC": money("0")},
+    )
+
+    # Leg 1: full buy of 1.0 @ 30000.
+    await broker.place_order(_limit_buy(qty="1", price="30000", cid="buy-1"))
+    bal = await broker.balances()
+    assert bal["USD"] == Decimal("69970")
+    assert bal["BTC"] == Decimal("1")
+
+    # Leg 2: a partial buy of 2.0 @ 31000 — armed to fill half (1.0); the other
+    # 1.0 stays open.
+    broker.arm_partial(money("0.5"))
+    vid2 = await broker.place_order(
+        _limit_buy(qty="2", price="31000", cid="buy-2")
+    )
+    bal = await broker.balances()
+    assert bal["USD"] == Decimal("38939")
+    assert bal["BTC"] == Decimal("2")
+    open_orders = await broker.open_orders()
+    assert len(open_orders) == 1
+    assert open_orders[0].venue_order_id == vid2
+    assert open_orders[0].remaining_qty == Decimal("1")
+
+    # Leg 3: sell 2.0 @ 29000 to flatten BTC.
+    await broker.place_order(_limit_sell(qty="2", price="29000", cid="sell-1"))
+    bal = await broker.balances()
+    assert bal["USD"] == Decimal("96881")
+    assert bal["BTC"] == Decimal("0")
+
+    # Fills reconcile: buy-1 (1.0) + buy-2 (1.0 armed) + sell (2.0) = 3; total
+    # fee 30 + 31 + 58 = 119.
+    all_fills = await broker.fills()
+    assert len(all_fills) == 3
+    assert sum((f.fee for f in all_fills), Decimal("0")) == Decimal("119")
+    assert [f.qty for f in all_fills] == [
+        Decimal("1"),
+        Decimal("1.0"),
+        Decimal("2"),
+    ]


### PR DESCRIPTION
## Summary
- Second leaf of **E4**: `trading_bot/brokers/paper.py` — `PaperBroker` (`name="paper"`), the **default** broker implementing the `Broker` port in-process (no venue/key). Immediate + partial fill models, fee (bps), balance threading, deterministic id/clock seams.

## Why
- A behind-the-port simulator lets the whole order→fill→position path be verified end-to-end with no network. See `doc/dev/03-decisions.md`.

## Note
- Implemented + verified during a GitHub outage (merged locally to keep E4 moving); this PR records it properly. Known gap logged: `PaperBroker` currently self-drives the `Order` state machine (a `Broker`-port contract violation) — to be made port-pure in leaf 04. See `doc/dev/06-status.md`.

## Test plan
- [x] `.venv/bin/python -m pytest` (307 passed, **0 skipped**); buy→partial→sell-to-flat → fills+balances match hand-computed Decimals
- [x] `ruff` + `mypy` clean