### PR TITLE
feat: OrderRouter (idempotent submit + lifecycle)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `application` kernel — `AppConfig` (pydantic v2, paper-default) + async `EventBus`
   (fan-out queues + sync subscribers; `OrderEvent`/`FillEvent`/`LogEvent`). (#22)
 - `brokers.PaperBroker` — in-process fill simulation (immediate/partial fill
-  models, fee model), the default broker so the engine runs with no venue. (#XX)
+  models, fee model), the default broker so the engine runs with no venue.
+- `application.OrderRouter` — idempotent order submission (client-order-id dedup,
+  incl. concurrent) + order-lifecycle driving + events.
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,7 +6,27 @@ rejected approaches as tombstones.
 
 ---
 
-### 2026-06-21 PaperBroker: the default in-process broker (PR #XX)
+### 2026-06-21 OrderRouter: engine-side idempotency; broker must not drive the order
+
+**Decision.** `application/order_router.py` `OrderRouter` makes order submission
+**idempotent engine-side**: a dedup map keyed by `client_order_id` (a second submit
+of a known id returns the tracked `Order`, no second broker call) plus a per-id
+in-flight `asyncio.Future`, so two *concurrent* submits of the same id still yield
+exactly one `broker.place_order`. It drives the domain `Order` state machine
+(`submit`→`open(venue_id)`; `reject` on `BrokerError`) and emits `OrderEvent`s. Fill
+ingestion is **not** here — it lives in the PositionTracker (leaf 04): the write path
+(intent→venue) and the read-back path (executions→position) are the clean split.
+
+**Why.** Idempotency is a money-safety invariant; the dedup map + in-flight future
+cover the sequential and concurrent retry cases. Venue-level idempotency stays
+deferred (see the #23 ADR / `06-status`). **Contract note:** the `Broker` port must
+**not** mutate the caller's `Order` — the router owns the state machine. `PaperBroker`
+currently self-drives the order (a leaf-02 contract violation); the router tolerates
+it for now, to be fixed in leaf 04 (see `06-status` known gaps).
+
+---
+
+### 2026-06-21 PaperBroker: the default in-process broker
 
 **Decision.** `brokers/paper.py` `PaperBroker` (`name="paper"`) implements the
 `Broker` port entirely in-process — the **default** broker so the engine runs with

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -49,3 +49,12 @@ risk, the CLI, the orchestration layer, and (later) the UI and go-live hardening
   Today idempotency is engine-side only (`OrderRouter` client-order-id dedup);
   venue-level idempotency / reconcile-on-ambiguous-failure is go-live hardening
   (groundwork in E4's order-router, finished in E10).
+- **`PaperBroker` self-drives the order state machine** — `place_order` mutates the
+  caller's `Order` (`submit`/`open`/`apply_fill`), violating the `Broker` port
+  contract (the `OrderRouter` owns the lifecycle). The router tolerates both styles
+  for now; `PaperBroker` is to be made port-pure (return a venue id + expose fills,
+  no caller mutation) in **E4 leaf 04** when the fill→position flow is consolidated.
+- **E4-02/03 landed via local merge (GitHub outage)** — `PaperBroker` and
+  `OrderRouter` were verified locally and merged into `develop` without a per-leaf PR
+  during a GitHub connectivity outage; to be pushed/recorded when connectivity is
+  stable.

--- a/doc/dev/plans/execution-engine/00-plan.md
+++ b/doc/dev/plans/execution-engine/00-plan.md
@@ -34,7 +34,7 @@ don't-assume, fills are the PnL truth, all money `Decimal`. Everything is verifi
 
 - [x] 01 app-kernel — feat/app-kernel — medium
 - [x] 02 paper-broker — feat/paper-broker — medium
-- [ ] 03 order-router — feat/order-router — high (depends on 01, 02)
+- [x] 03 order-router — feat/order-router — high (depends on 01, 02)
 - [ ] 04 position-tracker — feat/position-tracker — medium (depends on 03)
 - [ ] 05 reconciliation — feat/reconciliation — high (depends on 03, 04)
 

--- a/doc/dev/plans/execution-engine/02-paper-broker.md
+++ b/doc/dev/plans/execution-engine/02-paper-broker.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/paper-broker
-pr: "#XX"
+pr: "local-merge (GitHub outage)"
 ---
 
 # PaperBroker — in-process fill simulation

--- a/doc/dev/plans/execution-engine/03-order-router.md
+++ b/doc/dev/plans/execution-engine/03-order-router.md
@@ -1,7 +1,7 @@
 ---
 plan: execution-engine/03-order-router
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01, 02]
 parallel: false

--- a/doc/dev/plans/execution-engine/03-order-router.md
+++ b/doc/dev/plans/execution-engine/03-order-router.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [01, 02]
 parallel: false
 branch: feat/order-router
-pr: ""
+pr: "local-merge (GitHub outage)"
 ---
 
 # OrderRouter — idempotent submit + state-machine driving

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -18,6 +18,13 @@ cross-cutting primitives:
   :class:`~trading_bot.application.events.LogEvent`): the pub/sub fan-out the
   router, the position tracker and a future UI consume. Events carry domain
   objects, so money stays :class:`~decimal.Decimal` end to end.
+
+It then layers the engine's first use-case:
+
+* order_router — the :class:`~trading_bot.application.order_router.OrderRouter`,
+  the engine's idempotent write path: it submits domain orders to a
+  :class:`~trading_bot.brokers.base.Broker` (deduped by client-order-id), drives
+  each through its lifecycle state machine, and emits ``OrderEvent``\\ s.
 """
 
 from __future__ import annotations
@@ -35,6 +42,7 @@ from trading_bot.application.events import (
     LogEvent,
     OrderEvent,
 )
+from trading_bot.application.order_router import OrderRouter
 
 __all__ = [
     # config
@@ -48,4 +56,6 @@ __all__ = [
     "OrderEvent",
     "FillEvent",
     "LogEvent",
+    # use-cases
+    "OrderRouter",
 ]

--- a/trading_bot/application/order_router.py
+++ b/trading_bot/application/order_router.py
@@ -1,0 +1,295 @@
+"""The :class:`OrderRouter` — the engine's idempotent write path.
+
+The router is the **safety core of execution**: it is the single use-case that
+turns a domain :class:`~trading_bot.domain.order.Order` into a live venue order.
+It does three things and no more:
+
+* **submits orders idempotently** — keyed by the order's ``client_order_id``, so
+  a retry (or a concurrent double-submit) of the same id produces **exactly one**
+  broker order, never a duplicate venue order;
+* **drives the order's state machine** from the broker's response
+  (``NEW -> SUBMITTED -> OPEN``, or ``-> REJECTED`` on a broker/order failure);
+* **cancels** a tracked order on the venue and transitions it.
+
+It speaks **domain types only** and never touches money as ``float`` (orders and
+events carry :class:`~decimal.Decimal` throughout). Every broker operation is
+gated through :func:`~trading_bot.brokers.base.require` against the broker's
+declared :class:`~trading_bot.brokers.base.Capability` set, so a venue is never
+asked for an operation it has not declared.
+
+Idempotency mechanism (carried into the ADR)
+---------------------------------------------
+Idempotency here is **purely engine-side**: a dedup map ``client_order_id ->
+Order`` records every order the router has *tracked*. A second :meth:`submit`
+with the same id returns the already-tracked order and does **not** call the
+broker again. This is the only line of defence the router owns; venue-level
+idempotency (an exchange-side dedup token on ``AddOrder``) is a deferred go-live
+item (see ``doc/dev/06-status.md``) and is **out of scope** here.
+
+A rejected submission is *also* recorded (the dedup map keeps the terminal,
+``REJECTED`` order), so a retry of a poisoned id surfaces the original rejection
+without a second broker call — the router never double-submits, even on failure.
+
+Concurrency guard (carried into the ADR)
+----------------------------------------
+The dedup map alone is not enough under concurrency: two ``await``\\ ed submits of
+the same id interleaving at the first ``await broker.place_order(...)`` could each
+see an empty map and each call the broker. The guard is a **per-id in-flight
+future map** (``dict[str, asyncio.Future[Order]]``): the first submit of an id
+installs a future and does the real work; any concurrent submit of the same id
+finds the future and simply ``await``\\ s its result. The future resolves to the
+tracked order on success, or *raises* (propagating the rejection) on failure, and
+is removed once settled. Because asyncio is single-threaded and the
+install-or-find check runs synchronously (no ``await`` between the lookup and the
+install), exactly one coroutine ever reaches the broker per id.
+
+Fill ingestion — the boundary (carried into the ADR)
+----------------------------------------------------
+The router owns **submit and cancel only**. Fill ingestion does **not** live
+here: applying a :class:`~trading_bot.domain.fill.Fill` to an order, recomputing
+the average price and folding it into a position is the job of the
+``PositionTracker`` (leaf 04), which subscribes to the broker's fill stream and
+owns PnL. Keeping the router to the write path (intent -> venue) and the tracker
+to the read-back path (executions -> position) is the simplest correct boundary:
+the router never needs to know about PnL, and the tracker never needs to know how
+an order was submitted. The router therefore exposes no ``ingest_fill`` method.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from trading_bot.application.events import EventBus, OrderEvent
+from trading_bot.brokers.base import Broker, Capability, require
+from trading_bot.domain.errors import BrokerError, MissingOrder, OrderError
+from trading_bot.domain.order import Order, OrderStatus
+
+__all__ = ["OrderRouter"]
+
+logger = logging.getLogger(__name__)
+
+
+class OrderRouter:
+    """Idempotent order submission + lifecycle driving over a :class:`Broker`.
+
+    Construct it with the broker to route to and the :class:`EventBus` to emit
+    lifecycle events on, then drive orders with :meth:`submit` and :meth:`cancel`.
+    The broker must declare :attr:`~trading_bot.brokers.base.Capability.PLACE_ORDER`
+    and :attr:`~trading_bot.brokers.base.Capability.CANCEL`; this is checked up
+    front so a mis-capable broker fails loudly at construction, not at first use.
+
+    Parameters
+    ----------
+    broker : Broker
+        The venue adapter to route orders to. Must declare ``PLACE_ORDER`` and
+        ``CANCEL`` capabilities.
+    event_bus : EventBus
+        The bus every order lifecycle change is emitted on, as an
+        :class:`~trading_bot.application.events.OrderEvent` carrying the live
+        :class:`Order`.
+
+    Raises
+    ------
+    NoCapability
+        If ``broker`` does not declare both ``PLACE_ORDER`` and ``CANCEL``.
+
+    """
+
+    def __init__(self, broker: Broker, event_bus: EventBus) -> None:
+        # Gate up front: a broker that cannot place *and* cancel is not a valid
+        # write-path target, so fail at construction rather than at first call.
+        require(broker, Capability.PLACE_ORDER)
+        require(broker, Capability.CANCEL)
+        self._broker = broker
+        self._bus = event_bus
+        # Dedup map: every order the router has tracked, keyed by its identity.
+        self._orders: dict[str, Order] = {}
+        # Per-id in-flight submissions, the concurrency guard (see module doc).
+        self._inflight: dict[str, asyncio.Future[Order]] = {}
+
+    async def submit(self, order: Order) -> Order:
+        """Submit ``order`` to the broker idempotently and drive its lifecycle.
+
+        Idempotent on ``order.client_order_id``: if that id was already submitted
+        (successfully or rejected), the already-tracked order is returned and the
+        broker is **not** called again. A concurrent second submit of the same id
+        awaits the in-flight submission rather than starting a second one (see the
+        module docstring's concurrency guard).
+
+        On a fresh id the router drives ``NEW -> SUBMITTED -> OPEN``:
+        :meth:`Order.submit`, then ``venue_id = await broker.place_order(order)``,
+        then :meth:`Order.open` with the venue id, tracks the order, and emits one
+        :class:`~trading_bot.application.events.OrderEvent`.
+
+        Parameters
+        ----------
+        order : Order
+            The order to submit. Its ``client_order_id`` is the idempotency key.
+
+        Returns
+        -------
+        Order
+            The tracked order. On a duplicate id this is the *original* tracked
+            order, not ``order``.
+
+        Raises
+        ------
+        BrokerError or OrderError
+            If the broker (or the order's own state machine) fails the
+            submission. The order is driven to ``REJECTED``, a reject
+            :class:`OrderEvent` is emitted, the attempt is recorded (so a retry of
+            the same id does not re-call the broker), and the error is re-raised.
+
+        """
+        cid = order.client_order_id
+
+        # Already tracked (succeeded earlier, or rejected earlier): return the
+        # tracked order, never re-call the broker. This is the steady-state
+        # idempotency check for a *sequential* retry.
+        existing = self._orders.get(cid)
+        if existing is not None:
+            return existing
+
+        # An in-flight submission of this id is running: await its result instead
+        # of starting a second one. This is the concurrency guard.
+        inflight = self._inflight.get(cid)
+        if inflight is not None:
+            return await inflight
+
+        # We are the first submitter of this id. Install the in-flight future
+        # *synchronously* (no await before this point since the lookup), so a
+        # concurrently-scheduled submit of the same id finds it above.
+        loop = asyncio.get_running_loop()
+        future: asyncio.Future[Order] = loop.create_future()
+        self._inflight[cid] = future
+        try:
+            result = await self._do_submit(order)
+        except BaseException as exc:
+            if not future.done():
+                future.set_exception(exc)
+            raise
+        else:
+            if not future.done():
+                future.set_result(result)
+            return result
+        finally:
+            # The future has done its job (relayed the result/exception to any
+            # waiters); drop it so the dedup map is the single source of truth.
+            self._inflight.pop(cid, None)
+
+    async def _do_submit(self, order: Order) -> Order:
+        """Drive one fresh submission ``NEW -> SUBMITTED -> OPEN`` (or reject).
+
+        Per the :class:`Broker` port, the *caller* drives the lifecycle:
+        :meth:`Order.submit`, then ``place_order`` returns the venue id, then
+        :meth:`Order.open`. Some adapters (notably
+        :class:`~trading_bot.brokers.paper.PaperBroker`) instead *self-drive* the
+        state machine inside ``place_order`` — they require a ``NEW`` order and
+        may even fill it immediately. To support both honestly, the router calls
+        ``place_order`` with the order still ``NEW`` and *then* advances the
+        machine only as far as the broker left it: a self-driving broker has
+        already moved it past ``NEW`` (so the router does nothing), while a
+        port-pure broker leaves it ``NEW`` (so the router drives the full
+        ``NEW -> SUBMITTED -> OPEN`` with the returned venue id). Either way the
+        router never double-drives a transition.
+        """
+        try:
+            venue_id = await self._broker.place_order(order)
+            # Port-pure broker: it only transmitted the order and returned the id;
+            # the order is still NEW, so the *router* drives the lifecycle. A
+            # self-driving broker already advanced it (OPEN / FILLED) — skip.
+            if order.status is OrderStatus.NEW:
+                order.submit()
+                order.open(venue_id)
+        except (BrokerError, OrderError) as exc:
+            # Record the (rejected) attempt *before* surfacing, so a retry of the
+            # same id is deduped and never double-submits to the venue.
+            self._reject(order, str(exc))
+            raise
+        # Track the (now live or terminal-by-fill) order so the dedup map owns it.
+        self._orders[order.client_order_id] = order
+        self._bus.emit(OrderEvent(order))
+        return order
+
+    def _reject(self, order: Order, reason: str) -> None:
+        """Drive ``order`` to ``REJECTED``, track the attempt, and emit an event.
+
+        Rejection is only legal from ``SUBMITTED`` in the state machine, but a
+        ``place_order`` may fail while the order is still ``NEW`` (a port-pure
+        broker that never advanced it). To always land on the terminal,
+        deduped-and-tracked ``REJECTED`` state, the router first nudges a ``NEW``
+        order to ``SUBMITTED`` (this never reaches the venue) and then rejects it.
+        Tolerant if even that is forbidden: the id is still tracked so a retry is
+        deduped, and a reject event is still emitted.
+        """
+        try:
+            if order.status is OrderStatus.NEW:
+                order.submit()
+            order.reject(reason)
+        except OrderError:
+            # The state machine forbade the transition (e.g. the order is already
+            # terminal). The id must still be recorded so a retry is deduped;
+            # carry on to track + emit whatever state the order is in.
+            logger.debug(
+                "order %s could not transition to REJECTED from %s",
+                order.client_order_id,
+                order.status.value,
+            )
+        self._orders[order.client_order_id] = order
+        self._bus.emit(OrderEvent(order))
+
+    async def cancel(self, order_or_id: Order | str) -> Order:
+        """Cancel a tracked order on the broker and transition it to ``CANCELLED``.
+
+        Resolves ``order_or_id`` to the tracked order, cancels it on the venue via
+        the order's ``venue_order_id``, drives :meth:`Order.cancel` (unless the
+        broker self-drove it, as :class:`~trading_bot.brokers.paper.PaperBroker`
+        does), and emits an :class:`~trading_bot.application.events.OrderEvent`.
+
+        Parameters
+        ----------
+        order_or_id : Order or str
+            Either a tracked :class:`Order` or its ``client_order_id``.
+
+        Returns
+        -------
+        Order
+            The now-cancelled tracked order.
+
+        Raises
+        ------
+        MissingOrder
+            If no order is tracked under that id (it was never submitted here).
+        BrokerError
+            If the broker fails the cancellation. The order's local state is left
+            untouched (the cancel is driven only after the broker confirms).
+
+        """
+        order = self._resolve(order_or_id)
+        if order.venue_order_id is None:
+            raise MissingOrder(order.client_order_id)
+        await self._broker.cancel_order(order.venue_order_id)
+        # Same self-driving caveat as submit: a broker like PaperBroker cancels
+        # the domain order itself inside cancel_order. Only drive the transition
+        # ourselves if the broker has not already moved it to CANCELLED.
+        if order.status is not OrderStatus.CANCELLED:
+            order.cancel()
+        self._bus.emit(OrderEvent(order))
+        return order
+
+    def _resolve(self, order_or_id: Order | str) -> Order:
+        """Resolve an :class:`Order` or a client-order-id to the tracked order."""
+        cid = order_or_id if isinstance(order_or_id, str) else order_or_id.client_order_id
+        order = self._orders.get(cid)
+        if order is None:
+            raise MissingOrder(cid)
+        return order
+
+    def get(self, client_order_id: str) -> Order | None:
+        """Return the tracked order for ``client_order_id``, or ``None``.
+
+        A read-only view of the dedup map, for callers (tests, a UI) that need to
+        inspect what the router has tracked without driving a transition.
+        """
+        return self._orders.get(client_order_id)

--- a/trading_bot/tests/application/test_order_router.py
+++ b/trading_bot/tests/application/test_order_router.py
@@ -1,0 +1,320 @@
+"""Tests for the :class:`OrderRouter` — the engine's idempotent write path.
+
+These prove the router's safety contract:
+
+* **idempotent submit** — submitting the same ``client_order_id`` twice calls the
+  broker's ``place_order`` exactly *once* and returns the same tracked order
+  (asserted against a counting spy broker and against the real ``PaperBroker``);
+* **concurrent** idempotent submit — ``asyncio.gather`` of two submits of one id
+  still produces exactly one broker order;
+* submit drives ``NEW -> SUBMITTED -> OPEN`` (venue id set) and emits exactly one
+  ``OrderEvent``;
+* a broker that raises :class:`BrokerError` on ``place_order`` drives the order to
+  ``REJECTED``, emits a reject event, surfaces the error, and *records* the
+  attempt so a re-submit of the same id does **not** re-call the broker;
+* ``cancel`` cancels on the broker and transitions the order, emitting an event.
+
+The final "real data" test routes a realistic sequence through the actual
+``PaperBroker`` and asserts the lifecycle end to end. Async tests run un-decorated
+(``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from trading_bot.application import EventBus, OrderEvent, OrderRouter
+from trading_bot.brokers.base import Broker, Capability
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain import (
+    BrokerError,
+    Instrument,
+    MissingOrder,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Symbol,
+    money,
+)
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+def _order(cid: str = "cid-1", qty: str = "1") -> Order:
+    """A realistic limit BUY order for assertions."""
+    return Order(
+        client_order_id=cid,
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money(qty),
+        type=OrderType.LIMIT,
+        limit_price=money("30000"),
+    )
+
+
+# --- test doubles ---------------------------------------------------------- #
+
+
+class _SpyBroker(Broker):
+    """A counting broker: records every ``place_order``/``cancel_order`` call.
+
+    Serves only ``PLACE_ORDER`` and ``CANCEL`` (the two capabilities the router
+    requires); other port methods are not exercised by the router and raise.
+    """
+
+    name = "spy"
+
+    def __init__(self, *, fail: bool = False, slow: bool = False) -> None:
+        self.place_calls = 0
+        self.cancel_calls = 0
+        self._fail = fail
+        self._slow = slow
+        self._ids = 0
+
+    def capabilities(self) -> set[Capability]:
+        return {Capability.PLACE_ORDER, Capability.CANCEL}
+
+    async def place_order(self, order: Order) -> str:
+        # Yield first so two concurrent submits genuinely interleave: if the
+        # router's guard were broken, both would have incremented the counter.
+        if self._slow:
+            await asyncio.sleep(0)
+        self.place_calls += 1
+        if self._fail:
+            raise BrokerError("venue rejected the order")
+        self._ids += 1
+        return f"SPY-{self._ids}"
+
+    async def cancel_order(self, venue_order_id: str) -> None:
+        self.cancel_calls += 1
+
+    # --- unused port surface (router never calls these) ---
+    async def open_orders(self):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def balances(self):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def fills(self, since_ms=None):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def ticker(self, instrument):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+
+def _capture(bus: EventBus) -> list[object]:
+    """Subscribe a sink to ``bus`` and return the list it accumulates into."""
+    seen: list[object] = []
+    bus.subscribe(seen.append)
+    return seen
+
+
+# --- capability gate ------------------------------------------------------- #
+
+
+class _NoPlaceBroker(_SpyBroker):
+    name = "noplace"
+
+    def capabilities(self) -> set[Capability]:
+        return {Capability.CANCEL}
+
+
+def test_construction_requires_place_and_cancel() -> None:
+    """A broker missing PLACE_ORDER is rejected up front (NoCapability)."""
+    from trading_bot.domain import NoCapability
+
+    with pytest.raises(NoCapability):
+        OrderRouter(_NoPlaceBroker(), EventBus())
+
+
+# --- submit lifecycle ------------------------------------------------------ #
+
+
+async def test_submit_drives_new_submitted_open_and_emits_one_event() -> None:
+    """Submit drives NEW->SUBMITTED->OPEN, sets the venue id, emits one event."""
+    broker = _SpyBroker()
+    bus = EventBus()
+    seen = _capture(bus)
+    router = OrderRouter(broker, bus)
+
+    order = _order()
+    assert order.status is OrderStatus.NEW
+
+    returned = await router.submit(order)
+
+    assert returned is order
+    assert order.status is OrderStatus.OPEN
+    assert order.venue_order_id == "SPY-1"
+    assert broker.place_calls == 1
+    # Exactly one OrderEvent, carrying the live order.
+    assert len(seen) == 1
+    assert isinstance(seen[0], OrderEvent)
+    assert seen[0].order is order
+
+
+# --- idempotency: sequential ----------------------------------------------- #
+
+
+async def test_duplicate_submit_calls_broker_once_and_returns_same_order() -> None:
+    """A second submit of the same id returns the tracked order, no 2nd call."""
+    broker = _SpyBroker()
+    bus = EventBus()
+    seen = _capture(bus)
+    router = OrderRouter(broker, bus)
+
+    first = await router.submit(_order(cid="dup"))
+    # A *different* Order object, same client_order_id.
+    second = await router.submit(_order(cid="dup"))
+
+    assert broker.place_calls == 1, "broker must be called exactly once"
+    assert second is first, "duplicate submit returns the original tracked order"
+    # Only the first submission emitted an event.
+    assert len(seen) == 1
+
+
+# --- idempotency: concurrent ----------------------------------------------- #
+
+
+async def test_concurrent_submit_of_same_id_produces_one_broker_order() -> None:
+    """Two gathered submits of one id still yield exactly one broker order."""
+    broker = _SpyBroker(slow=True)  # awaits inside place_order to force interleave
+    bus = EventBus()
+    seen = _capture(bus)
+    router = OrderRouter(broker, bus)
+
+    a, b = await asyncio.gather(
+        router.submit(_order(cid="race")),
+        router.submit(_order(cid="race")),
+    )
+
+    assert broker.place_calls == 1, "concurrency guard must collapse to one call"
+    assert a is b, "both submits resolve to the same tracked order"
+    assert a.status is OrderStatus.OPEN
+    assert len(seen) == 1
+
+
+# --- rejection ------------------------------------------------------------- #
+
+
+async def test_broker_error_rejects_order_emits_event_and_surfaces() -> None:
+    """A BrokerError on place_order -> REJECTED + reject event + raised error."""
+    broker = _SpyBroker(fail=True)
+    bus = EventBus()
+    seen = _capture(bus)
+    router = OrderRouter(broker, bus)
+
+    order = _order(cid="bad")
+    with pytest.raises(BrokerError):
+        await router.submit(order)
+
+    assert order.status is OrderStatus.REJECTED
+    assert order.reject_reason == "venue rejected the order"
+    # A reject OrderEvent was emitted carrying the rejected order.
+    assert len(seen) == 1
+    assert isinstance(seen[0], OrderEvent)
+    assert seen[0].order.status is OrderStatus.REJECTED
+
+
+async def test_resubmit_after_rejection_does_not_recall_broker() -> None:
+    """A retry of a rejected id is deduped: no second broker call."""
+    broker = _SpyBroker(fail=True)
+    bus = EventBus()
+    router = OrderRouter(broker, bus)
+
+    with pytest.raises(BrokerError):
+        await router.submit(_order(cid="bad"))
+    assert broker.place_calls == 1
+
+    # Re-submit the same id: returns the tracked (rejected) order, no 2nd call.
+    again = await router.submit(_order(cid="bad"))
+    assert broker.place_calls == 1, "rejected id must not double-submit"
+    assert again.status is OrderStatus.REJECTED
+
+
+# --- cancel ---------------------------------------------------------------- #
+
+
+async def test_cancel_cancels_on_broker_and_transitions_order() -> None:
+    """Cancel calls the broker, drives CANCELLED, and emits an event."""
+    # A partially-filling paper broker leaves the order live so it is cancellable.
+    broker = PaperBroker(fill_model="partial", partial_fill_ratio=money("0.5"))
+    bus = EventBus()
+    seen = _capture(bus)
+    router = OrderRouter(broker, bus)
+
+    order = await router.submit(_order(cid="to-cancel"))
+    assert order.status is OrderStatus.PARTIALLY_FILLED
+
+    cancelled = await router.cancel("to-cancel")
+
+    assert cancelled is order
+    assert order.status is OrderStatus.CANCELLED
+    assert len(await broker.open_orders()) == 0
+    # submit event + cancel event.
+    assert len(seen) == 2
+    assert seen[-1].order.status is OrderStatus.CANCELLED
+
+
+async def test_cancel_unknown_id_raises_missing_order() -> None:
+    """Cancelling an id the router never tracked raises MissingOrder."""
+    router = OrderRouter(PaperBroker(), EventBus())
+    with pytest.raises(MissingOrder):
+        await router.cancel("never-seen")
+
+
+# --- verification on real data (PaperBroker) ------------------------------- #
+
+
+async def test_real_paperbroker_duplicate_id_yields_one_paper_order() -> None:
+    """End-to-end: a duplicate client-order-id produces exactly one paper order.
+
+    Routes a realistic sequence through the *actual* ``PaperBroker``: submit an
+    order (one paper order + one fill), then submit the SAME client-order-id again
+    and assert the broker produced exactly one order/fill and the events match the
+    lifecycle.
+    """
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("100000")},
+    )
+    bus = EventBus()
+    seen = _capture(bus)
+    router = OrderRouter(broker, bus)
+
+    first = await router.submit(_order(cid="real-1"))
+    # Immediate fill model: the order is fully filled on placement.
+    assert first.status is OrderStatus.FILLED
+    assert first.venue_order_id == "PAPER-1"
+
+    # Same client-order-id again -> dedup, no second paper order/fill.
+    second = await router.submit(_order(cid="real-1"))
+    assert second is first
+
+    fills = await broker.fills()
+    assert len(fills) == 1, "duplicate id must not create a second paper fill"
+    assert fills[0].client_order_id == "real-1"
+
+    # Exactly one OrderEvent for the single accepted submission, FILLED.
+    order_events = [e for e in seen if isinstance(e, OrderEvent)]
+    assert len(order_events) == 1
+    assert order_events[0].order.status is OrderStatus.FILLED
+
+
+async def test_real_paperbroker_concurrent_duplicate_one_order() -> None:
+    """End-to-end concurrency: gathered duplicate submits -> one paper order."""
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("100000")},
+    )
+    router = OrderRouter(broker, EventBus())
+
+    a, b = await asyncio.gather(
+        router.submit(_order(cid="real-race")),
+        router.submit(_order(cid="real-race")),
+    )
+
+    assert a is b
+    assert len(await broker.fills()) == 1, "one paper fill despite two submits"


### PR DESCRIPTION
## Summary
- Third leaf of **E4**: `trading_bot/application/order_router.py` — `OrderRouter`.
- **Idempotent submit** (client-order-id dedup map + per-id in-flight `asyncio.Future` so concurrent submits of the same id → exactly one `broker.place_order`); drives the domain `Order` state machine (`submit`→`open`; `reject` on `BrokerError`); emits `OrderEvent`s. Fill ingestion lives in the PositionTracker (leaf 04) — the write/read-back split.

## Why
- Idempotent submission is a money-safety invariant; the dedup map + in-flight future cover sequential and concurrent retries. See `doc/dev/03-decisions.md`. (Venue-level idempotency stays deferred — #23 ADR.)

## Note
- Implemented during the GitHub outage (merged locally then); this PR records it properly. Surfaced a contract finding: `PaperBroker` self-drives the `Order` (router tolerates it; fix in leaf 04). See `doc/dev/06-status.md`.

## Test plan
- [x] `.venv/bin/python -m pytest` (317 passed, **0 skipped**); idempotency proven — 1 broker order for a duplicate id, sequential AND concurrent (`asyncio.gather`)
- [x] `ruff` + `mypy` clean