### PR TITLE
docs: plan perf-persistence-risk (E6)

### DIFF
--- a/doc/dev/plans/perf-persistence-risk/00-plan.md
+++ b/doc/dev/plans/perf-persistence-risk/00-plan.md
@@ -1,0 +1,50 @@
+---
+plan: perf-persistence-risk
+kind: global
+status: planning
+roadmap: "- [ ] **E6 — Performance, persistence & risk.** `PerformanceService` (PnL/KPI), `storage` (SQLite order/fill history + state for reconciliation), `RiskManager` (pre-trade limits + kill-switch)."
+release_on_done: false
+---
+
+# E6 — Performance, persistence & risk
+
+## Goal
+
+The last safety/observability block before the MVP CLI: durable **persistence**
+(SQLite order/fill history + engine state — the reconciliation source), a live
+**PerformanceService** (PnL/KPI over the fill stream), and a **RiskManager**
+(pre-trade limits + kill-switch) that gates every order. Opens `trading_bot/storage/`
+and extends `application/`.
+
+**Invariants** (from `CLAUDE.md`): all money is `Decimal` (stored as **TEXT** in
+SQLite, never float); fills are the PnL source of truth; the **risk gate + kill-switch
+gate every order**. Everything is offline-testable.
+
+## Decomposition
+
+1. **storage** — `trading_bot/storage/`: SQLite append-only order/fill history + state (the reconciliation source).
+2. **performance-service** — `application/performance_service.py`: live PnL/KPI over the `FillEvent` stream.
+3. **risk-manager** — `application/risk.py`: pre-trade limits + kill-switch, gating `OrderRouter.submit`.
+
+## Leaf checklist
+
+- [ ] 01 storage — feat/storage — high
+- [ ] 02 performance-service — feat/performance-service — medium
+- [ ] 03 risk-manager — feat/risk-manager — high
+
+## Dependencies
+
+- The three leaves are independent of each other (storage / perf / risk) — run
+  serially in the main worktree (the safe default). All assume E4 (merged).
+
+## Done criteria
+
+- `trading_bot/storage/` persists orders/fills (Decimal as TEXT) and round-trips
+  them; `application/` exposes `PerformanceService` and `RiskManager`.
+- `OrderRouter.submit` is **gated** by the `RiskManager`: an order breaching a limit
+  (or with the kill-switch tripped) raises `RiskLimitBreached` and is never placed;
+  the kill-switch cancels open orders + halts new ones.
+- `ruff`/`mypy`/`pytest` green via `.venv` (0 unexpected skips). Persistence verified
+  by writing real engine events and reading them back; risk + perf verified end-to-end
+  through `OrderRouter`→`PaperBroker`.
+- Last leaf (03) removes the E6 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/perf-persistence-risk/01-storage.md
+++ b/doc/dev/plans/perf-persistence-risk/01-storage.md
@@ -1,0 +1,76 @@
+---
+plan: perf-persistence-risk/01-storage
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: feat/storage
+pr: ""
+---
+
+# Storage — SQLite order/fill history + engine state
+
+## Goal
+
+Open `trading_bot/storage/`: a SQLite append-only store for orders, fills and a bit
+of engine state — the **reconciliation source** (E4's `reconcile` ultimately reads
+truth from the broker, but the local store records what the engine has seen/done).
+All money persisted as **TEXT** (exact `Decimal`, never float).
+
+## Files to change
+
+- `trading_bot/storage/__init__.py` — new; export the store.
+- `trading_bot/storage/sqlite_store.py` — new; `SqliteStore` (stdlib `sqlite3`, WAL).
+- `trading_bot/tests/storage/__init__.py` — new (empty).
+- `trading_bot/tests/storage/test_sqlite_store.py` — new.
+
+## Steps
+
+1. Read dccd's `storage/runs_sqlite.py`
+   (`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/storage/runs_sqlite.py`)
+   for the stdlib-`sqlite3` pattern (WAL pragma, `row_factory`, a `_conn` context
+   manager, `CREATE TABLE IF NOT EXISTS`, parametrised SQL). Read `domain/order.py`
+   + `domain/fill.py` for the fields to persist.
+2. `SqliteStore(db_path)`: open with WAL; create tables if absent:
+   - `orders` (client_order_id PK, venue_order_id, instrument, side, type, qty TEXT,
+     limit_price TEXT?, stop_price TEXT?, status, filled_qty TEXT, avg_fill_price TEXT?,
+     ts) — **upsert** by `client_order_id` (an order's row reflects its latest state).
+   - `fills` (fill_id PK, client_order_id, instrument, side, qty TEXT, price TEXT,
+     fee TEXT, ts) — **append-only** (insert-or-ignore on fill_id; fills never mutate).
+   - `state` (key PK, value TEXT) — small key/value for engine state (e.g. last
+     reconcile ts).
+   All money/qty columns are **TEXT** holding `str(Decimal)`; convert back with
+   `money(...)` on read.
+3. Write API: `upsert_order(order)`, `record_fill(fill)`, `set_state(k, v)` /
+   `get_state(k)`. Read API: `get_order(cid)`, `orders()`, `fills(since_ms=None)` →
+   rebuild domain `Order`/`Fill` objects (exact Decimal).
+4. Optional bus integration: `attach(event_bus)` subscribing to `OrderEvent`
+   (→ `upsert_order`) and `FillEvent` (→ `record_fill`) so the store fills itself
+   from the engine's event stream. Keep it a thin adapter; the store works standalone.
+
+## Tests (via `.venv`)
+
+- Round-trip: `upsert_order` then `get_order` returns an equal domain `Order`
+  (status, Decimal qty/prices exact); a re-`upsert` of the same `client_order_id`
+  updates the row (one row, latest status).
+- `record_fill` then `fills()` returns equal domain `Fill`s (Decimal exact);
+  re-recording the same `fill_id` is a no-op (append-only, no dup).
+- `fills(since_ms=...)` filters by ts.
+- `set_state`/`get_state` round-trips; missing key → `None`.
+- **No float**: assert stored columns are TEXT and reading yields `Decimal`
+  (e.g. a price like `0.1` round-trips exactly).
+- Bus integration: emitting `OrderEvent`/`FillEvent` populates the store.
+
+## Verification on real data
+
+Drive a realistic engine sequence (submit orders + fills through
+`OrderRouter`→`PaperBroker` with the store `attach`ed to the bus), then **reopen the
+SQLite file** in a fresh `SqliteStore` and assert the persisted orders/fills match —
+positions rebuildable from the stored fills via `Position.from_fills`. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`storage.SqliteStore` — append-only SQLite order/fill history + state (Decimal as TEXT)."
+- ADR: the schema + money-as-TEXT decision + upsert-orders/append-only-fills rule.
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/perf-persistence-risk/02-performance-service.md
+++ b/doc/dev/plans/perf-persistence-risk/02-performance-service.md
@@ -1,0 +1,65 @@
+---
+plan: perf-persistence-risk/02-performance-service
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/performance-service
+pr: ""
+---
+
+# PerformanceService — live PnL/KPI over the fill stream
+
+## Goal
+
+`PerformanceService`: a live performance view that subscribes to `FillEvent`s on the
+`EventBus`, maintains the realised-PnL / equity curve, and exposes KPIs (Sharpe,
+Sortino, max-drawdown, Calmar) by delegating to `domain.performance` (fynance-backed,
+present in `.venv`). Read-side only — it never places orders.
+
+## Files to change
+
+- `trading_bot/application/performance_service.py` — new; `PerformanceService`.
+- `trading_bot/application/__init__.py` — export it.
+- `trading_bot/tests/application/test_performance_service.py` — new.
+
+## Steps
+
+1. Read `domain/performance.py` (`pnl`/`cum_pnl`/`equity_curve`/`equity_array` +
+   `sharpe`/`sortino`/`max_drawdown`/`calmar`, all Decimal/fynance), `domain/fill.py`,
+   `domain/position.py` (`Position.from_fills`), `application/events.py` (`FillEvent`).
+2. `PerformanceService(*, v0=money("0"), event_bus=None)`:
+   - keep an ordered fill list (per instrument and/or aggregate — pick the simplest
+     coherent model; document). `apply(fill)` folds a fill; if given an `event_bus`,
+     subscribe to `FillEvent` and `apply` automatically.
+   - expose `realised_pnl()`, `fees_paid()`, `equity_curve()` (Decimal), and
+     `position(instrument)` (via `Position.from_fills`).
+   - KPI methods `sharpe()/sortino()/max_drawdown()/calmar()` delegating to
+     `domain.performance` over the equity/returns series. These need fynance — it's in
+     the venv, so they run; if a series is too short to compute, return a defined
+     value (e.g. `0.0`/`None`) rather than raising — document.
+3. Money stays `Decimal` in the PnL core; the KPI series may be float (as
+   `domain.performance` already does).
+
+## Tests (via `.venv`)
+
+- Feed a known fill sequence → `realised_pnl()`/`fees_paid()`/`equity_curve()` match
+  hand-computed Decimal values (consistent with `Position.from_fills`).
+- KPIs over a known equity curve match calling `domain.performance.sharpe(...)` etc.
+  directly (these run — fynance is installed).
+- Subscribed to an `EventBus`: emitting `FillEvent`s updates the performance view.
+- Too-short series → the documented safe value, no exception.
+
+## Verification on real data
+
+Run a realistic trade sequence through `OrderRouter`→`PaperBroker` with the
+`PerformanceService` subscribed to the bus; assert its realised PnL + equity endpoint
+match an independent computation from the same fills, and that the KPIs match
+`domain.performance` over that equity curve. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.PerformanceService` — live PnL/KPI over the fill stream (fynance-backed KPIs)."
+- ADR: the aggregation model + the short-series KPI policy, if non-trivial.
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/perf-persistence-risk/03-risk-manager.md
+++ b/doc/dev/plans/perf-persistence-risk/03-risk-manager.md
@@ -1,0 +1,80 @@
+---
+plan: perf-persistence-risk/03-risk-manager
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: feat/risk-manager
+pr: ""
+---
+
+# RiskManager — pre-trade limits + kill-switch (gates every order)
+
+## Goal
+
+`RiskManager`: a **pre-trade gate** enforcing `AppConfig.RiskConfig` limits
+(`max_order`, `max_position`, `max_daily_loss`) plus a **kill-switch** (cancels open
+orders + halts new ones). Integrated into `OrderRouter.submit` so **every order is
+gated** — a breaching order (or a tripped switch) raises `RiskLimitBreached` and is
+**never placed**. The last E6 leaf — closes the E6 roadmap line.
+
+## Files to change
+
+- `trading_bot/application/risk.py` — new; `RiskManager`.
+- `trading_bot/application/order_router.py` — integrate the gate (optional
+  `risk_manager` param; checked before `broker.place_order`).
+- `trading_bot/application/__init__.py` — export `RiskManager`.
+- `trading_bot/tests/application/test_risk.py` — new.
+- `doc/dev/07-roadmap.md` — remove the E6 line. `doc/dev/06-status.md` — mark E6 done.
+
+## Steps
+
+1. Read `application/config.py` (`RiskConfig`), `application/order_router.py`
+   (`submit` — the hook point, before `place_order`), `application/position_tracker.py`
+   (`position(instrument)` for current exposure), `domain/order.py`,
+   `domain/errors.py` (`RiskLimitBreached`).
+2. `RiskManager(config: RiskConfig, *, position_tracker=None)`:
+   - `check(order)` — raise `RiskLimitBreached` if:
+     - `max_order` set and `order.qty > max_order`;
+     - `max_position` set and the resulting net position
+       (`|current_net + signed(order)|`, via `position_tracker`) `> max_position`;
+     - `max_daily_loss` set and the day's realised loss already `>= max_daily_loss`
+       (feed it realised PnL — via a `PerformanceService`/tracker hook or a setter;
+       keep the coupling thin, document how daily loss is sourced/reset).
+   - **Kill-switch**: `trip(reason)` sets a tripped flag (any subsequent `check`
+     raises `RiskLimitBreached`); `reset()` clears it. `async kill(router, broker)`
+     (or a documented entry) cancels all open orders and trips the switch.
+   - `None` limits = unconstrained.
+3. Integrate in `OrderRouter`: accept an optional `risk_manager`; in `submit`, call
+   `risk_manager.check(order)` **before** `broker.place_order` — a raise means no
+   venue call, the order is rejected/raised cleanly (document whether the order goes
+   `REJECTED` or the error simply propagates without tracking). Keep idempotency intact.
+
+## Tests (via `.venv`)
+
+- `max_order`: an order above the cap → `RiskLimitBreached`, broker `place_order`
+  **not** called (spy/PaperBroker count).
+- `max_position`: an order that would push net exposure past the cap → blocked;
+  one within → allowed.
+- `max_daily_loss`: once the day's realised loss ≥ cap, new orders are blocked.
+- **Kill-switch**: `trip()` → every subsequent `submit` raises and places nothing;
+  `kill(router, broker)` cancels open orders; `reset()` re-enables.
+- `None` limits → everything passes.
+- Integration: `OrderRouter(..., risk_manager=rm)` blocks a breaching order end-to-end
+  (no paper order created) and allows a compliant one.
+
+## Verification on real data
+
+Through `OrderRouter`→`PaperBroker`: submit a compliant order (fills, position moves),
+then a breaching one (assert `RiskLimitBreached` + **no** new paper order + position
+unchanged); trip the kill-switch and assert open orders are cancelled and further
+submits are halted. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.RiskManager` — pre-trade limits + kill-switch gating every order."
+- ADR: the gate placement (in `OrderRouter.submit`, pre-`place_order`), the limit
+  semantics (max order/position/daily-loss), and the kill-switch behaviour + how
+  daily-loss is sourced.
+- Status/roadmap: **remove the E6 line** from `07-roadmap.md`; mark E6 done in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E6 — Performance, persistence & risk** — the last safety/observability block before the MVP CLI.

## Goal
Durable SQLite persistence (order/fill history + state, the reconciliation source), a live `PerformanceService` (PnL/KPI over the fill stream), and a `RiskManager` (pre-trade limits + kill-switch) that **gates every order**.

## Leaves
- [ ] 01 storage — feat/storage — high
- [ ] 02 performance-service — feat/performance-service — medium
- [ ] 03 risk-manager — feat/risk-manager — high

Invariants: money `Decimal` (TEXT in SQLite, never float); fills = PnL truth; risk gate + kill-switch on every order. All offline-testable. Leaves independent — run serially.
After merge: `/execute-leaf perf-persistence-risk next`.