### PR TITLE
docs: plan strategy-runner (E5)

### DIFF
--- a/doc/dev/plans/strategy-runner/00-plan.md
+++ b/doc/dev/plans/strategy-runner/00-plan.md
@@ -1,0 +1,50 @@
+---
+plan: strategy-runner
+kind: global
+status: planning
+roadmap: "- [ ] **E5 — Strategy runner.** Load a strategy (config + fynance signal), feed it data from dccd, emit target positions/orders; the live loop. Replaces `legacy/StrategyBot`."
+release_on_done: false
+---
+
+# E5 — Strategy runner
+
+## Goal
+
+Wire the triptych into a live loop: a **Strategy** (config + a signal callable,
+typically fynance-backed) is fed market **data** (a `DataFeed`, dccd-backed) and
+produces a domain `Signal`; the runner turns that into a target `Position` and
+routes the resulting orders through the E4 `OrderRouter`. Replaces the legacy
+`StrategyBot` iterator + importlib `get_signal({-1,0,1})` loading
+(`trading_bot/legacy/strategy_manager.py`). The first epic that consumes **both**
+sibling repos (dccd data, fynance signals).
+
+**Hard invariant — causality / no lookahead:** a strategy at bar *t* may only see
+bars `≤ t`; the feed must never hand future data to the signal. (Mirrors fynance's
+walk-forward discipline.)
+
+## Decomposition
+
+1. **strategy-spec** — `application/strategy.py`: how a strategy is declared/loaded (config + signal callable → domain `Signal`).
+2. **data-feed** — `application/data_feed.py`: `DataFeed` abstraction; in-memory feed (offline) + dccd-backed feed (`Client.read`); causal.
+3. **strategy-runner** — `application/strategy_runner.py`: the loop feed→signal→target position→orders via the router.
+
+## Leaf checklist
+
+- [ ] 01 strategy-spec — feat/strategy-spec — medium
+- [ ] 02 data-feed — feat/data-feed — high
+- [ ] 03 strategy-runner — feat/strategy-runner — high (depends on 01, 02)
+
+## Dependencies
+
+- 01 and 02 are independent (01 needs E1/E4-01; 02 needs E2 + dccd) — run serially.
+- 03 depends on 01 + 02 (and E4-03 OrderRouter + E4-04 PositionTracker).
+
+## Done criteria
+
+- `application/` exposes `Strategy`, `DataFeed` (+ in-memory & dccd-backed), and
+  `StrategyRunner`. `ruff`/`mypy`/`pytest` green via `.venv` (0 skipped).
+- A strategy run is verifiable **fully offline**: in-memory bars → fynance-backed
+  signal → target position → orders on `PaperBroker` → positions match expectation;
+  **causality asserted** (signal at t sees only bars ≤ t).
+- A dccd-read smoke (`-m network`) reads real bars where inventory has data.
+- Last leaf (03) removes the E5 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/strategy-runner/01-strategy-spec.md
+++ b/doc/dev/plans/strategy-runner/01-strategy-spec.md
@@ -1,0 +1,69 @@
+---
+plan: strategy-runner/01-strategy-spec
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/strategy-spec
+pr: ""
+---
+
+# Strategy spec — declare & load a strategy
+
+## Goal
+
+Define how a strategy is declared and loaded: a `Strategy` (config + a **signal
+callable** that takes a bars frame and returns a domain `Signal`). Replaces the
+legacy importlib `get_signal({-1,0,1})` loading. Pure-ish, typed.
+
+## Files to change
+
+- `trading_bot/application/strategy.py` — new; `Strategy`, `StrategySpec`, loader.
+- `trading_bot/application/__init__.py` — export them.
+- `trading_bot/tests/application/test_strategy.py` — new.
+
+## Steps
+
+1. Read `domain/signal.py` (`Signal.exposure` / `Signal.target_qty`),
+   `domain/instrument.py`, `application/config.py` (`StrategyConfig` skeleton:
+   `name`, `symbol`), and the legacy spec
+   (`trading_bot/legacy/strategy_manager.py` + `strategies/example/strategy.py`'s
+   `get_signal`).
+2. Define `SignalFn = Callable[[BarsT], Signal]` where `BarsT` is the bars frame
+   type (a polars `DataFrame` of OHLC, or a typed wrapper — pick the simplest that
+   the data-feed leaf will produce; document it). The callable returns a domain
+   `Signal` for the strategy's instrument.
+3. `Strategy` dataclass: `name`, `instrument` (from `StrategyConfig.symbol`),
+   `signal_fn: SignalFn`, optional `reference_qty` (max position size for
+   fractional-exposure signals), optional warmup/lookback (min bars before the
+   signal is valid). Method `evaluate(bars) -> Signal` that calls `signal_fn` and
+   validates the returned `Signal` is for this instrument.
+4. A **loader**: build a `Strategy` from a `StrategyConfig` + a resolvable
+   `signal_fn` reference (an importable `"module:function"` string **or** a passed
+   callable — keep it simple and safe; document the resolution). This is the modern
+   replacement for the legacy importlib path — no exec of arbitrary files.
+5. Ship a tiny built-in example signal (e.g. a moving-average crossover using
+   fynance) for tests/docs.
+
+## Tests (via `.venv`)
+
+- A `Strategy` with a hand-written `signal_fn` (returns `Signal.exposure(...)`) →
+  `evaluate(bars)` returns the expected `Signal`; an instrument mismatch raises.
+- The fynance-backed example signal (MA crossover) on a known bar series → expected
+  long/flat/short exposure at the crossover points.
+- Loader resolves a `"module:function"` reference to a callable and builds the
+  `Strategy`; an unresolvable reference raises a clear error.
+- Warmup: fewer than `lookback` bars → a defined behaviour (flat `Signal` or raise — document).
+
+## Verification on real data
+
+In-process. Run the example MA-crossover `signal_fn` over a realistic OHLC series
+(synthetic-but-realistic, or a fixture) and assert the signals flip at the expected
+crossovers — and that no signal at bar *t* used any bar `> t`. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.Strategy` — declare/load a strategy (config + signal callable → domain `Signal`)."
+- ADR: the strategy contract (signal callable → `Signal`) + the safe loader (no arbitrary-file exec, vs legacy importlib).
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/strategy-runner/02-data-feed.md
+++ b/doc/dev/plans/strategy-runner/02-data-feed.md
@@ -1,0 +1,72 @@
+---
+plan: strategy-runner/02-data-feed
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: feat/data-feed
+pr: ""
+---
+
+# DataFeed — bars to a strategy (in-memory + dccd-backed)
+
+## Goal
+
+A `DataFeed` abstraction that yields market **bars** to a strategy: an **in-memory**
+feed (always offline-testable) and a **dccd-backed** feed reading real bars via
+`dccd.Client.read(...)`. **Causal:** at step *t* the feed exposes only bars `≤ t` —
+never future data.
+
+## Files to change
+
+- `trading_bot/application/data_feed.py` — new; `DataFeed` protocol + `InMemoryFeed` + `DccdFeed`.
+- `trading_bot/application/__init__.py` — export them.
+- `trading_bot/tests/application/test_data_feed.py` — new.
+
+## Steps
+
+1. Read the dccd `Client.read` signature
+   (`read(exchange, symbol, data_type="ohlc", span=None, start_ns=None, end_ns=None) -> polars.DataFrame`)
+   and `inventory()`. dccd is installed in `.venv`.
+2. `DataFeed` protocol (async or sync iterator — pick to match how the runner
+   consumes; document): yields a growing **window** of bars (a frame containing all
+   bars up to and including the current step), so the strategy's `signal_fn` always
+   gets a causal frame. Provide `bars_so_far()` / iteration that advances one bar at
+   a time.
+3. `InMemoryFeed(frame)`: wraps a fixed bars frame and replays it bar-by-bar,
+   yielding the causal prefix `frame[: t+1]` at each step. Deterministic — the
+   backbone of offline tests and backtests.
+4. `DccdFeed(client, exchange, symbol, span, ...)`:
+   - **historical mode**: `client.read(...)` once, then replay like `InMemoryFeed`
+     (so a backtest over real stored bars is reproducible).
+   - **live mode**: advance as new bars arrive (poll `read` for the latest closed
+     bar on the span cadence, or bridge a live source); only emit a bar once it is
+     **closed** (no partial/lookahead). Keep the dccd coupling thin and injectable
+     so tests don't need dccd.
+5. Normalise the frame columns the strategy expects (document the schema:
+   timestamp + OHLC[V]); reuse `domain.instrument` for the symbol.
+
+## Tests (via `.venv`)
+
+- `InMemoryFeed`: replaying N bars yields N causal prefixes; the frame at step *t*
+  contains exactly bars `0..t` and **never** a bar `> t` (assert the last timestamp).
+- A strategy `signal_fn` fed by `InMemoryFeed` only ever sees causal frames
+  (instrument a spy `signal_fn` that records the max timestamp it saw).
+- `DccdFeed` historical mode with an **injected fake dccd client** (returns a canned
+  polars frame) → replays the same causal prefixes; no real dccd needed.
+- Live mode emits a bar only once closed (with a faked clock/poll).
+
+## Verification on real data
+
+`-m network` (opt-in): if dccd `inventory()` has any stored OHLC, `DccdFeed`
+historical reads it via `Client.read` and replays at least a few causal prefixes
+(assert monotonic timestamps, no lookahead). If inventory is empty, document that
+the real-data check is gated on stored data and rely on the injected-client test.
+**Run** the offline suite via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.DataFeed` — causal bars feed (in-memory + dccd-backed)."
+- ADR: the causal-window contract + the thin dccd coupling (injected client) + closed-bar-only live rule.
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/strategy-runner/03-strategy-runner.md
+++ b/doc/dev/plans/strategy-runner/03-strategy-runner.md
@@ -1,0 +1,72 @@
+---
+plan: strategy-runner/03-strategy-runner
+kind: leaf
+status: planned
+complexity: high
+depends: [01, 02]
+parallel: false
+branch: feat/strategy-runner
+pr: ""
+---
+
+# StrategyRunner — the live loop
+
+## Goal
+
+`StrategyRunner` wires it together: pull bars from a `DataFeed`, evaluate the
+`Strategy`'s signal, turn the domain `Signal` into a target position change, and
+route the resulting `Order`(s) through the E4 `OrderRouter` — emitting events and
+reading the current position from the `PositionTracker`. Replaces the legacy
+`StrategyBot` iterator. **Last E5 leaf — closes the E5 roadmap line.**
+
+## Files to change
+
+- `trading_bot/application/strategy_runner.py` — new; `StrategyRunner`.
+- `trading_bot/application/__init__.py` — export it.
+- `trading_bot/tests/application/test_strategy_runner.py` — new.
+- `doc/dev/07-roadmap.md` — remove the E5 line. `doc/dev/06-status.md` — mark E5 done.
+
+## Steps
+
+1. Read `application/strategy.py` (`Strategy.evaluate`), `application/data_feed.py`
+   (`DataFeed`), `application/order_router.py` (`OrderRouter.submit`),
+   `application/position_tracker.py` (`position(instrument)`),
+   `domain/signal.py` (`Signal.delta_to(position, reference_qty)`),
+   `domain/order.py` (`Order`).
+2. `StrategyRunner(strategy, feed, router, tracker, *, event_bus=None, order_factory=None)`:
+   - `async run(max_steps=None)` (and/or `async step()`): for each bar window from
+     `feed`, `signal = strategy.evaluate(bars)`; `current = tracker.position(instrument)`;
+     `delta = signal.delta_to(current, reference_qty=strategy.reference_qty)`; if
+     `delta != 0`, build an `Order` (market by default, or via `order_factory`) with
+     a **deterministic, unique `client_order_id`** (e.g. `f"{strategy.name}-{step}"`)
+     and `await router.submit(order)`. Emit a `LogEvent`/`OrderEvent`.
+   - Respect **warmup** (skip until `lookback` bars). Honour `feed`'s causality —
+     the runner never peeks ahead.
+   - No order when `delta == 0` (already at target).
+3. The `client_order_id` scheme must make a re-run idempotent at the router (same
+   step → same id → no duplicate), tying into E4's idempotency.
+
+## Tests (via `.venv`, fully offline)
+
+- End-to-end: `InMemoryFeed` of a known OHLC series + the MA-crossover strategy +
+  `OrderRouter`→`PaperBroker` + `PositionTracker` → the position track follows the
+  signal (long after the up-cross, flat/short after the down-cross); orders match
+  the deltas; money exact `Decimal`.
+- `delta == 0` step emits no order.
+- Warmup: no orders before `lookback` bars.
+- **Idempotent re-run**: running the same steps twice (same client-order-ids) does
+  not double-submit (one paper order per step).
+- **Causality**: the strategy never saw a future bar (spy on the signal_fn).
+
+## Verification on real data
+
+Fully offline (the engine's "real data" is the in-memory feed + PaperBroker). Run a
+realistic OHLC series end to end and assert the resulting positions/PnL match a
+hand-computed expectation from the signal, with **no lookahead**. Optionally, with
+`-m network`, drive the runner from a `DccdFeed` over real stored bars. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.StrategyRunner` — the live loop (data → signal → target position → orders)."
+- ADR: the runner loop + the per-step `client_order_id` idempotency scheme + warmup/causality handling.
+- Status/roadmap: **remove the E5 line** from `07-roadmap.md`; mark E5 done in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E5 — Strategy runner** — the first epic consuming **both** sibling repos (dccd data, fynance signals).

## Goal
A `Strategy` (config + signal callable → domain `Signal`) is fed market bars by a `DataFeed` (dccd-backed) and the `StrategyRunner` turns the signal into a target `Position` → orders via the E4 `OrderRouter`. Replaces the legacy `StrategyBot` + importlib `get_signal({-1,0,1})`.

**Hard invariant — causality / no lookahead:** at bar *t* a strategy sees only bars ≤ t.

## Leaves
- [ ] 01 strategy-spec — feat/strategy-spec — medium
- [ ] 02 data-feed — feat/data-feed — high
- [ ] 03 strategy-runner — feat/strategy-runner — high (depends on 01, 02)

Everything offline-testable via an in-memory feed + `PaperBroker`; a dccd-read smoke is `-m network`.
After merge: `/execute-leaf strategy-runner next`.