### PR TITLE
feat: DataFeed (causal bars; in-memory + dccd-backed)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `application.Strategy` — declare/load a strategy (config + a signal callable
   `bars→domain Signal`) with a **safe loader** (importable `module:function`, no
   arbitrary-file exec) + a fynance-backed MA-crossover example signal.
+- `application.DataFeed` — causal bars feed (`InMemoryFeed` + dccd-backed
+  `DccdFeed`): growing windows `frame[:t+1]`, never a future bar; live emits only
+  closed bars.
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,24 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-21 DataFeed: causal windows, thin injectable dccd coupling
+
+**Decision.** `application/data_feed.py` `DataFeed` is a sync `Iterable[polars.DataFrame]`
+of **growing causal windows** — at step *t* it yields `frame[:t+1]` (all bars ≤ t,
+never a future bar), so any feed-driven backtest is lookahead-free by construction.
+`InMemoryFeed` replays a fixed frame; `DccdFeed` reads real bars via `dccd.Client.read`
+(mapping dccd's `TS,open,high,low,close,volume` → `time,o,h,l,c,v`) and replays the same
+way, with an `async live_windows` that emits a bar only once **closed**
+(`now − bar.time ≥ span`). The dccd client is injected (typed against a minimal
+protocol) — nothing imports dccd, so offline tests use a fake returning a canned frame.
+
+**Why.** Causality is the hard strategy invariant (mirrors fynance walk-forward); making
+the window prefix the data structure removes a whole class of lookahead bugs. A sync
+iterator fits the backtest loop; closed-bar-only keeps live identical to replay. Thin
+injectable coupling keeps the offline suite dccd-free and isolates dccd's column quirks.
+
+---
+
 ### 2026-06-21 Strategy contract: bars→Signal callable + safe loader (no file exec)
 
 **Decision.** `application/strategy.py` models a strategy as `(instrument,

--- a/doc/dev/plans/strategy-runner/00-plan.md
+++ b/doc/dev/plans/strategy-runner/00-plan.md
@@ -31,7 +31,7 @@ walk-forward discipline.)
 ## Leaf checklist
 
 - [x] 01 strategy-spec — feat/strategy-spec — medium
-- [ ] 02 data-feed — feat/data-feed — high
+- [x] 02 data-feed — feat/data-feed — high
 - [ ] 03 strategy-runner — feat/strategy-runner — high (depends on 01, 02)
 
 ## Dependencies

--- a/doc/dev/plans/strategy-runner/02-data-feed.md
+++ b/doc/dev/plans/strategy-runner/02-data-feed.md
@@ -6,7 +6,7 @@ complexity: high
 depends: []
 parallel: false
 branch: feat/data-feed
-pr: ""
+pr: "#32"
 ---
 
 # DataFeed — bars to a strategy (in-memory + dccd-backed)

--- a/doc/dev/plans/strategy-runner/02-data-feed.md
+++ b/doc/dev/plans/strategy-runner/02-data-feed.md
@@ -1,7 +1,7 @@
 ---
 plan: strategy-runner/02-data-feed
 kind: leaf
-status: planned
+status: executing
 complexity: high
 depends: []
 parallel: false

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -43,6 +43,12 @@ It then layers the engine's use-cases:
   :func:`~trading_bot.application.strategy.load_strategy` loader (no
   arbitrary-file exec), and the built-in
   :func:`~trading_bot.application.strategy.ma_crossover_signal` example.
+* data_feed — the :class:`~trading_bot.application.data_feed.DataFeed` protocol
+  (an iterator of growing **causal** bar windows — at step ``t`` only bars
+  ``≤ t``, never a future bar) with the offline
+  :class:`~trading_bot.application.data_feed.InMemoryFeed` and the dccd-backed
+  :class:`~trading_bot.application.data_feed.DccdFeed` (injected client; thin
+  coupling), the source of the bars frames a ``signal_fn`` evaluates.
 """
 
 from __future__ import annotations
@@ -52,6 +58,12 @@ from trading_bot.application.config import (
     BrokerConfig,
     RiskConfig,
     StrategyConfig,
+)
+from trading_bot.application.data_feed import (
+    BARS_SCHEMA,
+    DataFeed,
+    DccdFeed,
+    InMemoryFeed,
 )
 from trading_bot.application.events import (
     Event,
@@ -87,6 +99,11 @@ __all__ = [
     "PositionTracker",
     "reconcile",
     "ReconResult",
+    # data feed
+    "DataFeed",
+    "InMemoryFeed",
+    "DccdFeed",
+    "BARS_SCHEMA",
     # strategy
     "Strategy",
     "SignalFn",

--- a/trading_bot/application/data_feed.py
+++ b/trading_bot/application/data_feed.py
@@ -1,0 +1,388 @@
+"""Feed market **bars** to a strategy as growing, *causal* windows.
+
+A :class:`DataFeed` turns a source of OHLC(V) bars into an **iterator of causal
+windows**: stepping it once yields a :class:`polars.DataFrame` containing every
+bar *up to and including* the current step — ``frame[: t + 1]`` at step ``t``.
+A strategy's :data:`~trading_bot.application.strategy.SignalFn` evaluated on that
+window therefore only ever sees bars ``≤ t``. This is the load-bearing
+invariant of the whole module:
+
+    **Causality / no lookahead** — at step ``t`` the feed exposes only bars
+    ``≤ t``; the window's last ``time`` is bar ``t``'s, never a later bar's.
+    A backtest driven by a feed is, by construction, free of forward-looking
+    leakage.
+
+The bars-frame schema (the shape
+:mod:`~trading_bot.application.strategy` consumes) is a :class:`polars.DataFrame`
+with columns, rows ordered oldest→newest:
+
+================  =========================================================
+column            meaning
+================  =========================================================
+``time``          bar open time (epoch units as stored; dccd OHLC is ns)
+``o`` ``h`` ``l`` open / high / low price of the bar
+``c``             **close** price of the bar
+``v``             traded volume over the bar
+================  =========================================================
+
+Sync vs async
+-------------
+:class:`DataFeed` is a **synchronous** ``Iterable[pl.DataFrame]`` — the natural
+shape for a backtest loop (``for window in feed: ...``), and how the runner
+(leaf 03) drives an offline replay. Iterating to exhaustion is finite for a
+fixed historical frame. For a *live* feed, where bars arrive over time, the
+poll-driven :meth:`DccdFeed.live_windows` async generator is provided as well; it
+emits a window only when a **new closed bar** has appeared (never a partial,
+still-forming bar — see :class:`DccdFeed`).
+
+dccd column mapping
+-------------------
+``dccd.Client.read(..., data_type="ohlc")`` returns columns
+``TS, open, high, low, close, volume, quote_volume, trades`` (``TS`` in
+nanoseconds UTC, sorted ascending, deduplicated). :class:`DccdFeed` normalises
+that to the strategy schema:
+
+================  ===============
+dccd column       schema column
+================  ===============
+``TS``            ``time``
+``open``          ``o``
+``high``          ``h``
+``low``           ``l``
+``close``         ``c``
+``volume``        ``v``
+================  ===============
+
+(``quote_volume`` / ``trades`` are dropped.) The dccd coupling is kept **thin
+and injectable**: :class:`DccdFeed` takes the client as a constructor argument
+typed against the tiny :class:`_DccdClient` protocol, so tests pass a fake
+client returning a canned frame and never need real dccd installed.
+
+This module lives in the application layer: it depends on :mod:`polars` and may
+import the pure domain. It performs no I/O of its own — only the injected dccd
+client does (and only inside :class:`DccdFeed`).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Iterator
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+import polars as pl
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+__all__ = [
+    "DataFeed",
+    "InMemoryFeed",
+    "DccdFeed",
+    "BARS_SCHEMA",
+]
+
+#: The columns a bars frame must carry for a strategy ``signal_fn`` (in order).
+BARS_SCHEMA: tuple[str, ...] = ("time", "o", "h", "l", "c", "v")
+
+#: dccd OHLC column -> bars-schema column. ``TS`` is nanoseconds UTC; the other
+#: dccd OHLC columns (``quote_volume``, ``trades``) are not part of the schema
+#: and are dropped on normalisation.
+_DCCD_TO_SCHEMA: dict[str, str] = {
+    "TS": "time",
+    "open": "o",
+    "high": "h",
+    "low": "l",
+    "close": "c",
+    "volume": "v",
+}
+
+
+def _validate_bars_schema(frame: pl.DataFrame) -> None:
+    """Raise :class:`ValueError` unless ``frame`` carries the bars schema.
+
+    Every column in :data:`BARS_SCHEMA` must be present (extra columns are
+    tolerated — a strategy may read any subset). The close column ``c`` is the
+    one the built-in signal needs, so a frame missing it is explicitly rejected.
+    """
+    missing = [col for col in BARS_SCHEMA if col not in frame.columns]
+    if missing:
+        raise ValueError(
+            f"bars frame missing required column(s) {missing}; "
+            f"expected schema {list(BARS_SCHEMA)}, got {frame.columns}"
+        )
+
+
+@runtime_checkable
+class DataFeed(Protocol):
+    """A source of **causal bar windows** for a strategy.
+
+    A ``DataFeed`` is a synchronous iterable: iterating it yields a growing
+    window of bars, one bar advanced per step. The window at step ``t`` is the
+    causal prefix ``frame[: t + 1]`` — all bars ``≤ t`` and **no later bar**, so
+    a ``signal_fn`` evaluated on it can never look ahead.
+
+    Implementations
+    ---------------
+    * :class:`InMemoryFeed` — replays a fixed in-memory frame (deterministic;
+      the backbone of offline tests/backtests).
+    * :class:`DccdFeed` — reads real stored bars via an injected dccd client and
+      replays them (historical), plus a live poll mode.
+    """
+
+    def __iter__(self) -> Iterator[pl.DataFrame]:
+        """Yield growing causal windows, one bar advanced per step."""
+        ...
+
+    def latest(self) -> pl.DataFrame:
+        """Return the full bars frame currently known to the feed.
+
+        For a historical/in-memory feed this is every bar; for a live feed it is
+        every bar seen so far (closed bars only). The returned frame is itself a
+        valid bars-schema frame — handy for warmup or a one-shot evaluation.
+        """
+        ...
+
+
+def _replay(frame: pl.DataFrame) -> Iterator[pl.DataFrame]:
+    """Yield ``frame[: t + 1]`` for ``t`` in ``0 .. height-1`` (causal prefixes).
+
+    The shared replay engine behind :class:`InMemoryFeed` and
+    :class:`DccdFeed`'s historical mode. An empty frame yields nothing.
+    """
+    height = frame.height
+    for t in range(height):
+        # frame[: t + 1] is bars 0..t inclusive — the causal window at step t.
+        yield frame[: t + 1]
+
+
+class InMemoryFeed:
+    """A :class:`DataFeed` over a fixed, in-memory bars frame.
+
+    Wraps a bars-schema frame (validated on construction) and replays it
+    bar-by-bar: iterating yields the causal prefix ``frame[: t + 1]`` at each
+    step ``t``. Deterministic and offline — the backbone of unit tests and
+    reproducible backtests.
+
+    Parameters
+    ----------
+    frame : polars.DataFrame
+        The OHLC(V) bars, oldest→newest, carrying at least the
+        :data:`BARS_SCHEMA` columns. Validated on construction.
+
+    Raises
+    ------
+    ValueError
+        If ``frame`` is missing any required schema column.
+
+    Examples
+    --------
+    >>> import polars as pl
+    >>> f = pl.DataFrame(
+    ...     {"time": [1, 2, 3], "o": [1.0, 2, 3], "h": [1.0, 2, 3],
+    ...      "l": [1.0, 2, 3], "c": [1.0, 2, 3], "v": [1.0, 1, 1]}
+    ... )
+    >>> feed = InMemoryFeed(f)
+    >>> [w.height for w in feed]
+    [1, 2, 3]
+    """
+
+    def __init__(self, frame: pl.DataFrame) -> None:
+        _validate_bars_schema(frame)
+        self._frame = frame
+
+    def __iter__(self) -> Iterator[pl.DataFrame]:
+        """Yield ``frame[: t + 1]`` for each bar (causal windows)."""
+        return _replay(self._frame)
+
+    def latest(self) -> pl.DataFrame:
+        """Return the full underlying bars frame."""
+        return self._frame
+
+
+@runtime_checkable
+class _DccdClient(Protocol):
+    """The slice of ``dccd.Client`` :class:`DccdFeed` actually uses.
+
+    Kept intentionally tiny so a test fake (or any read-only OHLC source) can
+    stand in without importing dccd. Both methods are **synchronous** (matching
+    ``dccd.Client``).
+    """
+
+    def read(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = ...,
+        span: int | None = ...,
+        start_ns: int | None = ...,
+        end_ns: int | None = ...,
+    ) -> pl.DataFrame:
+        """Return stored bars as a polars frame (dccd OHLC columns)."""
+        ...
+
+
+def normalise_dccd_ohlc(frame: pl.DataFrame) -> pl.DataFrame:
+    """Map a dccd OHLC frame to the bars schema ``time,o,h,l,c,v``.
+
+    Renames the dccd columns per :data:`_DCCD_TO_SCHEMA` and selects exactly the
+    schema columns (dropping ``quote_volume`` / ``trades``). The row order dccd
+    guarantees (ascending ``TS``) is preserved, so the result is oldest→newest.
+
+    Parameters
+    ----------
+    frame : polars.DataFrame
+        A dccd OHLC read (columns ``TS, open, high, low, close, volume, ...``).
+
+    Returns
+    -------
+    polars.DataFrame
+        A bars-schema frame.
+
+    Raises
+    ------
+    ValueError
+        If a required dccd source column is absent (so the mapping cannot
+        produce the full schema).
+    """
+    missing = [src for src in _DCCD_TO_SCHEMA if src not in frame.columns]
+    if missing:
+        raise ValueError(
+            f"dccd OHLC frame missing source column(s) {missing}; "
+            f"expected {list(_DCCD_TO_SCHEMA)}, got {frame.columns}"
+        )
+    renamed = frame.rename(_DCCD_TO_SCHEMA)
+    return renamed.select(list(BARS_SCHEMA))
+
+
+class DccdFeed:
+    """A :class:`DataFeed` backed by stored bars read through a dccd client.
+
+    Two modes share one causal-window contract:
+
+    * **historical** (the default, used by :meth:`__iter__` / :meth:`latest`):
+      read the dataset **once** via ``client.read(...)``, normalise dccd's
+      columns to the bars schema, then replay it bar-by-bar exactly like
+      :class:`InMemoryFeed`. Reproducible backtests over real stored bars.
+    * **live** (:meth:`live_windows`): an async generator that polls
+      ``client.read(...)`` on the span cadence and emits a window only when a
+      **new closed bar** has appeared. A bar is treated as closed once its open
+      time is at least one ``span`` in the past (``now - bar.time ≥ span``), so a
+      still-forming, partial bar is never emitted — **no lookahead**. The dccd
+      client is synchronous, so the poll is run via an injected ``sleep``/``now``
+      pair (defaulting to wall-clock + ``asyncio.sleep``) that tests override
+      with a fake clock.
+
+    The dccd client is **injected** (typed against :class:`_DccdClient`) so tests
+    pass a fake returning a canned frame; nothing here imports dccd.
+
+    Parameters
+    ----------
+    client : _DccdClient
+        A read-only OHLC source with dccd's ``read`` signature (the real
+        ``dccd.Client``, or a test fake).
+    exchange : str
+        Exchange name passed straight to ``client.read``.
+    symbol : str
+        Pair/symbol passed straight to ``client.read``. dccd uses its own pair
+        strings (e.g. ``"BTC/USDT"``); the caller passes whatever the stored
+        dataset is keyed by. (Domain ``Symbol`` rendering lives in the runner.)
+    span : int
+        Bar width in **seconds** (dccd's ``span``); also the live close cadence.
+    start_ns, end_ns : int or None, optional
+        Optional inclusive nanosecond bounds forwarded to ``client.read``.
+
+    Raises
+    ------
+    ValueError
+        On construction if ``span`` is not positive.
+    """
+
+    def __init__(
+        self,
+        client: _DccdClient,
+        exchange: str,
+        symbol: str,
+        span: int,
+        *,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+    ) -> None:
+        if span <= 0:
+            raise ValueError(f"span must be positive seconds, got {span}")
+        self._client = client
+        self._exchange = exchange
+        self._symbol = symbol
+        self._span = span
+        self._start_ns = start_ns
+        self._end_ns = end_ns
+
+    def _read_normalised(self, *, end_ns: int | None = None) -> pl.DataFrame:
+        """Read the dataset via the client and normalise to the bars schema.
+
+        ``end_ns`` overrides the construction bound (used by live polling to cap
+        the read at the latest closed bar); otherwise the construction
+        ``end_ns`` applies.
+        """
+        raw = self._client.read(
+            self._exchange,
+            self._symbol,
+            "ohlc",
+            self._span,
+            self._start_ns,
+            self._end_ns if end_ns is None else end_ns,
+        )
+        return normalise_dccd_ohlc(raw)
+
+    def __iter__(self) -> Iterator[pl.DataFrame]:
+        """Read once (historical) and yield causal windows, bar by bar."""
+        return _replay(self._read_normalised())
+
+    def latest(self) -> pl.DataFrame:
+        """Read and return the full normalised bars frame (historical snapshot)."""
+        return self._read_normalised()
+
+    async def live_windows(
+        self,
+        *,
+        now_ns: Callable[[], int],
+        sleep: Callable[[float], Awaitable[None]],
+        max_steps: int | None = None,
+    ) -> AsyncIterator[pl.DataFrame]:
+        """Poll for new **closed** bars and yield a growing causal window each.
+
+        On each poll it reads the dataset capped at the latest closed-bar
+        boundary (``cutoff = now - span``, in ns), so a bar still being formed is
+        excluded. When the read surfaces at least one bar beyond what was already
+        emitted, the new full prefix (every closed bar so far) is yielded — a
+        causal window, never a partial bar. It then sleeps one ``span`` before
+        polling again.
+
+        Parameters
+        ----------
+        now_ns : Callable[[], int]
+            Returns the current time in nanoseconds UTC. Injected so tests drive
+            a fake clock; live callers pass ``lambda: time.time_ns()``.
+        sleep : Callable[[float], Awaitable[None]]
+            Async sleep (seconds). Live callers pass ``asyncio.sleep``; tests
+            pass a fake that advances the fake clock.
+        max_steps : int or None, optional
+            Stop after yielding this many windows (bounds the otherwise-infinite
+            live loop — required for tests; ``None`` runs until cancelled).
+
+        Yields
+        ------
+        polars.DataFrame
+            A causal window of all closed bars known so far, each time a new
+            closed bar appears.
+        """
+        # span in nanoseconds — the closed-bar cutoff and the poll cadence.
+        span_ns = self._span * 1_000_000_000
+        emitted = 0  # number of closed bars already yielded
+        steps = 0
+        while max_steps is None or steps < max_steps:
+            cutoff_ns = now_ns() - span_ns  # a bar is closed only if time <= cutoff
+            frame = self._read_normalised(end_ns=cutoff_ns)
+            if frame.height > emitted:
+                emitted = frame.height
+                steps += 1
+                yield frame
+            await sleep(float(self._span))

--- a/trading_bot/tests/application/test_data_feed.py
+++ b/trading_bot/tests/application/test_data_feed.py
@@ -1,0 +1,384 @@
+"""Tests for :mod:`trading_bot.application.data_feed`.
+
+These prove the feed's load-bearing **causality / no-lookahead** invariant and
+the thin, injectable dccd coupling:
+
+* :class:`InMemoryFeed` replaying ``N`` bars yields exactly ``N`` windows; the
+  window at step ``t`` has ``t + 1`` rows and its last ``time`` is bar ``t``'s —
+  never a later bar (the no-lookahead assertion);
+* schema validation rejects a frame missing the close column ``c``;
+* a spy ``signal_fn`` driven by an :class:`InMemoryFeed` only ever sees causal
+  frames (the max ``time`` it observes equals the current bar's, never ahead);
+* :class:`DccdFeed` historical mode with an **injected fake client** (returning a
+  canned frame carrying dccd's real column names) normalises to the bars schema
+  and replays the same causal prefixes — no real dccd needed;
+* live mode emits a bar only once it is **closed** (a still-forming bar under a
+  faked clock is never yielded);
+* (``-m network``) a real-data check: if dccd ``inventory()`` reports any stored
+  OHLC, build a :class:`DccdFeed` over it and assert monotonic timestamps and no
+  lookahead across a few prefixes; skip with a clear reason if nothing is stored.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from trading_bot.application.data_feed import (
+    BARS_SCHEMA,
+    DataFeed,
+    DccdFeed,
+    InMemoryFeed,
+    normalise_dccd_ohlc,
+)
+
+# --- helpers --------------------------------------------------------------- #
+
+
+def _bars(closes: list[float], *, start_ts: int = 1_000) -> pl.DataFrame:
+    """A bars-schema frame from a list of closes (time in seconds, +60s/bar)."""
+    n = len(closes)
+    times = [start_ts + 60 * i for i in range(n)]
+    return pl.DataFrame(
+        {
+            "time": times,
+            "o": closes,
+            "h": closes,
+            "l": closes,
+            "c": closes,
+            "v": [1.0] * n,
+        }
+    )
+
+
+def _dccd_ohlc(closes: list[float], *, start_ns: int, span_ns: int) -> pl.DataFrame:
+    """A frame mimicking ``dccd.Client.read(..., 'ohlc')`` (its column names)."""
+    n = len(closes)
+    return pl.DataFrame(
+        {
+            "TS": [start_ns + span_ns * i for i in range(n)],
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "close": closes,
+            "volume": [1.0] * n,
+            "quote_volume": [10.0] * n,
+            "trades": [5] * n,
+        }
+    )
+
+
+class _FakeDccdClient:
+    """A fake dccd client: ``read`` returns a canned frame, honouring ``end_ns``.
+
+    Records the arguments of each ``read`` call so a test can assert what the
+    feed forwarded, and slices the canned frame to ``end_ns`` (inclusive) so the
+    live-mode closed-bar logic can be exercised against a moving cutoff.
+    """
+
+    def __init__(self, frame: pl.DataFrame) -> None:
+        self._frame = frame
+        self.calls: list[dict[str, object]] = []
+
+    def read(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+    ) -> pl.DataFrame:
+        self.calls.append(
+            {
+                "exchange": exchange,
+                "symbol": symbol,
+                "data_type": data_type,
+                "span": span,
+                "start_ns": start_ns,
+                "end_ns": end_ns,
+            }
+        )
+        frame = self._frame
+        if end_ns is not None:
+            frame = frame.filter(pl.col("TS") <= end_ns)
+        return frame
+
+
+# --- InMemoryFeed: causality ----------------------------------------------- #
+
+
+def test_inmemory_replays_n_causal_windows() -> None:
+    """Replaying N bars yields N windows; window t has t+1 rows, last time = t."""
+    frame = _bars([10.0, 11, 12, 13, 14])
+    feed = InMemoryFeed(frame)
+
+    windows = list(feed)
+
+    assert len(windows) == frame.height
+    for t, window in enumerate(windows):
+        # Causal: exactly bars 0..t, and the last time is bar t's — never later.
+        assert window.height == t + 1
+        assert window["time"][-1] == frame["time"][t]
+        # The last bar of the window is never ahead of the current step.
+        assert window["time"][-1] <= frame["time"][t]
+
+
+def test_inmemory_window_never_contains_future_bar() -> None:
+    """The max time in window t equals bar t's time — no lookahead, ever."""
+    frame = _bars([1.0, 2, 3, 4, 5, 6])
+    for t, window in enumerate(InMemoryFeed(frame)):
+        assert window["time"].max() == frame["time"][t]
+
+
+def test_inmemory_latest_returns_full_frame() -> None:
+    """``latest()`` returns the whole underlying frame."""
+    frame = _bars([1.0, 2, 3])
+    assert InMemoryFeed(frame).latest().equals(frame)
+
+
+def test_inmemory_empty_frame_yields_nothing() -> None:
+    """An empty (but schema-valid) frame replays to zero windows."""
+    empty = _bars([])
+    assert list(InMemoryFeed(empty)) == []
+
+
+def test_inmemory_is_a_datafeed() -> None:
+    """InMemoryFeed satisfies the runtime-checkable DataFeed protocol."""
+    assert isinstance(InMemoryFeed(_bars([1.0])), DataFeed)
+
+
+# --- InMemoryFeed: schema validation --------------------------------------- #
+
+
+def test_schema_validation_rejects_missing_close() -> None:
+    """A frame missing the close column ``c`` is rejected on construction."""
+    bad = pl.DataFrame(
+        {"time": [1, 2], "o": [1.0, 2], "h": [1.0, 2], "l": [1.0, 2], "v": [1.0, 1]}
+    )
+    with pytest.raises(ValueError, match="missing required column"):
+        InMemoryFeed(bad)
+
+
+def test_schema_validation_tolerates_extra_columns() -> None:
+    """Extra columns beyond the schema are tolerated (a signal may ignore them)."""
+    frame = _bars([1.0, 2, 3]).with_columns(pl.lit("x").alias("extra"))
+    feed = InMemoryFeed(frame)
+    # All schema columns survive into the windows.
+    last = list(feed)[-1]
+    for col in BARS_SCHEMA:
+        assert col in last.columns
+
+
+# --- A spy signal_fn only ever sees causal frames -------------------------- #
+
+
+def test_spy_signal_fn_only_sees_causal_frames() -> None:
+    """A spy recording the max time it sees never observes a future bar."""
+    frame = _bars([100.0, 101, 102, 103, 104])
+    seen_max: list[int] = []
+
+    def spy(window: pl.DataFrame) -> None:
+        seen_max.append(int(window["time"].max()))
+
+    for t, window in enumerate(InMemoryFeed(frame)):
+        spy(window)
+        # At step t the spy may only have seen up to bar t's time.
+        assert seen_max[-1] == int(frame["time"][t])
+        assert seen_max[-1] <= int(frame["time"][t])
+
+
+# --- DccdFeed historical: normalisation + causal replay -------------------- #
+
+
+def test_normalise_dccd_ohlc_maps_columns() -> None:
+    """dccd OHLC columns map to time,o,h,l,c,v (extras dropped, order kept)."""
+    raw = _dccd_ohlc([1.0, 2, 3], start_ns=10**18, span_ns=60 * 10**9)
+    norm = normalise_dccd_ohlc(raw)
+    assert list(norm.columns) == list(BARS_SCHEMA)
+    # close -> c carried through faithfully.
+    assert norm["c"].to_list() == [1.0, 2, 3]
+    assert norm["time"].to_list() == raw["TS"].to_list()
+
+
+def test_normalise_dccd_ohlc_rejects_missing_source() -> None:
+    """A dccd frame missing a source column (e.g. close) is rejected."""
+    raw = _dccd_ohlc([1.0, 2], start_ns=1, span_ns=1).drop("close")
+    with pytest.raises(ValueError, match="missing source column"):
+        normalise_dccd_ohlc(raw)
+
+
+def test_dccd_historical_replays_causal_prefixes() -> None:
+    """Historical mode reads once, normalises, and replays causal prefixes."""
+    span = 60
+    span_ns = span * 1_000_000_000
+    raw = _dccd_ohlc([5.0, 6, 7, 8], start_ns=10**18, span_ns=span_ns)
+    client = _FakeDccdClient(raw)
+    feed = DccdFeed(client, "binance", "BTC/USDT", span)
+
+    windows = list(feed)
+
+    assert len(windows) == 4
+    for t, window in enumerate(windows):
+        assert list(window.columns) == list(BARS_SCHEMA)
+        assert window.height == t + 1
+        # Causal: last time is bar t's TS, never a later one.
+        assert window["time"][-1] == raw["TS"][t]
+        assert window["time"].max() == raw["TS"][t]
+    # The read was forwarded with the dccd contract args.
+    assert client.calls[0]["exchange"] == "binance"
+    assert client.calls[0]["symbol"] == "BTC/USDT"
+    assert client.calls[0]["data_type"] == "ohlc"
+    assert client.calls[0]["span"] == span
+
+
+def test_dccd_latest_returns_full_normalised_frame() -> None:
+    """``latest()`` returns the full normalised bars frame."""
+    raw = _dccd_ohlc([1.0, 2, 3], start_ns=1, span_ns=1)
+    feed = DccdFeed(_FakeDccdClient(raw), "kraken", "XBT/USD", 1)
+    full = feed.latest()
+    assert list(full.columns) == list(BARS_SCHEMA)
+    assert full.height == 3
+
+
+def test_dccd_rejects_non_positive_span() -> None:
+    """Construction rejects a non-positive span."""
+    with pytest.raises(ValueError, match="span must be positive"):
+        DccdFeed(_FakeDccdClient(_dccd_ohlc([], start_ns=0, span_ns=1)), "x", "y", 0)
+
+
+def test_dccd_is_a_datafeed() -> None:
+    """DccdFeed satisfies the runtime-checkable DataFeed protocol."""
+    feed = DccdFeed(_FakeDccdClient(_dccd_ohlc([1.0], start_ns=0, span_ns=1)), "x", "y", 1)
+    assert isinstance(feed, DataFeed)
+
+
+# --- DccdFeed live: closed-bar-only ---------------------------------------- #
+
+
+class _FakeClock:
+    """A monotonic fake clock (ns) advanced by the fake sleep, for live tests."""
+
+    def __init__(self, start_ns: int) -> None:
+        self.t = start_ns
+
+    def now_ns(self) -> int:
+        return self.t
+
+    async def sleep(self, seconds: float) -> None:
+        self.t += int(seconds * 1_000_000_000)
+
+
+async def test_live_emits_only_closed_bars() -> None:
+    """Live mode never yields a bar whose close time has not yet passed.
+
+    Three bars exist in the store at times t0, t0+span, t0+2*span. The clock
+    starts just after bar 0's close window but before bar 1's, so the first poll
+    must surface only bar 0 (bars 1 and 2 are still 'forming' relative to the
+    clock). As the fake clock advances one span per poll, each newly closed bar
+    appears, and a window is never longer than the number of bars that have
+    actually closed.
+    """
+    span = 60
+    span_ns = span * 1_000_000_000
+    t0 = 1_000 * span_ns
+    raw = _dccd_ohlc([10.0, 11, 12], start_ns=t0, span_ns=span_ns)
+    client = _FakeDccdClient(raw)
+    feed = DccdFeed(client, "binance", "BTC/USDT", span)
+
+    # Clock starts one span after bar 0's open => bar 0 is closed, bars 1,2 not.
+    clock = _FakeClock(t0 + span_ns)
+
+    windows: list[pl.DataFrame] = []
+    async for window in feed.live_windows(
+        now_ns=clock.now_ns, sleep=clock.sleep, max_steps=3
+    ):
+        windows.append(window)
+
+    # One window per newly closed bar; growing causal prefixes.
+    assert [w.height for w in windows] == [1, 2, 3]
+    # First window holds only the closed bar 0 — the not-yet-closed bars were
+    # excluded (no lookahead / no partial bar).
+    assert windows[0]["time"].to_list() == [t0]
+    assert windows[1]["time"].to_list() == [t0, t0 + span_ns]
+    assert windows[2]["time"].to_list() == [t0, t0 + span_ns, t0 + 2 * span_ns]
+    # Every read was capped at the closed-bar cutoff (now - span), never beyond.
+    for call in client.calls:
+        assert call["end_ns"] is not None
+
+
+class _StopPolling(Exception):
+    """Sentinel raised by the fake sleep to break an unbounded live loop."""
+
+
+async def test_live_does_not_emit_unclosed_bar_when_none_closed() -> None:
+    """With the clock before the first bar closes, no window is emitted."""
+    span = 60
+    span_ns = span * 1_000_000_000
+    t0 = 5_000 * span_ns
+    raw = _dccd_ohlc([1.0], start_ns=t0, span_ns=span_ns)
+    feed = DccdFeed(_FakeDccdClient(raw), "binance", "BTC/USDT", span)
+
+    # Clock sits during bar 0's formation window (before t0 + span): not closed.
+    clock = _FakeClock(t0 + span_ns // 2)
+
+    windows: list[pl.DataFrame] = []
+    # Bound the loop by sleeps via a small wrapper: stop after a few polls.
+    polls = 0
+
+    async def bounded_sleep(seconds: float) -> None:
+        nonlocal polls
+        polls += 1
+        # Do NOT advance the clock — the bar stays unclosed forever here.
+        if polls >= 3:
+            raise _StopPolling
+
+    with pytest.raises(_StopPolling):
+        async for window in feed.live_windows(
+            now_ns=clock.now_ns, sleep=bounded_sleep
+        ):
+            windows.append(window)
+
+    assert windows == []  # nothing closed => nothing emitted
+
+
+# --- Verification on real data (opt-in) ------------------------------------ #
+
+
+@pytest.mark.network
+def test_dccd_real_inventory_causal_replay() -> None:
+    """Real dccd: replay a stored OHLC dataset and assert no lookahead.
+
+    Skips with a clear reason when no OHLC dataset is stored (the injected-client
+    tests above cover the logic; this only adds real-data coverage when present).
+    """
+    dccd = pytest.importorskip("dccd")
+    client = dccd.Client()
+    ohlc = [d for d in client.inventory() if d.get("data_type") == "ohlc" and d.get("rows", 0) > 0]
+    if not ohlc:
+        pytest.skip("no stored dccd OHLC dataset to replay (inventory empty)")
+
+    entry = ohlc[0]
+    feed = DccdFeed(
+        client,
+        entry["exchange"],
+        entry["pair"],
+        int(entry["span"]),
+    )
+    full = feed.latest()
+    if full.height == 0:
+        pytest.skip(f"dccd OHLC dataset {entry['exchange']}/{entry['pair']} read empty")
+
+    assert list(full.columns) == list(BARS_SCHEMA)
+    # Monotonic non-decreasing timestamps over the whole frame.
+    times = full["time"].to_list()
+    assert times == sorted(times)
+
+    # Replay a few causal prefixes and assert each window's last time is its
+    # current bar's — never a later one.
+    for t, window in enumerate(feed):
+        assert window.height == t + 1
+        assert window["time"][-1] == full["time"][t]
+        assert window["time"].max() == full["time"][t]
+        if t >= 4:
+            break


### PR DESCRIPTION
## Summary
- Second leaf of **E5**: `application/data_feed.py` — `DataFeed` (sync `Iterable[polars.DataFrame]` of growing causal windows `frame[:t+1]`), `InMemoryFeed` (offline backbone), `DccdFeed` (real bars via `dccd.Client.read`).
- **Causality by construction**: at step *t* the feed exposes only bars ≤ t. Live mode emits a bar only once **closed**.

## Why
- Causality is the hard strategy invariant (mirrors fynance walk-forward) — making the window prefix the data structure removes a class of lookahead bugs. Thin injectable dccd coupling keeps the offline suite dccd-free. dccd `TS,open,high,low,close,volume` → `time,o,h,l,c,v`. See `doc/dev/03-decisions.md`.

## Changes
- `application/data_feed.py` + exports; `tests/application/test_data_feed.py` (16 offline + 1 `-m network`, skips cleanly if no stored OHLC).

## Changelog
Added: `application.DataFeed` — causal bars feed (in-memory + dccd-backed).

## Test plan
- [x] `.venv/bin/python -m pytest` (373 passed, 4 deselected = network; 0 unexpected skips)
- [x] causality asserted (window last `time` == bar t; spy `signal_fn` never sees a future bar)
- [x] `ruff` + `mypy` clean