### PR TITLE
feat: reconciliation — converge local state with the broker (closes E4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   incl. concurrent) + order-lifecycle driving + events.
 - `application.PositionTracker` — live per-instrument `Position`s folded from
   broker-confirmed `FillEvent`s (delegates to `Position.from_fills`).
+- `application.reconcile` — converge local order/position state with the broker on
+  startup/reconnect (adopt venue open orders, ingest unknown, close orphans, rebuild
+  positions from broker fills; idempotent). Completes the **E4 execution engine**.
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,26 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-21 Reconciliation: venue is truth, rebuild positions from fills, idempotent
+
+**Decision.** `application/reconcile.py` `reconcile(broker, router, tracker)` reads the
+broker's open orders + balances + fills and converges local state, writing **only**
+locally (never to the venue). **Orders — venue open set is truth:** ingest unknown
+venue-open orders (no broker call, no lifecycle transition), keep already-tracked ones
+(ingest idempotent, engine object authoritative), **close-and-forget** non-terminal
+orphans the venue has no record of (drive `CANCELLED` + evict), leave terminal locals.
+**Positions — broker fills are truth:** rebuild the `PositionTracker` from
+`broker.fills()` so positions equal `Position.from_fills` per instrument. **Idempotent:**
+no venue change ⇒ second pass is a no-op. Added minimal helpers `OrderRouter.{tracked_orders,ingest,forget}`
+and `PositionTracker.reset` (no private-state reaching).
+
+**Why.** *Reconcile, don't assume* is a hard live-trading invariant: after any
+disconnect the venue's records — not local optimism — must win, with no order
+duplicated or lost. Rebuilding positions from fills (rather than diffing) is trivially
+correct and never double-counts. Idempotency makes it safe to run on every reconnect.
+
+---
+
 ### 2026-06-21 PositionTracker from fills; PaperBroker made port-pure
 
 **Decision.** `application/position_tracker.py` `PositionTracker` keeps a per-instrument

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,15 +10,16 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**E1 (domain), E2 (transport) and E3 (brokers) are complete** — the whole
-**Foundation** block. `trading_bot/domain/` (money, instrument, errors, order, fill,
-position, signal, performance — pure, mypy-strict), `trading_bot/transport/`
-(`AsyncHTTPClient`, `WebSocketBase`, `RateLimiter` + `KrakenCallCounter`), and
-`trading_bot/brokers/` (the `Broker` port + registry + `KrakenBroker` REST +
-`KrakenPrivateWS` — signing verified vs Kraken's vector; private endpoints
-mock-tested, real private verification gated on a key) are in. The later layers
-(`storage`, `application`, `interfaces`) are pending — next is **E4 (execution
-engine)**. See `07-roadmap.md` /
+**Foundation (E1–E3) and the execution engine (E4) are complete.**
+`trading_bot/domain/` (money, instrument, errors, order, fill, position, signal,
+performance — pure, mypy-strict), `trading_bot/transport/` (`AsyncHTTPClient`,
+`WebSocketBase`, `RateLimiter` + `KrakenCallCounter`), `trading_bot/brokers/` (the
+`Broker` port + registry + `KrakenBroker` REST + `KrakenPrivateWS` + the **port-pure
+`PaperBroker`**), and `trading_bot/application/` (`AppConfig` + `EventBus`,
+`OrderRouter` with idempotent submit, `PositionTracker` from fills, `reconcile`) are
+in — the whole order→fill→position→reconcile path runs in-process. The later layers
+(strategy runner, storage, perf/risk, interfaces) are pending — next is **E5
+(strategy runner)**. See `07-roadmap.md` /
 `08-program-plan.md`.
 
 ## Done

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,9 +12,6 @@ The single source *index* of open work. Each unchecked item is a candidate for
 
 ## Execution engine
 
-- [ ] **E4 — Order router + PaperBroker.** Idempotent submit (client-order-id),
-  routing, reconciliation; `PaperBroker` simulation behind the same port;
-  `PositionTracker` from confirmed fills. _(depends on E3)_
 - [ ] **E5 — Strategy runner.** Load a strategy (config + fynance signal), feed it
   data from dccd, emit target positions/orders; the live loop. Replaces
   `legacy/StrategyBot`. _(depends on E4)_

--- a/doc/dev/plans/execution-engine/00-plan.md
+++ b/doc/dev/plans/execution-engine/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: execution-engine
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E4 — Order router + PaperBroker.** Idempotent submit (client-order-id), routing, reconciliation; `PaperBroker` simulation behind the same port; `PositionTracker` from confirmed fills."
 release_on_done: false
 ---
@@ -36,7 +36,7 @@ don't-assume, fills are the PnL truth, all money `Decimal`. Everything is verifi
 - [x] 02 paper-broker — feat/paper-broker — medium
 - [x] 03 order-router — feat/order-router — high (depends on 01, 02)
 - [x] 04 position-tracker — feat/position-tracker — medium (depends on 03)
-- [ ] 05 reconciliation — feat/reconciliation — high (depends on 03, 04)
+- [x] 05 reconciliation — feat/reconciliation — high (depends on 03, 04)
 
 ## Dependencies
 

--- a/doc/dev/plans/execution-engine/05-reconciliation.md
+++ b/doc/dev/plans/execution-engine/05-reconciliation.md
@@ -1,7 +1,7 @@
 ---
 plan: execution-engine/05-reconciliation
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [03, 04]
 parallel: false

--- a/doc/dev/plans/execution-engine/05-reconciliation.md
+++ b/doc/dev/plans/execution-engine/05-reconciliation.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [03, 04]
 parallel: false
 branch: feat/reconciliation
-pr: ""
+pr: "#28"
 ---
 
 # Reconciliation — converge local state with the broker

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -31,6 +31,12 @@ It then layers the engine's use-cases:
   applied explicitly) into a live net
   :class:`~trading_bot.domain.position.Position` per instrument, the owner of
   exposure and realised PnL.
+* reconcile — :func:`~trading_bot.application.reconcile.reconcile` (and its
+  :class:`~trading_bot.application.reconcile.ReconResult`): the *reconcile,
+  don't assume* pass that, on startup or after a disconnect, refetches the
+  venue's open orders, balances and fills and converges the router's tracked
+  orders and the tracker's positions to that truth — never leaving a duplicated
+  or lost order.
 """
 
 from __future__ import annotations
@@ -50,6 +56,7 @@ from trading_bot.application.events import (
 )
 from trading_bot.application.order_router import OrderRouter
 from trading_bot.application.position_tracker import PositionTracker
+from trading_bot.application.reconcile import ReconResult, reconcile
 
 __all__ = [
     # config
@@ -66,4 +73,6 @@ __all__ = [
     # use-cases
     "OrderRouter",
     "PositionTracker",
+    "reconcile",
+    "ReconResult",
 ]

--- a/trading_bot/application/order_router.py
+++ b/trading_bot/application/order_router.py
@@ -279,3 +279,63 @@ class OrderRouter:
         inspect what the router has tracked without driving a transition.
         """
         return self._orders.get(client_order_id)
+
+    def tracked_orders(self) -> dict[str, Order]:
+        """Return a snapshot of every tracked order, keyed by client-order-id.
+
+        A read-only copy of the dedup map (the mapping is fresh; the
+        :class:`Order` values are shared). For callers — notably
+        :func:`~trading_bot.application.reconcile.reconcile` — that need to
+        diff the router's view against the venue's truth without driving a
+        transition.
+        """
+        return dict(self._orders)
+
+    def ingest(self, order: Order) -> Order:
+        """Adopt an already-live venue ``order`` into the tracked map, no submit.
+
+        The reconciliation path (:func:`~trading_bot.application.reconcile.
+        reconcile`) uses this to adopt an order the **venue** reports as open
+        but the router never tracked locally (e.g. submitted before a restart,
+        or in a window the engine missed). Unlike :meth:`submit`, this performs
+        **no broker call** and drives **no lifecycle transition** — ``order`` is
+        the venue's already-reconstructed view (its ``status`` and
+        ``venue_order_id`` are populated by the broker's ``open_orders``), and
+        the router simply records it under its ``client_order_id`` so subsequent
+        :meth:`get` / :meth:`cancel` resolve it.
+
+        Idempotent on ``client_order_id``: ingesting an id the router already
+        tracks is a no-op that returns the **existing** tracked order (the
+        engine's own object is authoritative for an id it already owns; the
+        venue snapshot is not allowed to clobber it). This keeps reconciliation
+        from ever duplicating an order.
+
+        Parameters
+        ----------
+        order : Order
+            The venue's reconstructed open order to adopt. Its
+            ``client_order_id`` is the tracking key.
+
+        Returns
+        -------
+        Order
+            The tracked order: the freshly-ingested ``order`` on a new id, or
+            the pre-existing tracked order on an id already owned.
+
+        """
+        existing = self._orders.get(order.client_order_id)
+        if existing is not None:
+            return existing
+        self._orders[order.client_order_id] = order
+        self._bus.emit(OrderEvent(order))
+        return order
+
+    def forget(self, client_order_id: str) -> Order | None:
+        """Drop ``client_order_id`` from the tracked map, returning the order.
+
+        The reconciliation path uses this to evict an **orphan**: a locally
+        tracked order the venue reports neither as open nor via any fill, after
+        reconcile has driven it terminal. Returns the removed order, or ``None``
+        if the id was not tracked (a no-op, so a second reconcile is clean).
+        """
+        return self._orders.pop(client_order_id, None)

--- a/trading_bot/application/position_tracker.py
+++ b/trading_bot/application/position_tracker.py
@@ -45,6 +45,8 @@ deterministic in fill order.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 from trading_bot.application.events import Event, EventBus, FillEvent
 from trading_bot.domain.fill import Fill
 from trading_bot.domain.instrument import Instrument
@@ -134,6 +136,36 @@ class PositionTracker:
         position = Position.from_fills(fills)
         self._positions[instrument] = position
         return position
+
+    def reset(self, fills: Iterable[Fill] = ()) -> None:
+        """Discard all tracked fills and rebuild from ``fills`` (the new truth).
+
+        Clears every per-instrument fill list and cached position, then folds
+        ``fills`` in the order given — each fill routed to its instrument's
+        bucket and that instrument's :class:`Position` recomputed via
+        :meth:`apply`. The reconciliation path
+        (:func:`~trading_bot.application.reconcile.reconcile`) calls this with
+        the broker's confirmed :meth:`~trading_bot.brokers.base.Broker.fills`
+        (the PnL source of truth) so local positions converge to **exactly**
+        the venue's, with no double-counting of fills the tracker had already
+        seen.
+
+        Because the broker's fill stream is the de-duplicated source, the
+        result is, by construction, ``Position.from_fills`` over the broker's
+        fills per instrument — re-running with the same fills yields the same
+        positions (idempotent rebuild).
+
+        Parameters
+        ----------
+        fills : Iterable[Fill], optional
+            The fills to rebuild from, **in execution order**. Defaults to
+            empty, which clears the tracker to flat.
+
+        """
+        self._fills = {}
+        self._positions = {}
+        for fill in fills:
+            self.apply(fill)
 
     def position(self, instrument: Instrument) -> Position | None:
         """Return the live net :class:`Position` for ``instrument``, or ``None``.

--- a/trading_bot/application/reconcile.py
+++ b/trading_bot/application/reconcile.py
@@ -1,0 +1,259 @@
+"""Reconciliation — converge local engine state to the broker's truth.
+
+The execution engine holds **two** local views that can drift from the venue:
+
+* the :class:`~trading_bot.application.order_router.OrderRouter`'s tracked-order
+  map (what the engine believes is live), and
+* the :class:`~trading_bot.application.position_tracker.PositionTracker`'s
+  positions (what the engine believes it holds).
+
+They drift whenever the engine is **not** the only writer of the venue's state:
+across a restart (in-memory maps are empty, the venue still holds open orders and
+a fill history), across a disconnect (fills landed while the WS feed was down,
+orders were cancelled on the venue or by another session), or simply because the
+engine missed an event. The standing invariant is **reconcile, don't assume**: on
+startup and after any disconnect, refetch the venue's open orders, balances and
+fills, and *converge* local state to that truth — never leaving a duplicated or a
+lost order, and never inferring a fill the broker did not confirm.
+
+:func:`reconcile` is that pass. It is **read-then-converge**: it pulls the three
+broker views once, then mutates only local state (the router map and the tracker)
+to match — it never places, cancels or otherwise writes to the venue, because the
+venue is the authority being converged *to*. It returns a :class:`ReconResult`
+counting exactly what changed, and emits one
+:class:`~trading_bot.application.events.LogEvent` summarising the pass.
+
+The rules (carried into the ADR)
+--------------------------------
+**Orders — the venue's open set is the truth.**
+
+* *Ingested* — a venue-open order the router does **not** track is adopted into
+  the map via :meth:`~trading_bot.application.order_router.OrderRouter.ingest`
+  (no broker call, no lifecycle transition: it is already live on the venue).
+  This is how an order placed before a restart is recovered.
+* *Adopted* — a venue-open order the router **already** tracks is left as the
+  engine's own object (``ingest`` is idempotent on the id and does not clobber
+  it); it is counted as adopted, not ingested.
+* *Orphan* — a **non-terminal** order the router tracks that the venue reports
+  **neither** as open **nor** in any fill is an orphan: the venue has no record
+  of it, so the engine must not keep believing it is live. The policy is
+  **close-and-forget**: drive it to :data:`~trading_bot.domain.order.OrderStatus
+  .CANCELLED` (tolerant if the state machine forbids the move — a ``NEW`` order
+  is nudged through ``SUBMITTED`` first; an order that cannot legally cancel is
+  still evicted) and drop it from the tracked map. Choosing ``CANCELLED`` over
+  ``REJECTED`` reflects the truth that the order was *accepted at some point but
+  is no longer live on the venue* — it is the least-surprising terminal state and
+  it stops any further engine action on a phantom order. A non-terminal tracked
+  order that has **no venue open record but does have fills** is treated the same
+  way (it is no longer open) — its fills still rebuild the position below.
+* *Terminal local order* — a tracked order already in a terminal state
+  (``FILLED`` / ``CANCELLED`` / ``REJECTED``) is left untouched; it is history,
+  not live state, and the venue not reporting it as open is expected.
+
+**Positions — the broker's fills are the truth.** The tracker is rebuilt from
+scratch (:meth:`~trading_bot.application.position_tracker.PositionTracker.reset`)
+over the broker's confirmed :meth:`~trading_bot.brokers.base.Broker.fills` — fills
+are the PnL source of truth, so the post-reconcile positions are **exactly**
+``Position.from_fills`` over the venue's fills, per instrument. Rebuilding (rather
+than diffing) makes the pass trivially correct and avoids ever double-counting a
+fill the tracker had already applied.
+
+**Idempotency.** With no venue change between two runs, the second
+:func:`reconcile` is a no-op: every venue-open order is already tracked (ingested
+in the first pass), there are no new orphans, and the rebuild folds the same
+fills to the same positions — so the second :class:`ReconResult` reports all
+zeros. This is what lets reconciliation run freely on every reconnect.
+
+**Money is :class:`~decimal.Decimal`** throughout — the broker views carry domain
+objects, so there is no float round-trip.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from trading_bot.application.events import EventBus, LogEvent
+from trading_bot.application.order_router import OrderRouter
+from trading_bot.application.position_tracker import PositionTracker
+from trading_bot.brokers.base import Broker
+from trading_bot.domain.errors import OrderError
+from trading_bot.domain.order import Order, OrderStatus
+
+__all__ = ["ReconResult", "reconcile"]
+
+
+@dataclass(frozen=True, slots=True)
+class ReconResult:
+    """A summary of one :func:`reconcile` pass — what converged, by count.
+
+    Every field is a count of orders/fills/positions the pass touched. A pass
+    over a venue that has not changed since the previous reconcile reports
+    **all zeros** (the idempotency contract).
+
+    Parameters
+    ----------
+    ingested_orders : int
+        Venue-open orders the router did **not** track and now does (adopted via
+        :meth:`~trading_bot.application.order_router.OrderRouter.ingest`).
+    adopted_orders : int
+        Venue-open orders the router **already** tracked (left as the engine's
+        own object; no change beyond confirming they are still live).
+    closed_orphans : int
+        Locally tracked **non-terminal** orders the venue does not report as open
+        — closed (``CANCELLED``) and evicted from the map per the orphan policy.
+    fills_applied : int
+        Broker-confirmed fills folded into the rebuilt
+        :class:`~trading_bot.application.position_tracker.PositionTracker`.
+    positions_rebuilt : int
+        Distinct instruments with a net position after the rebuild.
+
+    """
+
+    ingested_orders: int
+    adopted_orders: int
+    closed_orphans: int
+    fills_applied: int
+    positions_rebuilt: int
+
+    @property
+    def changed(self) -> bool:
+        """Whether the pass converged anything (any non-zero *mutating* count).
+
+        ``True`` when the pass ingested an order or closed an orphan — the two
+        actions that mutate the router's tracked map. ``adopted_orders``,
+        ``fills_applied`` and ``positions_rebuilt`` are *confirmations* of state
+        that already matched (a steady-state reconcile re-folds the same fills
+        into the same positions), so they do **not** by themselves mean the
+        engine's view changed. A no-op idempotent second pass therefore has
+        ``changed is False`` even though it re-reports the standing fill/position
+        counts.
+        """
+        return self.ingested_orders > 0 or self.closed_orphans > 0
+
+
+async def reconcile(
+    broker: Broker,
+    router: OrderRouter,
+    tracker: PositionTracker,
+    *,
+    since_ms: int | None = None,
+    event_bus: EventBus | None = None,
+) -> ReconResult:
+    """Converge the router's orders and the tracker's positions to ``broker``.
+
+    Refetches the venue's open orders, balances and fills, then mutates **only**
+    local state to match (it never writes to the venue). Orders converge to the
+    venue's open set (ingest unknown ones, close orphans), positions are rebuilt
+    from the broker's confirmed fills. See the module docstring for the full
+    reconciliation rules and the orphan-order policy.
+
+    Idempotent: with no venue change between calls, the second pass is a no-op
+    and its :class:`ReconResult` reports all zeros.
+
+    Parameters
+    ----------
+    broker : Broker
+        The venue adapter whose state is the truth. Its ``open_orders``,
+        ``balances`` and ``fills`` are read once each; nothing is written.
+    router : OrderRouter
+        The engine's tracked-order map, converged to the venue's open set.
+    tracker : PositionTracker
+        The engine's positions, rebuilt from the broker's fills.
+    since_ms : int, optional
+        Lower time bound (ms since the Unix epoch, UTC) passed to
+        :meth:`~trading_bot.brokers.base.Broker.fills`. ``None`` (default) pulls
+        the venue's full/default fill window — the safe choice on a cold start,
+        where the tracker is rebuilt from the complete fill history.
+    event_bus : EventBus, optional
+        If given, a single :class:`~trading_bot.application.events.LogEvent`
+        summarising the pass is emitted on it. Defaults to ``None`` (no event).
+
+    Returns
+    -------
+    ReconResult
+        The per-category counts of what the pass converged.
+
+    """
+    # --- 1. Pull the venue's truth (one fetch each; no writes). ------------- #
+    open_orders = await broker.open_orders()
+    await broker.balances()  # refetched for the reconcile contract; not diffed here.
+    broker_fills = await broker.fills(since_ms)
+
+    venue_open_cids = {order.client_order_id for order in open_orders}
+
+    # --- 2. Orders: adopt the venue's open set as truth. -------------------- #
+    ingested = 0
+    adopted = 0
+    for venue_order in open_orders:
+        # ingest is idempotent on the id: a new id is added (ingested), an id we
+        # already own is left as our object (adopted) — never duplicated.
+        already = router.get(venue_order.client_order_id) is not None
+        router.ingest(venue_order)
+        if already:
+            adopted += 1
+        else:
+            ingested += 1
+
+    # Orphans: a non-terminal tracked order the venue reports neither as open nor
+    # via any fill has no venue record — close it and evict it (the orphan rule).
+    closed_orphans = 0
+    for cid, order in router.tracked_orders().items():
+        if cid in venue_open_cids:
+            continue  # still live on the venue — keep it.
+        if order.is_terminal:
+            continue  # history, not live state — leave it.
+        # Non-terminal but the venue does not list it as open. Whether or not it
+        # has fills, it is no longer open on the venue: close-and-forget. Its
+        # fills (if any) still rebuild the position in step 3.
+        _close_orphan(order)
+        router.forget(cid)
+        closed_orphans += 1
+
+    # --- 3. Positions: rebuild from the broker's confirmed fills (truth). --- #
+    tracker.reset(broker_fills)
+    positions_rebuilt = len(tracker.all_positions())
+
+    result = ReconResult(
+        ingested_orders=ingested,
+        adopted_orders=adopted,
+        closed_orphans=closed_orphans,
+        fills_applied=len(broker_fills),
+        positions_rebuilt=positions_rebuilt,
+    )
+
+    if event_bus is not None:
+        event_bus.emit(
+            LogEvent(
+                message=(
+                    f"reconcile: ingested={result.ingested_orders} "
+                    f"adopted={result.adopted_orders} "
+                    f"closed_orphans={result.closed_orphans} "
+                    f"fills_applied={result.fills_applied} "
+                    f"positions_rebuilt={result.positions_rebuilt}"
+                ),
+                level="info",
+            )
+        )
+
+    return result
+
+
+def _close_orphan(order: Order) -> None:
+    """Drive an orphan ``order`` to ``CANCELLED``, tolerant of the state machine.
+
+    The venue has no record of ``order``, so the engine must stop believing it is
+    live. ``CANCELLED`` is the terminal that reflects "was accepted, is no longer
+    live" (see the module's orphan policy). A ``NEW`` order is nudged through
+    ``SUBMITTED`` first (this reaches no venue); if even that is forbidden the
+    order is left in whatever state it is in — the caller evicts it from the map
+    regardless, so a phantom order never lingers.
+    """
+    try:
+        if order.status is OrderStatus.NEW:
+            order.submit()
+        order.cancel()
+    except OrderError:
+        # The state machine forbade the transition. Eviction from the tracked map
+        # (done by the caller) is what actually removes the phantom; the exact
+        # terminal label is best-effort.
+        pass

--- a/trading_bot/tests/application/test_reconcile.py
+++ b/trading_bot/tests/application/test_reconcile.py
@@ -1,0 +1,379 @@
+"""Tests for :func:`~trading_bot.application.reconcile.reconcile`.
+
+These prove the *reconcile, don't assume* contract against the real
+:class:`~trading_bot.brokers.paper.PaperBroker`: after a simulated disconnect the
+engine's local state (the :class:`~trading_bot.application.order_router.
+OrderRouter`'s tracked orders and the :class:`~trading_bot.application.
+position_tracker.PositionTracker`'s positions) **converges** to the venue's truth,
+with no order duplicated or lost.
+
+The cases cover the two divergence directions:
+
+* **(a) the venue knows more than the engine** — orders/fills placed *directly* on
+  the broker (bypassing the router, as if submitted before a restart) are
+  *ingested* into the router and *rebuild* the tracker's position;
+* **(b) the engine knows more than the venue** — a non-terminal order the router
+  tracks that the broker does not list is *closed and forgotten* per the orphan
+  policy.
+
+Plus: positions equal ``Position.from_fills`` over the broker's fills; a second
+``reconcile`` is a no-op (``ReconResult`` all zeros / ``changed is False``); and
+the core safety property — no duplicated or lost order — holds across the pass.
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+from trading_bot.application import (
+    EventBus,
+    LogEvent,
+    OrderRouter,
+    PositionTracker,
+    ReconResult,
+    reconcile,
+)
+from trading_bot.brokers import PaperBroker
+from trading_bot.domain import (
+    Instrument,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Position,
+    Symbol,
+    money,
+)
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+ETH_USD = Instrument(Symbol("ETH", "USD"))
+
+
+def _limit(
+    cid: str,
+    side: OrderSide = OrderSide.BUY,
+    qty: str = "1",
+    price: str = "30000",
+    instrument: Instrument = BTC_USD,
+) -> Order:
+    """A realistic limit order for seeding the broker or the router."""
+    return Order(
+        client_order_id=cid,
+        instrument=instrument,
+        side=side,
+        qty=money(qty),
+        type=OrderType.LIMIT,
+        limit_price=money(price),
+    )
+
+
+def _engine(broker: PaperBroker) -> tuple[EventBus, OrderRouter, PositionTracker]:
+    """Wire a fresh bus + router + tracker over ``broker`` (router/tracker empty)."""
+    bus = EventBus()
+    router = OrderRouter(broker, bus)
+    tracker = PositionTracker()
+    return bus, router, tracker
+
+
+def _assert_positions_match_broker_fills(
+    tracker: PositionTracker, broker_fills: list
+) -> None:
+    """Assert every tracked position equals ``Position.from_fills`` per instrument."""
+    by_instrument: dict[Instrument, list] = {}
+    for f in broker_fills:
+        by_instrument.setdefault(f.instrument, []).append(f)
+    expected = {
+        inst: Position.from_fills(fills) for inst, fills in by_instrument.items()
+    }
+    assert tracker.all_positions() == expected
+
+
+# --- (a) venue knows an order/fill the engine never saw -------------------- #
+
+
+async def test_reconcile_ingests_venue_open_order_and_rebuilds_position() -> None:
+    """A venue order + fill the engine missed is ingested and folds the position.
+
+    Simulates a restart: an order is placed *directly* on the broker (the router
+    is empty, as in-memory state would be after a crash). The broker fully fills
+    a buy and leaves a partially-filled order open. After ``reconcile`` the router
+    tracks the open order and the tracker's position equals a fold over the
+    broker's fills.
+    """
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("1000000")},
+    )
+    bus, router, tracker = _engine(broker)
+
+    # Placed directly on the broker (not via the router) -> the engine never saw
+    # them. A full buy (closes, no open order) and a half-filled buy (stays open).
+    await broker.place_order(_limit("missed-full", qty="2", price="30000"))
+    broker.arm_partial(money("0.5"))
+    await broker.place_order(_limit("missed-open", qty="4", price="30000"))
+
+    assert router.get("missed-full") is None
+    assert router.get("missed-open") is None
+    assert tracker.all_positions() == {}
+
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+
+    # The still-open order is ingested; the fully-filled one left no open record.
+    venue_open = await broker.open_orders()
+    venue_open_cids = {o.client_order_id for o in venue_open}
+    assert venue_open_cids == {"missed-open"}
+    assert router.get("missed-open") is not None
+    assert router.get("missed-open").status in (
+        OrderStatus.OPEN,
+        OrderStatus.PARTIALLY_FILLED,
+    )
+    assert result.ingested_orders == 1
+    assert result.adopted_orders == 0
+    assert result.closed_orphans == 0
+
+    # Position rebuilt from the broker's fills (the truth).
+    broker_fills = await broker.fills()
+    assert result.fills_applied == len(broker_fills)
+    _assert_positions_match_broker_fills(tracker, broker_fills)
+
+
+# --- (b) engine tracks an order the venue does not know -------------------- #
+
+
+async def test_reconcile_closes_orphan_order_not_on_venue() -> None:
+    """A non-terminal tracked order the venue doesn't list is closed and forgotten.
+
+    The router is made to track an ``OPEN`` order (ingested) that the broker has
+    no record of — a phantom left after a disconnect. ``reconcile`` must close it
+    (``CANCELLED``) and drop it from the map per the orphan policy.
+    """
+    broker = PaperBroker(starting_balances={"USD": money("1000000")})
+    bus, router, tracker = _engine(broker)
+
+    # Build a live OPEN order and ingest it into the router *without* the broker
+    # ever knowing it (the broker's open_orders is empty) — an orphan.
+    phantom = _limit("orphan-1", qty="1", price="30000")
+    phantom.submit()
+    phantom.open("VENUE-GONE")
+    router.ingest(phantom)
+    assert router.get("orphan-1") is phantom
+    assert not phantom.is_terminal
+
+    assert await broker.open_orders() == []
+
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+
+    # Closed (CANCELLED) and evicted from the tracked map.
+    assert phantom.status is OrderStatus.CANCELLED
+    assert router.get("orphan-1") is None
+    assert result.closed_orphans == 1
+    assert result.ingested_orders == 0
+    assert result.adopted_orders == 0
+
+
+async def test_reconcile_closes_new_orphan_nudged_through_submitted() -> None:
+    """A ``NEW`` orphan (never opened) is nudged SUBMITTED then closed CANCELLED.
+
+    Exercises the orphan-close path for an order that never reached the venue:
+    ``cancel`` is illegal from ``NEW``, so the policy nudges it through
+    ``SUBMITTED`` (reaching no venue) before cancelling.
+    """
+    broker = PaperBroker(starting_balances={"USD": money("1000000")})
+    bus, router, tracker = _engine(broker)
+
+    fresh = _limit("new-orphan", qty="1", price="30000")  # still NEW
+    assert fresh.status is OrderStatus.NEW
+    assert not fresh.is_terminal
+    router.ingest(fresh)
+
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+
+    assert fresh.status is OrderStatus.CANCELLED
+    assert router.get("new-orphan") is None
+    assert result.closed_orphans == 1
+
+
+async def test_reconcile_leaves_terminal_local_order_alone() -> None:
+    """A terminal tracked order is history, not an orphan — left untouched."""
+    broker = PaperBroker(starting_balances={"USD": money("1000000")})
+    bus, router, tracker = _engine(broker)
+
+    # A FILLED order the venue (rightly) no longer lists as open.
+    done = _limit("done-1", qty="1", price="30000")
+    done.submit()
+    done.open("VENUE-1")
+    done.apply_fill(money("1"), money("30000"))
+    assert done.status is OrderStatus.FILLED
+    router.ingest(done)
+
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+
+    # Untouched: still tracked, still FILLED, not counted as an orphan.
+    assert router.get("done-1") is done
+    assert done.status is OrderStatus.FILLED
+    assert result.closed_orphans == 0
+
+
+# --- positions equal Position.from_fills over the broker's fills ----------- #
+
+
+async def test_reconcile_positions_equal_from_fills_multi_instrument() -> None:
+    """Positions are rebuilt from broker fills, exactly, across instruments."""
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000"), ETH_USD: money("2000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    bus, router, tracker = _engine(broker)
+
+    # A realistic mixed sequence placed straight on the broker.
+    await broker.place_order(_limit("b1", OrderSide.BUY, "2", "30000", BTC_USD))
+    await broker.place_order(_limit("b2", OrderSide.BUY, "1", "31500", BTC_USD))
+    await broker.place_order(_limit("b3", OrderSide.SELL, "1", "32000", BTC_USD))
+    await broker.place_order(_limit("e1", OrderSide.BUY, "10", "2000", ETH_USD))
+
+    await reconcile(broker, router, tracker, event_bus=bus)
+
+    broker_fills = await broker.fills()
+    _assert_positions_match_broker_fills(tracker, broker_fills)
+    # Sanity on the BTC leg: long 2 @ 30000 + 1 @ 31500 -> 3 @ 30500; sell 1 -> 2.
+    btc = tracker.position(BTC_USD)
+    assert btc is not None
+    assert btc.net_qty == money("2")
+    assert btc.avg_entry_price == money("30500")
+
+
+# --- idempotency: a second reconcile is a no-op ---------------------------- #
+
+
+async def test_second_reconcile_is_a_noop() -> None:
+    """Running ``reconcile`` twice with no venue change: the second is all zeros."""
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("1000000")},
+    )
+    bus, router, tracker = _engine(broker)
+
+    await broker.place_order(_limit("full", qty="2", price="30000"))
+    broker.arm_partial(money("0.5"))
+    await broker.place_order(_limit("open", qty="4", price="30000"))
+
+    first = await reconcile(broker, router, tracker, event_bus=bus)
+    assert first.changed  # the first pass ingested the open order
+
+    snapshot_orders = router.tracked_orders()
+    snapshot_positions = tracker.all_positions()
+
+    second = await reconcile(broker, router, tracker, event_bus=bus)
+
+    # Idempotent: nothing new ingested, no new orphans -> not "changed".
+    assert second.ingested_orders == 0
+    assert second.adopted_orders == 1  # the still-open order is re-confirmed
+    assert second.closed_orphans == 0
+    assert second.changed is False
+    # Local state identical to after the first pass.
+    assert router.tracked_orders() == snapshot_orders
+    assert tracker.all_positions() == snapshot_positions
+
+
+def test_recon_result_changed_flag() -> None:
+    """``ReconResult.changed`` reflects only the mutating counts."""
+    assert ReconResult(0, 0, 0, 0, 0).changed is False
+    assert ReconResult(0, 3, 0, 5, 2).changed is False  # adopt/fills/pos only
+    assert ReconResult(1, 0, 0, 0, 0).changed is True  # an ingest
+    assert ReconResult(0, 0, 1, 0, 0).changed is True  # an orphan close
+
+
+# --- a LogEvent summarises the pass ---------------------------------------- #
+
+
+async def test_reconcile_emits_log_event_summary() -> None:
+    """A single ``LogEvent`` summarising the pass is emitted on the bus."""
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("1000000")},
+    )
+    bus, router, tracker = _engine(broker)
+    seen: list[object] = []
+    bus.subscribe(seen.append)
+
+    await broker.place_order(_limit("x", qty="2", price="30000"))
+    await reconcile(broker, router, tracker, event_bus=bus)
+
+    logs = [e for e in seen if isinstance(e, LogEvent)]
+    assert len(logs) == 1
+    assert "reconcile:" in logs[0].message
+
+
+async def test_reconcile_without_bus_emits_nothing_and_still_converges() -> None:
+    """``event_bus=None`` is valid: no event, state still converges."""
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("1000000")},
+    )
+    _bus, router, tracker = _engine(broker)
+    broker.arm_partial(money("0.5"))
+    await broker.place_order(_limit("open", qty="4", price="30000"))
+
+    result = await reconcile(broker, router, tracker)  # no event_bus
+
+    assert result.ingested_orders == 1
+    assert router.get("open") is not None
+
+
+# --- core safety property: no order duplicated or lost --------------------- #
+
+
+async def test_no_order_duplicated_or_lost_across_reconcile() -> None:
+    """The router's tracked-order set converges to the venue open set, no dup/loss.
+
+    A realistic divergence: one order the engine submitted *and* the venue still
+    holds open (must remain, exactly once), one order only the venue holds (must
+    be ingested), and one phantom only the engine holds (must be dropped). After
+    reconcile the tracked **open** orders equal the venue's open set — every venue
+    order present exactly once (no loss, no duplicate) and no phantom left behind.
+    """
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("1000000")},
+    )
+    bus, router, tracker = _engine(broker)
+
+    # 1. Engine-and-venue: routed through the engine AND still open on the venue.
+    broker.arm_partial(money("0.5"))
+    shared = await router.submit(_limit("shared", qty="4", price="30000"))
+    assert shared.status is OrderStatus.OPEN
+    assert router.get("shared") is not None
+
+    # 2. Venue-only: placed straight on the broker, engine never saw it.
+    broker.arm_partial(money("0.5"))
+    await broker.place_order(_limit("venue-only", qty="4", price="30000"))
+
+    # 3. Engine-only phantom: tracked OPEN order the venue has no record of.
+    phantom = _limit("phantom", qty="1", price="30000")
+    phantom.submit()
+    phantom.open("GONE")
+    router.ingest(phantom)
+
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+
+    # The venue's open set is the truth we converge to.
+    venue_open = {o.client_order_id for o in await broker.open_orders()}
+    assert venue_open == {"shared", "venue-only"}
+
+    # Every venue-open order is tracked exactly once (no loss, no duplicate); the
+    # tracked *non-terminal* set equals the venue open set; the phantom is gone.
+    tracked = router.tracked_orders()
+    non_terminal = {cid for cid, o in tracked.items() if not o.is_terminal}
+    assert non_terminal == venue_open
+    assert router.get("phantom") is None
+    assert phantom.status is OrderStatus.CANCELLED
+
+    # Counts: 'shared' was already tracked (adopted), 'venue-only' ingested,
+    # 'phantom' closed.
+    assert result.adopted_orders == 1
+    assert result.ingested_orders == 1
+    assert result.closed_orphans == 1
+
+    # And no order object is duplicated in the map (ids are unique by construction
+    # of a dict, but assert the engine's own 'shared' object was kept, not replaced
+    # by the venue's reconstructed snapshot).
+    assert tracked["shared"] is shared


### PR DESCRIPTION
## Summary
- **Final leaf of E4**: `application/reconcile.py` — `reconcile(broker, router, tracker)`.
- On startup/reconnect: adopt the venue's open orders as truth, ingest unknown ones, **close-and-forget** non-terminal orphans, **rebuild positions from broker fills**; idempotent (no venue change → no-op). Writes only locally, never to the venue.
- Closes E4 — the execution engine is complete; `07-roadmap.md` E4 line removed, `06-status.md` updated.

## Why
- *Reconcile, don't assume* is a hard live-trading invariant: after any disconnect the venue's records must win, with **no order duplicated or lost**. Rebuilding positions from fills (not diffing) is trivially correct and never double-counts. See `doc/dev/03-decisions.md`.

## Changes
- `application/reconcile.py` (new) + `ReconResult`; minimal helpers `OrderRouter.{tracked_orders,ingest,forget}` + `PositionTracker.reset`; `tests/application/test_reconcile.py` (11 tests).

## Test plan
- [x] `.venv/bin/python -m pytest` (337 passed, **0 skipped**)
- [x] divergence→convergence proven: no order duplicated/lost; positions == `Position.from_fills(broker.fills())`; idempotent second run
- [x] `ruff` + `mypy` clean