### PR TITLE
feat: StrategyRunner — the live loop (closes E5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `application.DataFeed` — causal bars feed (`InMemoryFeed` + dccd-backed
   `DccdFeed`): growing windows `frame[:t+1]`, never a future bar; live emits only
   closed bars.
+- `application.StrategyRunner` — the live loop wiring `DataFeed` → strategy signal
+  → `Signal.delta_to(position)` → order → `OrderRouter`, with per-step idempotent
+  client-order-ids. Completes the **E5 strategy runner**: a strategy now runs
+  end-to-end (dccd data → fynance signal → managed positions on a broker).
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,26 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-22 StrategyRunner: the live loop, per-step idempotent ids, warmup in one place
+
+**Decision.** `application/strategy_runner.py` `StrategyRunner(strategy, feed, router,
+tracker, *, event_bus, order_factory)` is an async driver over the sync `DataFeed`:
+per causal window, `signal = strategy.evaluate(bars)`; `delta =
+signal.delta_to(tracker.position(instrument), reference_qty)`; if `delta != 0`, submit a
+MARKET order (side/qty from the delta) with a **deterministic per-step
+`client_order_id`** `f"{strategy.name}-{step}"` so a re-run dedups to one venue order
+(the runner half of E4 idempotency). `delta == 0` → no order. Warmup is **not**
+re-implemented — `Strategy.evaluate` returns flat below `lookback`, so flat-vs-flat →
+no order. `order_factory`'s id is always overridden by the runner.
+
+**Why.** This closes the loop: dccd data → fynance signal → target position → managed
+orders, lookahead-free by construction (the runner only reads the window it's handed).
+Keeping warmup in the strategy and idempotency in the runner avoids duplicated logic.
+The step index advances even on no-order steps so ids stay 1:1 with bars (a re-run
+reproduces them exactly).
+
+---
+
 ### 2026-06-21 DataFeed: causal windows, thin injectable dccd coupling
 
 **Decision.** `application/data_feed.py` `DataFeed` is a sync `Iterable[polars.DataFrame]`

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,16 +10,17 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**Foundation (E1–E3) and the execution engine (E4) are complete.**
-`trading_bot/domain/` (money, instrument, errors, order, fill, position, signal,
-performance — pure, mypy-strict), `trading_bot/transport/` (`AsyncHTTPClient`,
-`WebSocketBase`, `RateLimiter` + `KrakenCallCounter`), `trading_bot/brokers/` (the
-`Broker` port + registry + `KrakenBroker` REST + `KrakenPrivateWS` + the **port-pure
-`PaperBroker`**), and `trading_bot/application/` (`AppConfig` + `EventBus`,
-`OrderRouter` with idempotent submit, `PositionTracker` from fills, `reconcile`) are
-in — the whole order→fill→position→reconcile path runs in-process. The later layers
-(strategy runner, storage, perf/risk, interfaces) are pending — next is **E5
-(strategy runner)**. See `07-roadmap.md` /
+**Foundation (E1–E3), the execution engine (E4) and the strategy runner (E5) are
+complete — a strategy now runs end-to-end.** `domain/` (pure, mypy-strict),
+`transport/` (`AsyncHTTPClient`, `WebSocketBase`, `RateLimiter`/`KrakenCallCounter`),
+`brokers/` (the `Broker` port + `KrakenBroker` REST + `KrakenPrivateWS` + the
+port-pure `PaperBroker`), and `application/` (`AppConfig` + `EventBus`, `OrderRouter`
+idempotent, `PositionTracker`, `reconcile`, **`Strategy` + safe loader, `DataFeed`
+causal, `StrategyRunner`**) are in. The full loop **dccd data → fynance signal →
+target position → managed orders on a broker → fills → position** runs in-process and
+is verified end-to-end. Pending: **E6** (performance service, SQLite persistence,
+risk manager + kill-switch), then **E7** (CLI — the MVP "first light"), E8
+orchestration, E9 UI, E10 go-live. Next is **E6**. See `07-roadmap.md` /
 `08-program-plan.md`.
 
 ## Done

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,9 +12,6 @@ The single source *index* of open work. Each unchecked item is a candidate for
 
 ## Execution engine
 
-- [ ] **E5 — Strategy runner.** Load a strategy (config + fynance signal), feed it
-  data from dccd, emit target positions/orders; the live loop. Replaces
-  `legacy/StrategyBot`. _(depends on E4)_
 - [ ] **E6 — Performance, persistence & risk.** `PerformanceService` (PnL/KPI),
   `storage` (SQLite order/fill history + state for reconciliation), `RiskManager`
   (pre-trade limits + kill-switch). _(depends on E4)_

--- a/doc/dev/plans/strategy-runner/00-plan.md
+++ b/doc/dev/plans/strategy-runner/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: strategy-runner
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E5 — Strategy runner.** Load a strategy (config + fynance signal), feed it data from dccd, emit target positions/orders; the live loop. Replaces `legacy/StrategyBot`."
 release_on_done: false
 ---
@@ -32,7 +32,7 @@ walk-forward discipline.)
 
 - [x] 01 strategy-spec — feat/strategy-spec — medium
 - [x] 02 data-feed — feat/data-feed — high
-- [ ] 03 strategy-runner — feat/strategy-runner — high (depends on 01, 02)
+- [x] 03 strategy-runner — feat/strategy-runner — high (depends on 01, 02)
 
 ## Dependencies
 

--- a/doc/dev/plans/strategy-runner/03-strategy-runner.md
+++ b/doc/dev/plans/strategy-runner/03-strategy-runner.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [01, 02]
 parallel: false
 branch: feat/strategy-runner
-pr: ""
+pr: "#33"
 ---
 
 # StrategyRunner — the live loop

--- a/doc/dev/plans/strategy-runner/03-strategy-runner.md
+++ b/doc/dev/plans/strategy-runner/03-strategy-runner.md
@@ -1,7 +1,7 @@
 ---
 plan: strategy-runner/03-strategy-runner
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01, 02]
 parallel: false

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -49,6 +49,14 @@ It then layers the engine's use-cases:
   :class:`~trading_bot.application.data_feed.InMemoryFeed` and the dccd-backed
   :class:`~trading_bot.application.data_feed.DccdFeed` (injected client; thin
   coupling), the source of the bars frames a ``signal_fn`` evaluates.
+* strategy_runner — the
+  :class:`~trading_bot.application.strategy_runner.StrategyRunner`, the engine's
+  live loop: it pulls causal windows from a ``DataFeed``, evaluates the
+  ``Strategy``'s ``Signal``, diffs it against the ``PositionTracker``'s live
+  position into a target delta, and submits the resulting ``Order`` through the
+  ``OrderRouter`` with a deterministic per-step ``client_order_id`` (so a re-run
+  dedups). No order during warmup or when already on target; causality is
+  preserved by construction.
 """
 
 from __future__ import annotations
@@ -81,6 +89,7 @@ from trading_bot.application.strategy import (
     load_strategy,
     ma_crossover_signal,
 )
+from trading_bot.application.strategy_runner import OrderFactory, StrategyRunner
 
 __all__ = [
     # config
@@ -109,4 +118,7 @@ __all__ = [
     "SignalFn",
     "load_strategy",
     "ma_crossover_signal",
+    # strategy runner
+    "StrategyRunner",
+    "OrderFactory",
 ]

--- a/trading_bot/application/strategy_runner.py
+++ b/trading_bot/application/strategy_runner.py
@@ -1,0 +1,300 @@
+"""The :class:`StrategyRunner` — the engine's live loop, data → orders.
+
+The runner is the **conductor** of an execution run: it pulls causal bar windows
+from a :class:`~trading_bot.application.data_feed.DataFeed`, evaluates the
+:class:`~trading_bot.application.strategy.Strategy`'s signal on each, turns that
+venue-neutral :class:`~trading_bot.domain.signal.Signal` into a *target position
+change* against the live :class:`~trading_bot.application.position_tracker.
+PositionTracker`, and routes the resulting :class:`~trading_bot.domain.order.
+Order` through the idempotent :class:`~trading_bot.application.order_router.
+OrderRouter`. It is the modern replacement for the legacy ``StrategyBot``
+iterator, and the last piece that closes the order ↔ fill loop:
+
+    feed → strategy.evaluate → signal.delta_to(position) → order → router
+       → broker → FillEvent → tracker → (next step's position)
+
+It owns no money logic of its own — every quantity decision is delegated to the
+pure domain (:meth:`Signal.delta_to`), every submission to the router, every fill
+fold to the tracker. The runner only *sequences* those collaborators.
+
+The loop shape (carried into the ADR)
+-------------------------------------
+The feed is a **synchronous** ``Iterable`` of causal windows, but the router is
+``async`` (a venue I/O boundary). So the runner is an ``async`` driver that
+iterates the sync feed and ``await``\\ s one submission per step. The public
+surface is deliberately small:
+
+* :meth:`run` — drive the whole feed (optionally capped at ``max_steps``),
+  returning the number of orders actually submitted;
+* :meth:`step` — process **one** already-pulled window, the unit :meth:`run`
+  calls in a loop. Exposed so a caller (a live driver, a test) can pump windows
+  in by hand and keep the step index it owns.
+
+Because each window is the feed's causal prefix ``frame[: t + 1]`` and the runner
+never reads beyond the window handed to it, **causality is preserved by
+construction** — the runner cannot peek ahead even if it wanted to.
+
+Per-step idempotency (carried into the ADR)
+-------------------------------------------
+Each step's order carries a **deterministic** ``client_order_id`` of the form
+``f"{strategy.name}-{step_index}"``. The step index is monotonic across a run
+(and across :meth:`run` re-invocations on the *same* runner instance), so
+re-running the *same sequence* on a *fresh* runner produces the *same* ids — and
+the router, which dedups on ``client_order_id``, turns a re-run into a no-op at
+the venue (no duplicate broker order). This is the runner's half of the E4
+idempotency contract: the router guarantees "one id → one venue order", and the
+runner guarantees "one step → one stable id".
+
+Warmup (carried into the ADR)
+-----------------------------
+Warmup is **not** re-implemented here. :meth:`Strategy.evaluate` already returns a
+*flat* (zero-exposure) signal until ``lookback`` bars are present. A flat target
+against a flat position yields ``delta == 0`` → no order. So no order is ever
+submitted during warmup, and the runner needs no special-case: the warmup
+guarantee lives in one place (the strategy), and the runner inherits it.
+
+This module lives in the application layer: it imports the pure domain and the
+sibling use-cases, holds money as :class:`~decimal.Decimal` end to end, and
+performs no I/O of its own (the router/broker do).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from trading_bot.application.events import EventBus, LogEvent
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.domain.position import Position
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from trading_bot.application.data_feed import DataFeed
+    from trading_bot.application.order_router import OrderRouter
+    from trading_bot.application.position_tracker import PositionTracker
+    from trading_bot.application.strategy import Strategy
+
+__all__ = ["StrategyRunner", "OrderFactory"]
+
+#: A caller-supplied order builder: ``(strategy, delta, bars) -> Order``. Given
+#: the signed target delta (``> 0`` buy, ``< 0`` sell) and the current bar
+#: window, it returns the :class:`Order` to submit (e.g. a LIMIT priced off the
+#: window's close instead of the default MARKET). The runner overrides the
+#: order's ``client_order_id`` with its deterministic per-step id, so a factory
+#: need not (and should not rely on) set one.
+OrderFactory = Callable[["Strategy", Money, "pl.DataFrame"], Order]
+
+_ZERO: Money = money("0")
+
+
+class StrategyRunner:
+    """Drive a :class:`Strategy` over a :class:`DataFeed`, routing the deltas.
+
+    On each causal bar window the runner evaluates the strategy's signal, reads
+    the live position from the tracker, computes the signed target change with
+    :meth:`Signal.delta_to`, and — when that change is non-zero — submits one
+    :class:`Order` through the router. See the module docstring for the loop
+    shape, the per-step idempotency scheme and the warmup guarantee.
+
+    Parameters
+    ----------
+    strategy : Strategy
+        The strategy to drive: its ``instrument``, ``signal_fn``,
+        ``reference_qty`` (the scale for a fractional-exposure signal) and
+        ``lookback`` (warmup) govern every step. ``strategy.name`` seeds the
+        per-step ``client_order_id``.
+    feed : DataFeed
+        The source of causal bar windows (``frame[: t + 1]`` at step ``t``). The
+        runner iterates it; at step ``t`` it sees only bars ``≤ t`` — no
+        lookahead.
+    router : OrderRouter
+        The idempotent write path. Each step's order is ``await``\\ ed through
+        :meth:`OrderRouter.submit`; a duplicate ``client_order_id`` (a re-run)
+        is deduped there into a single venue order.
+    tracker : PositionTracker
+        The live net-position read-back. ``tracker.position(instrument)`` gives
+        the current exposure the delta is computed against; a ``None`` (no fill
+        yet) is treated as flat. For the loop to close, the same broker's fills
+        must reach this tracker (wire ``PaperBroker(event_bus=bus)`` +
+        ``PositionTracker(event_bus=bus)``), so a step's fills are reflected in
+        the *next* step's position.
+    event_bus : EventBus, optional
+        If given, the runner emits a :class:`~trading_bot.application.events.
+        LogEvent` per submitted order (a human-readable trace of the run).
+        Defaults to ``None`` (no trace emitted; orders still flow through the
+        router's own ``OrderEvent``\\ s).
+    order_factory : OrderFactory, optional
+        Builds the :class:`Order` for a step from ``(strategy, delta, bars)``.
+        Defaults to a MARKET order for ``abs(delta)`` on the side of ``delta``.
+        Whatever it returns, the runner overrides the ``client_order_id`` with
+        its deterministic per-step id (so idempotency is the runner's, not the
+        factory's, concern).
+
+    Examples
+    --------
+    >>> # runner = StrategyRunner(strategy, feed, router, tracker, event_bus=bus)
+    >>> # n_orders = await runner.run()          # drive the whole feed
+    >>> # await runner.step(some_window)         # or pump one window by hand
+
+    """
+
+    def __init__(
+        self,
+        strategy: Strategy,
+        feed: DataFeed,
+        router: OrderRouter,
+        tracker: PositionTracker,
+        *,
+        event_bus: EventBus | None = None,
+        order_factory: OrderFactory | None = None,
+    ) -> None:
+        self._strategy = strategy
+        self._feed = feed
+        self._router = router
+        self._tracker = tracker
+        self._bus = event_bus
+        self._order_factory = order_factory
+        # Monotonic step index — also the per-step client-order-id seed. It is an
+        # instance counter so a fresh runner over the same feed reproduces the
+        # same ids (deterministic re-run), while a *single* runner re-driven via
+        # repeated ``run`` calls keeps advancing (never reusing an id within one
+        # instance's lifetime).
+        self._step_index = 0
+
+    @property
+    def step_index(self) -> int:
+        """The next step index (== number of windows processed so far)."""
+        return self._step_index
+
+    async def run(self, max_steps: int | None = None) -> int:
+        """Drive the feed window-by-window, submitting the per-step deltas.
+
+        Iterates the feed (the sync iterable of causal windows) and calls
+        :meth:`step` on each, stopping early after ``max_steps`` windows if
+        given. Honours causality by construction — each window is the feed's
+        causal prefix and the runner never reads past it.
+
+        Parameters
+        ----------
+        max_steps : int or None, optional
+            Process at most this many windows (bounds an otherwise feed-length
+            run; useful for tests and live feeds). ``None`` (default) drains the
+            feed to exhaustion.
+
+        Returns
+        -------
+        int
+            The number of orders **submitted** during this call (steps where the
+            delta was non-zero). Warmup and on-target steps submit nothing and
+            are not counted.
+
+        """
+        submitted = 0
+        processed = 0
+        for bars in self._feed:
+            if max_steps is not None and processed >= max_steps:
+                break
+            order = await self.step(bars)
+            if order is not None:
+                submitted += 1
+            processed += 1
+        return submitted
+
+    async def step(self, bars: pl.DataFrame) -> Order | None:
+        """Process **one** causal window: evaluate, diff, and maybe submit.
+
+        Evaluates ``strategy.evaluate(bars)`` (flat during warmup), reads the
+        current position from the tracker, computes
+        ``delta = signal.delta_to(position, reference_qty=strategy.reference_qty)``
+        and, **only if ``delta != 0``**, builds an order (MARKET by default, or
+        via the ``order_factory``) with the deterministic per-step
+        ``client_order_id`` and submits it through the router. The step index is
+        always advanced (so ids stay aligned to the bar sequence even on a
+        no-order step).
+
+        Parameters
+        ----------
+        bars : polars.DataFrame
+            The causal bar window for this step (``frame[: t + 1]``). The runner
+            reads only this window — never a later bar.
+
+        Returns
+        -------
+        Order or None
+            The submitted order (the router's tracked instance), or ``None`` when
+            the step submitted nothing (warmup, or already on target /
+            ``delta == 0``).
+
+        """
+        step = self._step_index
+        # Advance the index *before* any early return so a no-order step still
+        # consumes its slot — keeping ``f"{name}-{step}"`` aligned 1:1 with the
+        # bar sequence (re-run determinism does not depend on order outcomes).
+        self._step_index += 1
+
+        signal = self._strategy.evaluate(bars)
+        current = self._tracker.position(self._strategy.instrument)
+        net_qty = current.net_qty if current is not None else _ZERO
+        # delta_to also handles a flat current position; we pass net_qty via a
+        # cheap flat Position only when the tracker has none, to keep the call
+        # uniform without reaching into the signal's internals.
+        position = (
+            current
+            if current is not None
+            else Position(
+                instrument=self._strategy.instrument,
+                net_qty=net_qty,
+                avg_entry_price=None,
+                realised_pnl=_ZERO,
+                fees_paid=_ZERO,
+            )
+        )
+        delta = signal.delta_to(
+            position, reference_qty=self._strategy.reference_qty
+        )
+
+        if delta == 0:
+            # Already on target (incl. flat-during-warmup → flat position): no
+            # order. This is where the warmup guarantee lands — see module doc.
+            return None
+
+        order = self._build_order(delta, bars, step)
+        submitted = await self._router.submit(order)
+        if self._bus is not None:
+            self._bus.emit(
+                LogEvent(
+                    message=(
+                        f"{self._strategy.name} step {step}: "
+                        f"{submitted.side.value} {submitted.qty} "
+                        f"{submitted.instrument} "
+                        f"(delta={delta}, cid={submitted.client_order_id})"
+                    )
+                )
+            )
+        return submitted
+
+    def _build_order(self, delta: Money, bars: pl.DataFrame, step: int) -> Order:
+        """Build the step's order, stamping the deterministic per-step id.
+
+        Uses the ``order_factory`` if given (then overrides its
+        ``client_order_id``), otherwise a MARKET order for ``abs(delta)`` on the
+        side implied by the sign of ``delta``. The id is always
+        ``f"{strategy.name}-{step}"`` so a re-run dedups at the router.
+        """
+        cid = f"{self._strategy.name}-{step}"
+        if self._order_factory is not None:
+            order = self._order_factory(self._strategy, delta, bars)
+            # The runner owns idempotency, not the factory: stamp the per-step id
+            # regardless of what the factory chose.
+            order.client_order_id = cid
+            return order
+        side = OrderSide.BUY if delta > 0 else OrderSide.SELL
+        return Order(
+            client_order_id=cid,
+            instrument=self._strategy.instrument,
+            side=side,
+            qty=abs(delta),
+            type=OrderType.MARKET,
+        )

--- a/trading_bot/tests/application/test_strategy_runner.py
+++ b/trading_bot/tests/application/test_strategy_runner.py
@@ -1,0 +1,493 @@
+"""Tests for the :class:`~trading_bot.application.strategy_runner.StrategyRunner`.
+
+These prove the runner's contract — the live loop ``feed → signal → delta →
+order → router → broker → fill → tracker`` — end to end against the real
+:class:`~trading_bot.brokers.paper.PaperBroker`, fully offline:
+
+* **end-to-end**: a known OHLC series (trend up then down) driven through an
+  ``InMemoryFeed`` + the MA-crossover strategy + ``OrderRouter`` → ``PaperBroker``
+  + ``PositionTracker``; the tracked position goes long after the up-cross and
+  flat/short after the down-cross, orders match the signal deltas, money exact
+  ``Decimal`` and a hand-reasoned final position;
+* **delta == 0**: a step already on target submits no order;
+* **warmup**: no order before ``lookback`` bars (the strategy returns flat, so the
+  delta is zero);
+* **idempotent re-run**: running the same sequence twice (same per-step
+  client-order-ids) does not double-submit — the broker sees one order per step;
+* **causality**: a spy ``signal_fn`` records the max bar ``time`` it ever saw and
+  asserts it never exceeds the current step's bar time (no lookahead).
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import polars as pl
+
+from trading_bot.application import (
+    EventBus,
+    InMemoryFeed,
+    LogEvent,
+    OrderRouter,
+    PositionTracker,
+    Strategy,
+    StrategyRunner,
+    ma_crossover_signal,
+)
+from trading_bot.brokers import PaperBroker
+from trading_bot.domain import (
+    Instrument,
+    OrderSide,
+    OrderType,
+    Signal,
+    Symbol,
+    money,
+)
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+# --- helpers --------------------------------------------------------------- #
+
+
+def _bars(closes: list[float], *, start_ts: int = 1_000) -> pl.DataFrame:
+    """A minimal OHLC(V) bars frame from a list of closes (time in seconds)."""
+    n = len(closes)
+    times = [start_ts + 60 * i for i in range(n)]
+    return pl.DataFrame(
+        {
+            "time": times,
+            "o": closes,
+            "h": closes,
+            "l": closes,
+            "c": closes,
+            "v": [1.0] * n,
+        }
+    )
+
+
+def _wire(
+    strategy: Strategy,
+    frame: pl.DataFrame,
+    *,
+    mark: str = "100",
+) -> tuple[StrategyRunner, PaperBroker, PositionTracker, EventBus]:
+    """Build a fully wired runner over a fresh broker/tracker/router stack.
+
+    The broker fills MARKET orders at the injected ``mark`` price and emits a
+    ``FillEvent`` per fill onto the bus the tracker subscribes to, so the loop
+    closes (a step's fills update the *next* step's position).
+    """
+    bus = EventBus()
+    tracker = PositionTracker(event_bus=bus)
+    broker = PaperBroker(
+        prices={BTC_USD: money(mark)},
+        fee_bps=money("0"),
+        fill_model="immediate",
+        starting_balances={"USD": money("10000000"), "BTC": money("0")},
+        event_bus=bus,
+    )
+    router = OrderRouter(broker, bus)
+    feed = InMemoryFeed(frame)
+    runner = StrategyRunner(strategy, feed, router, tracker, event_bus=bus)
+    return runner, broker, tracker, bus
+
+
+# --- end-to-end: trend up then down ---------------------------------------- #
+
+
+async def test_end_to_end_position_follows_signal() -> None:
+    """The tracked position follows the MA-crossover signal, long then short.
+
+    A close series that trends up (so the fast MA crosses *above* the slow MA →
+    long) then down (fast crosses *below* → short) is driven through the whole
+    stack. With ``reference_qty = 2``, an EXPOSURE signal of ``+1`` targets long
+    2 and ``-1`` targets short 2. We assert the tracked net_qty is long after the
+    up-leg and short after the down-leg, with exact ``Decimal`` money.
+    """
+    # 20 up then 20 down — comfortably past a fast=3/slow=6 crossover each way.
+    up = [float(100 + i) for i in range(20)]
+    down = [float(120 - i) for i in range(1, 21)]
+    frame = _bars(up + down)
+
+    strat = Strategy(
+        name="ma",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+    runner, broker, tracker, _bus = _wire(strat, frame, mark="100")
+
+    await runner.run()
+
+    # After the full up-then-down series the latest signal is short (fast < slow
+    # on the descending tail), so the target net position is -2.
+    pos = tracker.position(BTC_USD)
+    assert pos is not None
+    assert pos.net_qty == Decimal("-2")
+
+    # Every fill the broker confirmed is for BTC/USD at the mark, exact Decimal.
+    fills = await broker.fills()
+    assert fills, "the run must have traded"
+    for f in fills:
+        assert f.instrument == BTC_USD
+        assert f.price == Decimal("100")
+
+    # The deltas net out to the final target exactly: sum of signed fill qtys
+    # (BUY +, SELL -) equals net_qty.
+    signed = sum(
+        (f.qty if f.side is OrderSide.BUY else -f.qty) for f in fills
+    )
+    assert signed == pos.net_qty
+
+
+async def test_position_goes_long_then_short_across_the_cross() -> None:
+    """Mid-run the position is long on the up-leg before flipping short.
+
+    Drives only the up-leg first (a separate runner) to pin that the position is
+    long *before* the down-cross — proving the track follows the signal at the
+    crossover, not just at the end.
+    """
+    up = [float(100 + i) for i in range(20)]
+    frame_up = _bars(up)
+    strat = Strategy(
+        name="ma",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+    runner, _broker, tracker, _bus = _wire(strat, frame_up, mark="100")
+    await runner.run()
+
+    pos = tracker.position(BTC_USD)
+    assert pos is not None
+    assert pos.net_qty == Decimal("2")  # long after the up-cross
+
+
+# --- delta == 0: no order -------------------------------------------------- #
+
+
+async def test_no_order_when_already_on_target() -> None:
+    """A step whose signal target equals the current position submits no order.
+
+    A constant long-exposure signal first buys to the target, then — on a second
+    identical window — is already on target (delta 0) and submits nothing.
+    """
+
+    def _always_long(bars: pl.DataFrame) -> Signal:
+        return Signal.exposure(BTC_USD, money("1"), ts=0)
+
+    strat = Strategy(
+        name="hold",
+        instrument=BTC_USD,
+        signal_fn=_always_long,
+        reference_qty=money("3"),
+    )
+    # Two identical bars: step 0 buys to long 3; step 1 is already on target.
+    frame = _bars([100.0, 100.0])
+    runner, broker, tracker, _bus = _wire(strat, frame, mark="100")
+
+    n = await runner.run()
+    assert n == 1  # only the first step traded
+    assert len(await broker.fills()) == 1
+    pos = tracker.position(BTC_USD)
+    assert pos is not None
+    assert pos.net_qty == Decimal("3")
+
+
+async def test_run_respects_max_steps() -> None:
+    """``run(max_steps=k)`` processes at most ``k`` windows and stops."""
+
+    def _always_long(bars: pl.DataFrame) -> Signal:
+        return Signal.exposure(BTC_USD, money("1"), ts=0)
+
+    strat = Strategy(
+        name="cap",
+        instrument=BTC_USD,
+        signal_fn=_always_long,
+        reference_qty=money("1"),
+    )
+    # 10 bars available, but cap at 1 window: only the first step runs.
+    frame = _bars([100.0] * 10)
+    runner, broker, _tracker, _bus = _wire(strat, frame, mark="100")
+
+    n = await runner.run(max_steps=1)
+    assert n == 1  # one order on the first (and only processed) step
+    assert runner.step_index == 1  # only one window consumed
+    assert len(await broker.fills()) == 1
+
+
+async def test_step_returns_none_on_zero_delta() -> None:
+    """``step`` returns ``None`` (no order) when the delta is zero, but advances."""
+
+    def _flat(bars: pl.DataFrame) -> Signal:
+        return Signal.exposure(BTC_USD, money("0"), ts=0)
+
+    strat = Strategy(name="flat", instrument=BTC_USD, signal_fn=_flat,
+                     reference_qty=money("1"))
+    runner, broker, _tracker, _bus = _wire(strat, _bars([100.0]), mark="100")
+
+    order = await runner.step(_bars([100.0]))
+    assert order is None
+    assert await broker.fills() == []
+    # The index still advanced (a no-order step consumes its slot).
+    assert runner.step_index == 1
+
+
+# --- warmup ---------------------------------------------------------------- #
+
+
+async def test_no_orders_during_warmup() -> None:
+    """No order is submitted before ``lookback`` bars are present.
+
+    With ``lookback = 6`` the strategy returns a flat signal for the first 5
+    windows (heights 1..5); against a flat position that is delta 0, so the
+    broker sees no order until at least 6 bars exist — and even then only if the
+    signal is non-flat. We use a flat-after-warmup close series to isolate warmup:
+    no order ever, because the signal is flat throughout, *especially* below
+    lookback.
+    """
+    # Closes that never cross (monotone) but we set lookback high to assert the
+    # warmup window submits nothing.
+    closes = [100.0, 101.0, 102.0, 103.0, 104.0]  # only 5 bars, < lookback 6
+    strat = Strategy(
+        name="warm",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=2, slow=4),
+        reference_qty=money("1"),
+        lookback=6,
+    )
+    runner, broker, tracker, _bus = _wire(strat, _bars(closes), mark="100")
+
+    n = await runner.run()
+    assert n == 0  # every window is in warmup -> flat -> delta 0 -> no order
+    assert await broker.fills() == []
+    assert tracker.position(BTC_USD) is None  # never traded -> no fill -> None
+
+
+# --- idempotent re-run ----------------------------------------------------- #
+
+
+async def test_idempotent_rerun_does_not_double_submit() -> None:
+    """Re-running the same steps (same client-order-ids) does not double-submit.
+
+    The runner's deterministic ``f"{name}-{step}"`` ids make a *re-run* a no-op at
+    the router. We drive the run once (capturing each order the runner submitted
+    via the router's ``OrderEvent``\\ s), then **replay those exact same orders**
+    through the *same* router and assert the broker placed **no new fills** — the
+    router deduped every id. This is the runner-half (stable ids) meeting the
+    router-half (one id → one venue order) of the E4 idempotency contract.
+    """
+    up = [float(100 + i) for i in range(20)]
+    down = [float(120 - i) for i in range(1, 21)]
+    frame = _bars(up + down)
+    strat = Strategy(
+        name="ma",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+
+    bus = EventBus()
+    broker = PaperBroker(
+        prices={BTC_USD: money("100")},
+        fee_bps=money("0"),
+        fill_model="immediate",
+        starting_balances={"USD": money("10000000"), "BTC": money("0")},
+        event_bus=bus,
+    )
+    router = OrderRouter(broker, bus)
+    tracker = PositionTracker(event_bus=bus)
+
+    # Capture every order the runner submits (the router emits one OrderEvent per
+    # tracked order).
+    from trading_bot.application import OrderEvent
+
+    submitted_orders: list = []
+    bus.subscribe(
+        lambda e: submitted_orders.append(e.order)
+        if isinstance(e, OrderEvent)
+        else None
+    )
+
+    runner = StrategyRunner(strat, InMemoryFeed(frame), router, tracker)
+    n1 = await runner.run()
+    fills_after_1 = len(await broker.fills())
+    tracked_after_1 = set(router.tracked_orders())
+
+    assert n1 > 0  # the run traded
+    assert fills_after_1 == n1  # one immediate fill per submitted order
+    # Every submitted id follows the per-step scheme.
+    for order in submitted_orders:
+        prefix, _, idx = order.client_order_id.rpartition("-")
+        assert prefix == "ma" and idx.isdigit()
+
+    # Replay the very same orders (same client-order-ids) through the same router.
+    for order in list(submitted_orders):
+        again = await router.submit(order)
+        # Returns the already-tracked order, never re-submits.
+        assert again is order
+
+    fills_after_2 = len(await broker.fills())
+    tracked_after_2 = set(router.tracked_orders())
+
+    # No new fills, and the tracked id set is identical — fully deduped.
+    assert fills_after_2 == fills_after_1
+    assert tracked_after_2 == tracked_after_1
+
+
+async def test_client_order_ids_are_deterministic_and_per_step() -> None:
+    """Each traded step gets ``f"{name}-{step}"``; ids follow the scheme.
+
+    Two fresh runners over the same feed (separate stacks) produce the *same* set
+    of per-step ids — determinism — and every id matches ``f"{name}-{step}"``
+    with the step index aligned to the bar it traded on.
+    """
+    up = [float(100 + i) for i in range(12)]
+    frame = _bars(up)
+
+    def _build() -> tuple[StrategyRunner, OrderRouter]:
+        strat = Strategy(
+            name="ids",
+            instrument=BTC_USD,
+            signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+            reference_qty=money("2"),
+            lookback=6,
+        )
+        bus = EventBus()
+        tracker = PositionTracker(event_bus=bus)
+        broker = PaperBroker(
+            prices={BTC_USD: money("100")},
+            fee_bps=money("0"),
+            starting_balances={"USD": money("10000000"), "BTC": money("0")},
+            event_bus=bus,
+        )
+        router = OrderRouter(broker, bus)
+        runner = StrategyRunner(strat, InMemoryFeed(frame), router, tracker)
+        return runner, router
+
+    runner_a, router_a = _build()
+    await runner_a.run()
+    cids_a = set(router_a.tracked_orders())
+
+    runner_b, router_b = _build()
+    await runner_b.run()
+    cids_b = set(router_b.tracked_orders())
+
+    assert cids_a, "at least one trade expected"
+    assert cids_a == cids_b  # deterministic across fresh runners
+    for cid in cids_a:
+        prefix, _, idx = cid.rpartition("-")
+        assert prefix == "ids"
+        assert idx.isdigit()
+
+
+# --- causality: the signal never sees a future bar ------------------------- #
+
+
+async def test_causality_signal_never_sees_future_bar() -> None:
+    """A spy ``signal_fn`` records the max bar time it saw; never beyond step t.
+
+    At step ``t`` the feed hands the runner the causal prefix ``frame[: t + 1]``,
+    whose last ``time`` is bar ``t``'s. The spy captures, on each call, the max
+    ``time`` in the window and the window height; we assert the window's last
+    time equals the step's bar time and never a later one — no lookahead.
+    """
+    closes = [100.0, 101.0, 99.0, 102.0, 98.0, 103.0, 97.0, 104.0]
+    frame = _bars(closes)
+    all_times: list[int] = frame["time"].to_list()
+
+    seen_max_time: list[int] = []
+    seen_heights: list[int] = []
+
+    def _spy(bars: pl.DataFrame) -> Signal:
+        seen_max_time.append(int(bars["time"].max()))  # type: ignore[arg-type]
+        seen_heights.append(bars.height)
+        # A trivial flat signal — we only care what bars it saw.
+        return Signal.exposure(BTC_USD, money("0"), ts=0)
+
+    strat = Strategy(name="spy", instrument=BTC_USD, signal_fn=_spy,
+                     reference_qty=money("1"))
+    runner, _broker, _tracker, _bus = _wire(strat, frame, mark="100")
+    await runner.run()
+
+    # One evaluation per bar, windows growing 1..N.
+    assert seen_heights == list(range(1, len(closes) + 1))
+    # At each step t, the max time seen is exactly bar t's time — never a later
+    # bar's. (Strict no-lookahead: the window's last time == the step's time.)
+    for t, max_time in enumerate(seen_max_time):
+        assert max_time == all_times[t]
+        # And it never exceeds the current step's bar time.
+        assert max_time <= all_times[t]
+
+
+# --- order shape & event trace --------------------------------------------- #
+
+
+async def test_order_factory_and_log_events() -> None:
+    """A custom ``order_factory`` is used (LIMIT), and a LogEvent traces a trade.
+
+    The factory returns a LIMIT order priced off the window's close; the runner
+    overrides its client-order-id with the deterministic per-step id. A LogEvent
+    is emitted per submitted order on the bus.
+    """
+    logs: list[LogEvent] = []
+
+    closes = [float(100 + i) for i in range(12)]
+    frame = _bars(closes)
+
+    def _limit_factory(strategy: Strategy, delta, bars: pl.DataFrame):
+        from trading_bot.domain import Order
+
+        close = money(str(bars["c"][-1]))
+        side = OrderSide.BUY if delta > 0 else OrderSide.SELL
+        return Order(
+            client_order_id="will-be-overridden",
+            instrument=strategy.instrument,
+            side=side,
+            qty=abs(delta),
+            type=OrderType.LIMIT,
+            limit_price=close,
+        )
+
+    strat = Strategy(
+        name="lim",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+    bus = EventBus()
+    bus.subscribe(lambda e: logs.append(e) if isinstance(e, LogEvent) else None)
+    tracker = PositionTracker(event_bus=bus)
+    broker = PaperBroker(
+        fee_bps=money("0"),
+        fill_model="immediate",
+        starting_balances={"USD": money("10000000"), "BTC": money("0")},
+        event_bus=bus,
+    )
+    router = OrderRouter(broker, bus)
+    runner = StrategyRunner(
+        strat,
+        InMemoryFeed(frame),
+        router,
+        tracker,
+        event_bus=bus,
+        order_factory=_limit_factory,
+    )
+    n = await runner.run()
+
+    assert n >= 1
+    # One LogEvent per submitted order.
+    assert len(logs) == n
+    # Every tracked order's id follows the runner's scheme, not the factory's.
+    for cid in router.tracked_orders():
+        assert cid.startswith("lim-")
+    # The orders were LIMITs (from the factory), filled at the close.
+    fills = await broker.fills()
+    assert fills


### PR DESCRIPTION
## Summary
- **Final leaf of E5**: `application/strategy_runner.py` — `StrategyRunner`.
- The live loop: per causal window from a `DataFeed`, evaluate the strategy's signal → `Signal.delta_to(current position)` → MARKET order → `OrderRouter.submit`, with a **deterministic per-step `client_order_id`** (a re-run dedups to one venue order).
- Closes E5 — **a strategy now runs end-to-end**: dccd data → fynance signal → target position → managed orders on a broker → fills → position. `07-roadmap.md` E5 line removed, `06-status.md` updated.

## Why
- Closes the loop lookahead-free by construction (the runner only reads the window it's handed). Warmup stays in `Strategy.evaluate`, idempotency in the runner — no duplicated logic. See `doc/dev/03-decisions.md`.

## Changes
- `application/strategy_runner.py` (100% cov) + export; `tests/application/test_strategy_runner.py` (11 tests, fully offline).

## Test plan
- [x] `.venv/bin/python -m pytest` (383 passed, 4 deselected = network; 0 unexpected skips)
- [x] end-to-end: OHLC trend → position follows the signal; causality + idempotent re-run proven
- [x] independent smoke (uptrend → long `reference_qty`) ✓
- [x] `ruff` + `mypy` clean