### PR TITLE
feat: strategy spec (declare/load + example signal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `application.reconcile` — converge local order/position state with the broker on
   startup/reconnect (adopt venue open orders, ingest unknown, close orphans, rebuild
   positions from broker fills; idempotent). Completes the **E4 execution engine**.
+- `application.Strategy` — declare/load a strategy (config + a signal callable
+  `bars→domain Signal`) with a **safe loader** (importable `module:function`, no
+  arbitrary-file exec) + a fynance-backed MA-crossover example signal.
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,26 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-21 Strategy contract: bars→Signal callable + safe loader (no file exec)
+
+**Decision.** `application/strategy.py` models a strategy as `(instrument,
+signal_fn)` where `signal_fn: polars.DataFrame(bars) → domain Signal` — unifying on
+the existing venue-neutral `Signal` (the runner turns `Signal` + `Position` into an
+order) instead of the legacy `get_signal(data) → {-1,0,1}` int. `evaluate` enforces
+the instrument invariant and returns a **flat** signal during warmup (`< lookback`
+bars) rather than guessing. `load_strategy` accepts a passed callable **or** an
+already-importable `"module:function"` string (`importlib.import_module` + `getattr`)
+— **never** an arbitrary-file `exec_module` like the legacy `StrategyBot`. The
+built-in `ma_crossover_signal` uses `fynance.sma` (causal trailing average).
+
+**Why.** A `bars→Signal` callable is the minimal strategy surface and reuses the
+domain vocabulary end to end. The safe loader removes the legacy code-execution sink
+(loose-file `exec`). Warmup-flat keeps an undertrained signal from taking a position.
+**Rejected:** loose-file importlib loading (security); a bespoke signal int (diverges
+from the `Signal` value object).
+
+---
+
 ### 2026-06-21 Reconciliation: venue is truth, rebuild positions from fills, idempotent
 
 **Decision.** `application/reconcile.py` `reconcile(broker, router, tracker)` reads the

--- a/doc/dev/plans/strategy-runner/00-plan.md
+++ b/doc/dev/plans/strategy-runner/00-plan.md
@@ -30,7 +30,7 @@ walk-forward discipline.)
 
 ## Leaf checklist
 
-- [ ] 01 strategy-spec — feat/strategy-spec — medium
+- [x] 01 strategy-spec — feat/strategy-spec — medium
 - [ ] 02 data-feed — feat/data-feed — high
 - [ ] 03 strategy-runner — feat/strategy-runner — high (depends on 01, 02)
 

--- a/doc/dev/plans/strategy-runner/01-strategy-spec.md
+++ b/doc/dev/plans/strategy-runner/01-strategy-spec.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/strategy-spec
-pr: ""
+pr: "#30"
 ---
 
 # Strategy spec — declare & load a strategy

--- a/doc/dev/plans/strategy-runner/01-strategy-spec.md
+++ b/doc/dev/plans/strategy-runner/01-strategy-spec.md
@@ -1,7 +1,7 @@
 ---
 plan: strategy-runner/01-strategy-spec
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -37,6 +37,12 @@ It then layers the engine's use-cases:
   venue's open orders, balances and fills and converges the router's tracked
   orders and the tracker's positions to that truth — never leaving a duplicated
   or lost order.
+* strategy — the :class:`~trading_bot.application.strategy.Strategy` (instrument
+  + a :data:`~trading_bot.application.strategy.SignalFn` callable that maps a
+  bars frame to a domain ``Signal``), the safe
+  :func:`~trading_bot.application.strategy.load_strategy` loader (no
+  arbitrary-file exec), and the built-in
+  :func:`~trading_bot.application.strategy.ma_crossover_signal` example.
 """
 
 from __future__ import annotations
@@ -57,6 +63,12 @@ from trading_bot.application.events import (
 from trading_bot.application.order_router import OrderRouter
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.reconcile import ReconResult, reconcile
+from trading_bot.application.strategy import (
+    SignalFn,
+    Strategy,
+    load_strategy,
+    ma_crossover_signal,
+)
 
 __all__ = [
     # config
@@ -75,4 +87,9 @@ __all__ = [
     "PositionTracker",
     "reconcile",
     "ReconResult",
+    # strategy
+    "Strategy",
+    "SignalFn",
+    "load_strategy",
+    "ma_crossover_signal",
 ]

--- a/trading_bot/application/strategy.py
+++ b/trading_bot/application/strategy.py
@@ -1,0 +1,350 @@
+"""Declare and load a strategy — config + a signal callable → domain ``Signal``.
+
+A :class:`Strategy` is the engine's unit of *what to trade and when*: it pairs a
+strategy's instrument with a **signal callable** (:data:`SignalFn`) that, given a
+bars frame, returns a venue-neutral :class:`~trading_bot.domain.signal.Signal`.
+The runner (leaf 03) drives a :class:`Strategy` on each new bar; this module only
+declares the contract and how a strategy is loaded.
+
+The signal contract
+--------------------
+A :data:`SignalFn` takes a **bars frame** and returns one
+:class:`~trading_bot.domain.signal.Signal` for the strategy's instrument. The
+bars frame is a :class:`polars.DataFrame` of OHLC(V) — the shape a dccd OHLC read
+yields (leaf 02). The assumed columns are:
+
+================  =========================================================
+column            meaning
+================  =========================================================
+``time``          bar open time, seconds (or ms) since the Unix epoch (UTC)
+``o`` ``h`` ``l`` open / high / low price of the bar
+``c``             **close** price of the bar — the column signals read
+``v``             traded volume over the bar
+================  =========================================================
+
+Only ``c`` (close) is required by the built-in example signal; a custom
+:data:`SignalFn` may use any subset. Rows are ordered oldest→newest, so row
+``-1`` is the most recent (current) bar. A signal computed at the current bar may
+only look at rows ``≤`` the current one — **no lookahead**.
+
+Loading — no arbitrary-file exec
+--------------------------------
+:func:`load_strategy` resolves a signal callable either from a passed callable
+*or* from a safe ``"module:function"`` import string (via
+:func:`importlib.import_module` + :func:`getattr`). This deliberately replaces
+the legacy ``StrategyBot`` path, which built a module spec from an *arbitrary file
+path* and ran :meth:`exec_module` on it (``legacy/strategy_manager.py``) — a code
+sink. Here only an *already-importable* dotted module can be named; nothing is
+executed from a loose file.
+
+This module lives in the application layer: it may import the pure domain and
+depends on :mod:`polars` (the bars frame type) and, for the example signal,
+:mod:`fynance`. It performs no I/O of its own.
+"""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import fynance as fy
+import numpy as np
+import polars as pl
+
+from trading_bot.application.config import StrategyConfig
+from trading_bot.domain.errors import InstrumentMismatch, SignalError
+from trading_bot.domain.instrument import Instrument, Symbol, parse_kraken_pair
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.signal import Signal
+
+__all__ = [
+    "SignalFn",
+    "Strategy",
+    "load_strategy",
+    "ma_crossover_signal",
+]
+
+#: A strategy's signal callable: a bars frame (OHLC, polars) → a domain
+#: :class:`~trading_bot.domain.signal.Signal` for the strategy's instrument.
+SignalFn = Callable[[pl.DataFrame], Signal]
+
+#: The close-price column the built-in signal reads from a bars frame.
+_CLOSE_COL = "c"
+
+
+def _bar_ts_ms(bars: pl.DataFrame) -> int:
+    """Best-effort timestamp (ms since epoch, UTC) for the latest bar.
+
+    Reads the ``time`` column of the last row if present, normalising a
+    seconds-scale value to milliseconds (dccd OHLC times are seconds). Falls
+    back to ``0`` when there is no usable time column, so a signal can still be
+    built (``ts`` only needs to be non-negative).
+    """
+    if "time" not in bars.columns or bars.height == 0:
+        return 0
+    raw = bars["time"][-1]
+    if raw is None:
+        return 0
+    val = int(raw)
+    # Heuristic: a seconds-scale epoch (< ~1e12) is widened to milliseconds to
+    # match Signal.ts / Fill.ts units; an already-ms value passes through.
+    return val if val >= 1_000_000_000_000 else val * 1_000
+
+
+@dataclass(frozen=True, slots=True)
+class Strategy:
+    """A declared strategy: an instrument and the signal callable that drives it.
+
+    Immutable. Build one directly, or via :func:`load_strategy` from a
+    :class:`~trading_bot.application.config.StrategyConfig`. The runner calls
+    :meth:`evaluate` on each new bar to obtain the strategy's target
+    :class:`~trading_bot.domain.signal.Signal`.
+
+    Parameters
+    ----------
+    name : str
+        Logical id of the strategy instance (matches the config's ``name``).
+    instrument : Instrument
+        The instrument the strategy trades. :meth:`evaluate` enforces that the
+        signal callable returns a :class:`~trading_bot.domain.signal.Signal` for
+        *this* instrument.
+    signal_fn : SignalFn
+        The signal callable: a bars frame → a domain ``Signal``.
+    reference_qty : Decimal or None, optional
+        The max position size (base units) a fractional-exposure signal is a
+        fraction of. Carried here so the runner can resolve a
+        :data:`~trading_bot.domain.signal.SignalMode.EXPOSURE` signal into a
+        quantity. ``None`` (default) when the strategy emits explicit-quantity
+        signals or the runner supplies the scale elsewhere. Must be positive
+        when given.
+    lookback : int, optional
+        Warmup: the minimum number of bars required before the signal is
+        meaningful (e.g. the slow MA window). Until that many bars are present
+        :meth:`evaluate` returns a **flat** signal rather than calling
+        ``signal_fn`` — see :meth:`evaluate`. Must be non-negative. Default ``0``
+        (no warmup).
+
+    """
+
+    name: str
+    instrument: Instrument
+    signal_fn: SignalFn
+    reference_qty: Money | None = None
+    lookback: int = 0
+
+    def __post_init__(self) -> None:
+        """Validate ``reference_qty`` (>0) and ``lookback`` (>=0)."""
+        if self.reference_qty is not None and self.reference_qty <= 0:
+            raise SignalError(
+                f"reference_qty must be positive, got {self.reference_qty}"
+            )
+        if self.lookback < 0:
+            raise SignalError(f"lookback must be non-negative, got {self.lookback}")
+
+    def evaluate(self, bars: pl.DataFrame) -> Signal:
+        """Evaluate the strategy on ``bars`` and return its target signal.
+
+        Warmup choice: if fewer than :attr:`lookback` bars are supplied, return
+        a **flat** ``Signal.exposure(instrument, 0)`` rather than calling
+        ``signal_fn`` or raising. Flat is the *safe* default — an undertrained
+        signal that has not seen its full window should hold no position, never
+        guess a direction. (Raising was the alternative; flat keeps the runner's
+        loop simple and never opens a position on partial data.)
+
+        Otherwise it calls ``signal_fn(bars)`` and validates the returned signal
+        is for :attr:`instrument`, raising :class:`InstrumentMismatch` if a
+        custom callable returns a signal for the wrong instrument.
+
+        Parameters
+        ----------
+        bars : polars.DataFrame
+            The OHLC(V) bars frame (oldest→newest); see the module docstring for
+            the assumed schema.
+
+        Returns
+        -------
+        Signal
+            The strategy's target signal for :attr:`instrument` (flat during
+            warmup).
+
+        Raises
+        ------
+        InstrumentMismatch
+            If ``signal_fn`` returns a signal for a different instrument.
+
+        """
+        if bars.height < self.lookback:
+            return Signal.exposure(
+                self.instrument, money("0"), ts=_bar_ts_ms(bars)
+            )
+
+        signal = self.signal_fn(bars)
+        if signal.instrument != self.instrument:
+            raise InstrumentMismatch(
+                str(self.instrument), str(signal.instrument)
+            )
+        return signal
+
+
+def _instrument_from_symbol(symbol: str) -> Instrument:
+    """Build an :class:`Instrument` from a config ``symbol`` string.
+
+    Accepts a canonical ``BASE/QUOTE`` (e.g. ``"BTC/USD"``) or a Kraken pair
+    string (e.g. ``"XXBTZUSD"``); both route through
+    :func:`~trading_bot.domain.instrument.parse_kraken_pair`, which honours an
+    explicit ``/`` separator. Falls back to a 4/4-ish split error message via the
+    parser.
+    """
+    sym: Symbol = parse_kraken_pair(symbol)
+    return Instrument(sym)
+
+
+def load_strategy(
+    config: StrategyConfig, signal_fn: SignalFn | str
+) -> Strategy:
+    """Build a :class:`Strategy` from a config and a resolvable signal callable.
+
+    The instrument is built from ``config.symbol`` (canonical ``BASE/QUOTE`` or a
+    Kraken pair string). ``signal_fn`` is resolved as:
+
+    * a **callable** — used directly;
+    * a ``"module:function"`` **string** — :func:`importlib.import_module` the
+      module, then :func:`getattr` the function. Only an already-importable
+      dotted module may be named; unlike the legacy path nothing is exec'd from a
+      loose file.
+
+    Parameters
+    ----------
+    config : StrategyConfig
+        The strategy declaration (``name`` + ``symbol``).
+    signal_fn : SignalFn or str
+        The signal callable, or a ``"module:function"`` import reference.
+
+    Returns
+    -------
+    Strategy
+        The loaded strategy (``reference_qty``/``lookback`` left at defaults).
+
+    Raises
+    ------
+    SignalError
+        If ``signal_fn`` is a string that does not resolve to a callable
+        (malformed reference, missing module, missing attribute, or the
+        attribute is not callable).
+
+    """
+    if callable(signal_fn):
+        resolved: SignalFn = signal_fn
+    else:
+        resolved = _resolve_ref(signal_fn)
+
+    instrument = _instrument_from_symbol(config.symbol)
+    return Strategy(name=config.name, instrument=instrument, signal_fn=resolved)
+
+
+def _resolve_ref(ref: str) -> SignalFn:
+    """Resolve a ``"module:function"`` string to a callable, safely.
+
+    Raises :class:`SignalError` (never lets a bare ``ImportError`` /
+    ``AttributeError`` escape) with a message naming the offending reference.
+    """
+    if ":" not in ref:
+        raise SignalError(
+            f"signal_fn reference {ref!r} must be 'module:function'"
+        )
+    module_name, _, attr = ref.partition(":")
+    if not module_name or not attr:
+        raise SignalError(
+            f"signal_fn reference {ref!r} must be 'module:function'"
+        )
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        raise SignalError(
+            f"cannot import module {module_name!r} for signal_fn {ref!r}: {exc}"
+        ) from exc
+    try:
+        fn = getattr(module, attr)
+    except AttributeError as exc:
+        raise SignalError(
+            f"module {module_name!r} has no attribute {attr!r} "
+            f"for signal_fn {ref!r}"
+        ) from exc
+    if not callable(fn):
+        raise SignalError(
+            f"signal_fn {ref!r} resolved to a non-callable {type(fn).__name__}"
+        )
+    return fn  # type: ignore[no-any-return]
+
+
+def ma_crossover_signal(
+    instrument: Instrument, *, fast: int = 10, slow: int = 30
+) -> SignalFn:
+    """Build a moving-average-crossover :data:`SignalFn` for ``instrument``.
+
+    A small built-in example (for tests / docs). The returned callable computes
+    a fast and a slow **simple** moving average over the close column (``c``)
+    using :func:`fynance.sma`, then emits a fractional-exposure signal on the
+    sign of ``fast_ma - slow_ma`` at the latest bar:
+
+    * ``+1`` (long) when the fast MA is above the slow MA;
+    * ``-1`` (short) when it is below;
+    * ``0`` (flat) when they are equal (or there is no data).
+
+    **Causality.** :func:`fynance.sma` is a trailing average (a shrinking window
+    for the first ``w-1`` bars, never reaching forward), and only the *last*
+    element of each MA is read, so the signal at bar ``t`` depends solely on
+    bars ``≤ t`` — no lookahead. The signal's ``ts`` is taken from the latest
+    bar's ``time`` (see the module docstring schema).
+
+    Parameters
+    ----------
+    instrument : Instrument
+        The instrument the produced signals are for.
+    fast : int, optional
+        Fast MA window (bars). Must be ``>= 1`` and ``< slow``. Default ``10``.
+    slow : int, optional
+        Slow MA window (bars). Must be ``> fast``. Default ``30``.
+
+    Returns
+    -------
+    SignalFn
+        A callable ``bars -> Signal.exposure(instrument, {-1,0,+1})``.
+
+    Raises
+    ------
+    ValueError
+        If the windows are not ``1 <= fast < slow``.
+
+    """
+    if fast < 1 or slow <= fast:
+        raise ValueError(
+            f"need 1 <= fast < slow, got fast={fast}, slow={slow}"
+        )
+
+    def _signal(bars: pl.DataFrame) -> Signal:
+        ts = _bar_ts_ms(bars)
+        if bars.height == 0 or _CLOSE_COL not in bars.columns:
+            return Signal.exposure(instrument, money("0"), ts=ts)
+
+        closes = bars[_CLOSE_COL].to_numpy().astype(np.float64)
+        # fy.sma shrinks the window for the first w-1 bars (still causal) and
+        # only warns that the window exceeds the series — benign here, so silence
+        # it: we read only the trailing MA value.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", UserWarning)
+            fast_ma = fy.sma(closes, w=fast)
+            slow_ma = fy.sma(closes, w=slow)
+        spread = float(fast_ma[-1] - slow_ma[-1])
+
+        if spread > 0:
+            target = money("1")
+        elif spread < 0:
+            target = money("-1")
+        else:
+            target = money("0")
+        return Signal.exposure(instrument, target, ts=ts)
+
+    return _signal

--- a/trading_bot/tests/application/test_strategy.py
+++ b/trading_bot/tests/application/test_strategy.py
@@ -1,0 +1,272 @@
+"""Tests for :mod:`trading_bot.application.strategy`.
+
+These prove the strategy contract and its safe loader:
+
+* a hand-written ``signal_fn`` is returned verbatim by
+  :meth:`Strategy.evaluate`, and a signal for the *wrong* instrument is rejected
+  with :class:`InstrumentMismatch`;
+* the built-in :func:`ma_crossover_signal` goes long after an up-cross and
+  short after a down-cross on a known close series, and is **causal** —
+  recomputing from only the bars ``≤ t`` reproduces the signal at ``t`` (no
+  lookahead);
+* :func:`load_strategy` resolves both a passed callable and a
+  ``"module:function"`` string, and raises a clear :class:`SignalError` on an
+  unresolvable reference;
+* warmup: fewer than ``lookback`` bars yields a flat signal (the documented
+  safe default), never a call into ``signal_fn``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import polars as pl
+import pytest
+
+from trading_bot.application.config import StrategyConfig
+from trading_bot.application.strategy import (
+    Strategy,
+    load_strategy,
+    ma_crossover_signal,
+)
+from trading_bot.domain.errors import InstrumentMismatch, SignalError
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.signal import Signal, SignalMode
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+ETH_USD = Instrument(Symbol("ETH", "USD"))
+
+
+# --- helpers --------------------------------------------------------------- #
+
+
+def _bars(closes: list[float], *, start_ts: int = 1_000) -> pl.DataFrame:
+    """A minimal OHLC(V) bars frame from a list of closes (time in seconds)."""
+    n = len(closes)
+    times = [start_ts + 60 * i for i in range(n)]
+    return pl.DataFrame(
+        {
+            "time": times,
+            "o": closes,
+            "h": closes,
+            "l": closes,
+            "c": closes,
+            "v": [1.0] * n,
+        }
+    )
+
+
+def constant_long_signal(bars: pl.DataFrame) -> Signal:
+    """Module-level signal_fn for the loader test (resolvable by import)."""
+    return Signal.exposure(BTC_USD, money("1"), ts=0)
+
+
+# --- Strategy.evaluate ----------------------------------------------------- #
+
+
+def test_evaluate_returns_signal_from_callable() -> None:
+    want = Signal.exposure(BTC_USD, money("1"), ts=5)
+    strat = Strategy(name="s", instrument=BTC_USD, signal_fn=lambda b: want)
+    got = strat.evaluate(_bars([100.0, 101.0]))
+    assert got is want
+
+
+def test_evaluate_rejects_instrument_mismatch() -> None:
+    # signal_fn returns a signal for ETH/USD but the strategy is BTC/USD.
+    strat = Strategy(
+        name="s",
+        instrument=BTC_USD,
+        signal_fn=lambda b: Signal.exposure(ETH_USD, money("1"), ts=0),
+    )
+    with pytest.raises(InstrumentMismatch):
+        strat.evaluate(_bars([100.0]))
+
+
+def test_strategy_rejects_bad_reference_qty_and_lookback() -> None:
+    with pytest.raises(SignalError):
+        Strategy(
+            name="s",
+            instrument=BTC_USD,
+            signal_fn=constant_long_signal,
+            reference_qty=money("0"),
+        )
+    with pytest.raises(SignalError):
+        Strategy(
+            name="s",
+            instrument=BTC_USD,
+            signal_fn=constant_long_signal,
+            lookback=-1,
+        )
+
+
+# --- warmup ---------------------------------------------------------------- #
+
+
+def test_warmup_returns_flat_below_lookback() -> None:
+    called = False
+
+    def fn(bars: pl.DataFrame) -> Signal:
+        nonlocal called
+        called = True
+        return Signal.exposure(BTC_USD, money("1"), ts=0)
+
+    strat = Strategy(name="s", instrument=BTC_USD, signal_fn=fn, lookback=5)
+    sig = strat.evaluate(_bars([100.0, 101.0, 102.0]))  # 3 < 5
+    assert sig.mode is SignalMode.EXPOSURE
+    assert sig.target == money("0")
+    assert not called  # signal_fn must not be invoked during warmup
+
+
+def test_warmup_calls_fn_at_lookback() -> None:
+    strat = Strategy(
+        name="s",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=1, slow=2),
+        lookback=2,
+    )
+    # exactly 2 bars -> fn is called (not flat-by-warmup).
+    sig = strat.evaluate(_bars([100.0, 200.0]))
+    assert sig.target == money("1")  # rising -> long
+
+
+# --- ma_crossover_signal --------------------------------------------------- #
+
+
+def test_ma_crossover_rejects_bad_windows() -> None:
+    with pytest.raises(ValueError):
+        ma_crossover_signal(BTC_USD, fast=5, slow=5)
+    with pytest.raises(ValueError):
+        ma_crossover_signal(BTC_USD, fast=0, slow=3)
+
+
+def test_ma_crossover_long_then_short() -> None:
+    fn = ma_crossover_signal(BTC_USD, fast=2, slow=4)
+
+    # A clear up-trend: fast MA rises above slow MA -> long.
+    up = _bars([10.0, 11.0, 13.0, 16.0, 20.0, 25.0])
+    long_sig = fn(up)
+    assert long_sig.mode is SignalMode.EXPOSURE
+    assert long_sig.target == money("1")
+
+    # A clear down-trend: fast MA falls below slow MA -> short.
+    down = _bars([25.0, 20.0, 16.0, 13.0, 11.0, 10.0])
+    short_sig = fn(down)
+    assert short_sig.target == money("-1")
+
+
+def test_ma_crossover_flips_at_crossover() -> None:
+    fn = ma_crossover_signal(BTC_USD, fast=2, slow=4)
+    # up then down: collect the exposure at each step (using only bars <= t).
+    closes = [10.0, 11.0, 13.0, 16.0, 20.0, 25.0, 22.0, 17.0, 12.0, 9.0, 7.0]
+    targets = [
+        float(fn(_bars(closes[: t + 1])).target) for t in range(len(closes))
+    ]
+    # Goes long during the up-leg and turns short during the down-leg.
+    assert any(t > 0 for t in targets), targets
+    assert targets[-1] < 0, targets  # short by the end of the down-leg
+
+
+def test_ma_crossover_is_causal() -> None:
+    """The signal at bar t must not depend on any bar > t (no lookahead)."""
+    fn = ma_crossover_signal(BTC_USD, fast=3, slow=5)
+    closes = [10.0, 12.0, 11.0, 14.0, 18.0, 22.0, 19.0, 15.0, 11.0, 8.0]
+
+    # The full-series signal at index t == the signal recomputed from closes[:t+1].
+    full = _bars(closes)
+    for t in range(len(closes)):
+        truncated = fn(_bars(closes[: t + 1]))
+        # Recompute the "signal as of t" from the full frame by slicing to t+1
+        # rows — must match the truncated-input computation exactly.
+        as_of_t = fn(full.head(t + 1))
+        assert truncated.target == as_of_t.target, (
+            f"lookahead at t={t}: {truncated.target} != {as_of_t.target}"
+        )
+
+
+def test_ma_crossover_ts_from_latest_bar() -> None:
+    fn = ma_crossover_signal(BTC_USD, fast=2, slow=4)
+    bars = _bars([10.0, 11.0, 13.0, 16.0], start_ts=1_700_000_000)
+    sig = fn(bars)
+    # latest bar time = 1_700_000_000 + 3*60 seconds -> milliseconds.
+    assert sig.ts == (1_700_000_000 + 180) * 1_000
+
+
+# --- load_strategy --------------------------------------------------------- #
+
+
+def test_load_strategy_with_callable() -> None:
+    cfg = StrategyConfig(name="ma-cross", symbol="BTC/USD")
+    strat = load_strategy(cfg, constant_long_signal)
+    assert strat.name == "ma-cross"
+    assert strat.instrument == BTC_USD
+    assert strat.signal_fn is constant_long_signal
+
+
+def test_load_strategy_with_import_string() -> None:
+    cfg = StrategyConfig(name="ma-cross", symbol="BTC/USD")
+    ref = "trading_bot.tests.application.test_strategy:constant_long_signal"
+    strat = load_strategy(cfg, ref)
+    assert strat.signal_fn is constant_long_signal
+    # And the resolved callable still works through evaluate().
+    sig = strat.evaluate(_bars([100.0, 101.0]))
+    assert sig.target == money("1")
+
+
+def test_load_strategy_kraken_pair_symbol() -> None:
+    cfg = StrategyConfig(name="s", symbol="XXBTZUSD")
+    strat = load_strategy(cfg, constant_long_signal)
+    assert strat.instrument == BTC_USD
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "no_colon_here",
+        ":missing_module",
+        "trading_bot.application.strategy:",
+        "trading_bot.does.not.exist:fn",
+        "trading_bot.application.strategy:nonexistent_attr",
+    ],
+)
+def test_load_strategy_unresolvable_raises(ref: str) -> None:
+    cfg = StrategyConfig(name="s", symbol="BTC/USD")
+    with pytest.raises(SignalError):
+        load_strategy(cfg, ref)
+
+
+def test_load_strategy_non_callable_attr_raises() -> None:
+    # __all__ is a list on the module -> resolvable but not callable.
+    cfg = StrategyConfig(name="s", symbol="BTC/USD")
+    with pytest.raises(SignalError):
+        load_strategy(cfg, "trading_bot.application.strategy:__all__")
+
+
+# --- verification on realistic synthetic data ------------------------------ #
+
+
+def test_verify_on_realistic_series() -> None:
+    """Trend up then down: exposure flips at the crossovers; fully causal."""
+    rng = np.random.default_rng(42)
+    up = np.linspace(100.0, 200.0, 60)
+    down = np.linspace(200.0, 100.0, 60)
+    trend = np.concatenate([up, down])
+    noise = rng.normal(0.0, 0.5, size=trend.shape)
+    closes = (trend + noise).tolist()
+
+    fn = ma_crossover_signal(BTC_USD, fast=5, slow=20)
+
+    # Step through; each step sees only bars <= t (causal by construction).
+    targets = [
+        float(fn(_bars(closes[: t + 1])).target) for t in range(len(closes))
+    ]
+
+    # Long somewhere in the up-leg, short somewhere in the down-leg.
+    up_leg = targets[20:60]
+    down_leg = targets[80:]
+    assert any(t > 0 for t in up_leg), up_leg
+    assert any(t < 0 for t in down_leg), down_leg
+
+    # Causality cross-check: full-frame head(t+1) == truncated input at every t.
+    full = _bars(closes)
+    for t in range(len(closes)):
+        assert float(fn(full.head(t + 1)).target) == targets[t]


### PR DESCRIPTION
## Summary
- First leaf of **E5 — Strategy runner**: `application/strategy.py`.
- `Strategy(instrument, signal_fn, reference_qty?, lookback?)` where `signal_fn: bars(polars) → domain Signal`; `evaluate(bars)` enforces the instrument invariant and is flat during warmup. A **safe loader** (`module:function` import, no arbitrary-file exec) and a fynance-backed `ma_crossover_signal` example.

## Why
- A `bars→Signal` callable is the minimal strategy surface and reuses the domain `Signal` end to end. The safe loader removes the legacy code-execution sink (loose-file `exec` in `StrategyBot`). See `doc/dev/03-decisions.md`. First code consuming **fynance** (`fy.sma`).

## Changes
- `application/strategy.py` + exports; `tests/application/test_strategy.py` (20 tests). Causality (no lookahead) asserted for the example signal.

## Changelog
Added: `application.Strategy` — declare/load (config + signal callable) + safe loader + fynance MA-crossover example.

## Test plan
- [x] `.venv/bin/python -m pytest` (357 passed, **0 skipped**)
- [x] causality asserted (signal at t uses only bars ≤ t)
- [x] `ruff` + `mypy` clean