### PR TITLE
docs: link E4-02/03 to PRs #24/#25; drop stale outage note

### DIFF
--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -54,7 +54,3 @@ risk, the CLI, the orchestration layer, and (later) the UI and go-live hardening
   contract (the `OrderRouter` owns the lifecycle). The router tolerates both styles
   for now; `PaperBroker` is to be made port-pure (return a venue id + expose fills,
   no caller mutation) in **E4 leaf 04** when the fill→position flow is consolidated.
-- **E4-02/03 landed via local merge (GitHub outage)** — `PaperBroker` and
-  `OrderRouter` were verified locally and merged into `develop` without a per-leaf PR
-  during a GitHub connectivity outage; to be pushed/recorded when connectivity is
-  stable.

--- a/doc/dev/plans/execution-engine/02-paper-broker.md
+++ b/doc/dev/plans/execution-engine/02-paper-broker.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/paper-broker
-pr: "local-merge (GitHub outage)"
+pr: "#24"
 ---
 
 # PaperBroker — in-process fill simulation

--- a/doc/dev/plans/execution-engine/03-order-router.md
+++ b/doc/dev/plans/execution-engine/03-order-router.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [01, 02]
 parallel: false
 branch: feat/order-router
-pr: "local-merge (GitHub outage)"
+pr: "#25"
 ---
 
 # OrderRouter — idempotent submit + state-machine driving


### PR DESCRIPTION
Post-flush cleanup: the PaperBroker (#24) and OrderRouter (#25) leaves landed via proper PRs once GitHub recovered, so their plan-tree `pr:` fields now point to #24/#25 and the now-false "landed via local merge" status note is removed.