### PR TITLE
feat: SqliteStore (order/fill history + state)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   → `Signal.delta_to(position)` → order → `OrderRouter`, with per-step idempotent
   client-order-ids. Completes the **E5 strategy runner**: a strategy now runs
   end-to-end (dccd data → fynance signal → managed positions on a broker).
+- `storage.SqliteStore` — append-only SQLite order/fill history + key/value state
+  (orders UPSERTed, fills append-only, money as TEXT — exact `Decimal`, never
+  float); optional `EventBus` attach. The reconciliation source.
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,24 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-22 Storage: SQLite, money as TEXT, orders UPSERT / fills append-only
+
+**Decision.** `trading_bot/storage/sqlite_store.py` `SqliteStore` (stdlib `sqlite3`,
+WAL) persists `orders` (UPSERT by `client_order_id` — latest state), `fills`
+(`INSERT OR IGNORE` by `fill_id` — immutable, append-only) and a `state` key/value.
+**All money/qty columns are TEXT** holding `str(Decimal)`, rebuilt with `money(...)` —
+never SQLite's REAL/float. Reads **reconstruct the domain object directly** from the
+row (no state-machine replay — the stored row is the truth). `attach(event_bus)`
+subscribes `OrderEvent→upsert_order` / `FillEvent→record_fill`.
+
+**Why.** SQLite's only numeric types are INTEGER/REAL (binary float); a price through
+REAL reintroduces exactly the rounding error `money` refuses — so TEXT is the only
+lossless option. Orders are stateful aggregates (one evolving row); fills are
+immutable facts (replay/refetch must be a no-op, never a duplicate). Replaying the
+state machine on read could disagree with what was recorded, so the row wins.
+
+---
+
 ### 2026-06-22 StrategyRunner: the live loop, per-step idempotent ids, warmup in one place
 
 **Decision.** `application/strategy_runner.py` `StrategyRunner(strategy, feed, router,

--- a/doc/dev/plans/perf-persistence-risk/00-plan.md
+++ b/doc/dev/plans/perf-persistence-risk/00-plan.md
@@ -28,7 +28,7 @@ gate every order**. Everything is offline-testable.
 
 ## Leaf checklist
 
-- [ ] 01 storage — feat/storage — high
+- [x] 01 storage — feat/storage — high
 - [ ] 02 performance-service — feat/performance-service — medium
 - [ ] 03 risk-manager — feat/risk-manager — high
 

--- a/doc/dev/plans/perf-persistence-risk/01-storage.md
+++ b/doc/dev/plans/perf-persistence-risk/01-storage.md
@@ -6,7 +6,7 @@ complexity: high
 depends: []
 parallel: false
 branch: feat/storage
-pr: ""
+pr: "#35"
 ---
 
 # Storage — SQLite order/fill history + engine state

--- a/doc/dev/plans/perf-persistence-risk/01-storage.md
+++ b/doc/dev/plans/perf-persistence-risk/01-storage.md
@@ -1,7 +1,7 @@
 ---
 plan: perf-persistence-risk/01-storage
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: []
 parallel: false

--- a/trading_bot/storage/__init__.py
+++ b/trading_bot/storage/__init__.py
@@ -1,0 +1,16 @@
+"""Storage layer — append-only SQLite order/fill history and engine state.
+
+This package is the engine's **persistence** boundary: it records what the
+engine has seen and done (orders, broker-confirmed fills, a little key/value
+state) into a stdlib-:mod:`sqlite3`, WAL-mode database — the reconciliation
+source on restart. Money is persisted as ``str(Decimal)`` TEXT (never float);
+orders are UPSERTed (latest state) and fills are append-only (immutable facts).
+
+See :class:`~trading_bot.storage.sqlite_store.SqliteStore`.
+"""
+
+from __future__ import annotations
+
+from trading_bot.storage.sqlite_store import SqliteStore
+
+__all__ = ["SqliteStore"]

--- a/trading_bot/storage/sqlite_store.py
+++ b/trading_bot/storage/sqlite_store.py
@@ -1,0 +1,456 @@
+"""The :class:`SqliteStore` — append-only SQLite order/fill history + state.
+
+This is the persistence layer's single store: a stdlib-:mod:`sqlite3`,
+WAL-mode database recording everything the engine has *seen* and *done* — the
+**reconciliation source** (on restart the engine reconciles its local view
+against the broker's truth, but this store holds what it last knew). It mirrors
+dccd's ``storage/runs_sqlite.py`` pattern (WAL pragma, ``row_factory =
+sqlite3.Row``, a ``_conn`` context manager opening a fresh connection per
+operation, ``CREATE TABLE IF NOT EXISTS`` on init, parametrised SQL).
+
+It speaks **domain types** at its boundary: writes accept
+:class:`~trading_bot.domain.order.Order` / :class:`~trading_bot.domain.fill.Fill`
+aggregates and reads rebuild them; internally it stores primitives only.
+
+Design choices (carried into the ADR)
+-------------------------------------
+* **Money as TEXT, never float.** Every monetary / quantity column is ``TEXT``
+  holding ``str(Decimal)``. SQLite's only numeric types are ``INTEGER`` and
+  ``REAL`` (binary float) — persisting a price through ``REAL`` would bake in
+  the very rounding error the :mod:`~trading_bot.domain.money` layer refuses.
+  Storing the canonical ``str`` form and rebuilding with
+  :func:`~trading_bot.domain.money.money` on read is exact and round-trips
+  losslessly. Enums are stored by ``.value`` and rebuilt via their constructor;
+  the :class:`~trading_bot.domain.instrument.Symbol` is stored as its ``BASE/QUOTE``
+  string and split back on ``"/"``.
+
+* **Orders are UPSERTed; fills are append-only.** An order is a *stateful
+  aggregate*: its row is keyed by ``client_order_id`` and an
+  ``INSERT ... ON CONFLICT DO UPDATE`` keeps exactly one row reflecting its
+  **latest** state (status, ``filled_qty``, ``avg_fill_price``, ...). A fill is
+  an *immutable fact*: its row is keyed by the venue ``fill_id`` and inserted
+  with ``INSERT OR IGNORE`` so re-recording the same execution (a replayed
+  event, a reconciliation re-fetch) is a silent no-op — fills never mutate and
+  never duplicate.
+
+* **Reads do not replay the state machine.** :meth:`get_order` / :meth:`orders`
+  reconstruct the :class:`Order` dataclass directly and set ``status`` /
+  ``filled_qty`` / ``avg_fill_price`` / ``venue_order_id`` to the stored values.
+  The persisted row *is* the truth; replaying ``submit -> open -> apply_fill``
+  would re-derive (and could disagree with) what the engine actually recorded.
+
+* **A fresh connection per operation.** Like dccd, every public method opens its
+  own connection through the :meth:`_conn` context manager. This keeps the store
+  trivially safe for the test usage (and for being shared across threads, since
+  no connection is held), at the cost of per-call connection overhead — fine for
+  an order/fill history written at human/venue rates.
+
+Optionally, :meth:`attach` subscribes the store to an
+:class:`~trading_bot.application.events.EventBus` so it fills itself from the
+engine's event stream (``OrderEvent -> upsert_order``,
+``FillEvent -> record_fill``). The store works standalone with no bus.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sqlite3
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Generator
+
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.order import (
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+)
+
+if TYPE_CHECKING:
+    from trading_bot.application.events import Event, EventBus
+
+__all__ = ["SqliteStore"]
+
+_SCHEMA = """
+PRAGMA journal_mode=WAL;
+PRAGMA synchronous=NORMAL;
+
+CREATE TABLE IF NOT EXISTS orders (
+    client_order_id TEXT PRIMARY KEY,
+    venue_order_id  TEXT,
+    instrument      TEXT NOT NULL,
+    side            TEXT NOT NULL,
+    type            TEXT NOT NULL,
+    qty             TEXT NOT NULL,
+    limit_price     TEXT,
+    stop_price      TEXT,
+    status          TEXT NOT NULL,
+    filled_qty      TEXT NOT NULL,
+    avg_fill_price  TEXT,
+    ts              INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS fills (
+    fill_id         TEXT PRIMARY KEY,
+    client_order_id TEXT NOT NULL,
+    instrument      TEXT NOT NULL,
+    side            TEXT NOT NULL,
+    qty             TEXT NOT NULL,
+    price           TEXT NOT NULL,
+    fee             TEXT NOT NULL,
+    ts              INTEGER NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_fills_ts ON fills(ts);
+CREATE INDEX IF NOT EXISTS idx_fills_cid ON fills(client_order_id);
+
+CREATE TABLE IF NOT EXISTS state (
+    key   TEXT PRIMARY KEY,
+    value TEXT
+);
+"""
+
+
+def _instrument_to_text(instrument: Instrument) -> str:
+    """Render an instrument to its ``BASE/QUOTE`` symbol string for storage."""
+    return str(instrument.symbol)
+
+
+def _instrument_from_text(text: str) -> Instrument:
+    """Rebuild an :class:`Instrument` from a ``BASE/QUOTE`` symbol string.
+
+    Trading metadata (``price_precision`` / ``qty_precision``) is *not*
+    persisted — it belongs to the venue's instrument catalogue, not the
+    order/fill history — so the rebuilt instrument carries only its symbol.
+    """
+    base, quote = text.split("/", 1)
+    return Instrument(Symbol(base, quote))
+
+
+class SqliteStore:
+    """Append-only SQLite store for order/fill history and engine state.
+
+    Construct it on a database path (created if absent, with its parent
+    directories); the schema is applied on init. Then persist with
+    :meth:`upsert_order`, :meth:`record_fill` and :meth:`set_state`, and read
+    back exact-:class:`~decimal.Decimal` domain objects with :meth:`get_order`,
+    :meth:`orders`, :meth:`fills` and :meth:`get_state`. Optionally wire it to an
+    :class:`~trading_bot.application.events.EventBus` with :meth:`attach`.
+
+    Parameters
+    ----------
+    db_path : str or pathlib.Path
+        Path to the SQLite database file. Created if absent; parent directories
+        are created too. Use ``":memory:"`` for an ephemeral in-memory store
+        (note: with a fresh connection per op, an in-memory DB does not persist
+        across operations — use a file path for anything real).
+
+    Examples
+    --------
+    >>> import tempfile, os
+    >>> from trading_bot.domain import Instrument, Symbol, Order, OrderSide, OrderType, money
+    >>> path = tempfile.mktemp(suffix=".db")
+    >>> store = SqliteStore(path)
+    >>> o = Order("cid-1", Instrument(Symbol("BTC", "USD")), OrderSide.BUY,
+    ...           money("2"), OrderType.LIMIT, limit_price=money("30000"))
+    >>> store.upsert_order(o)
+    >>> store.get_order("cid-1").qty
+    Decimal('2')
+    >>> store.close(); os.unlink(path)
+
+    """
+
+    def __init__(self, db_path: str | pathlib.Path) -> None:
+        self._path = pathlib.Path(db_path)
+        if str(self._path) != ":memory:":
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+        with self._conn() as conn:
+            conn.executescript(_SCHEMA)
+
+    @contextmanager
+    def _conn(self) -> Generator[sqlite3.Connection, None, None]:
+        """Yield a fresh connection (``sqlite3.Row`` rows), commit or rollback."""
+        conn = sqlite3.connect(str(self._path))
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+    # --- write API --------------------------------------------------------- #
+
+    def upsert_order(self, order: Order) -> None:
+        """Insert or update ``order``'s row, keyed by ``client_order_id``.
+
+        UPSERT semantics: the first call inserts; any later call with the same
+        ``client_order_id`` overwrites every mutable column so the single row
+        always reflects the order's **latest** state (``status``,
+        ``filled_qty``, ``avg_fill_price``, ``venue_order_id``). Money/qty are
+        stored as ``str(Decimal)`` TEXT; enums by ``.value``.
+
+        Parameters
+        ----------
+        order : Order
+            The order aggregate to persist (its current snapshot).
+
+        """
+        with self._conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO orders (
+                    client_order_id, venue_order_id, instrument, side, type,
+                    qty, limit_price, stop_price, status, filled_qty,
+                    avg_fill_price, ts
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(client_order_id) DO UPDATE SET
+                    venue_order_id = excluded.venue_order_id,
+                    instrument     = excluded.instrument,
+                    side           = excluded.side,
+                    type           = excluded.type,
+                    qty            = excluded.qty,
+                    limit_price    = excluded.limit_price,
+                    stop_price     = excluded.stop_price,
+                    status         = excluded.status,
+                    filled_qty     = excluded.filled_qty,
+                    avg_fill_price = excluded.avg_fill_price,
+                    ts             = excluded.ts
+                """,
+                (
+                    order.client_order_id,
+                    order.venue_order_id,
+                    _instrument_to_text(order.instrument),
+                    order.side.value,
+                    order.type.value,
+                    str(order.qty),
+                    None if order.limit_price is None else str(order.limit_price),
+                    None if order.stop_price is None else str(order.stop_price),
+                    order.status.value,
+                    str(order.filled_qty),
+                    None
+                    if order.avg_fill_price is None
+                    else str(order.avg_fill_price),
+                    None,
+                ),
+            )
+
+    def record_fill(self, fill: Fill) -> None:
+        """Append ``fill`` to the fills table — append-only, no overwrite.
+
+        ``INSERT OR IGNORE`` on the ``fill_id`` primary key: re-recording the
+        same execution (a replayed :class:`~trading_bot.application.events.
+        FillEvent`, a reconciliation re-fetch) is a silent no-op. Fills are
+        immutable facts; they never mutate and never duplicate. Money/qty/fee
+        are stored as ``str(Decimal)`` TEXT.
+
+        Parameters
+        ----------
+        fill : Fill
+            The broker-confirmed execution to persist.
+
+        """
+        with self._conn() as conn:
+            conn.execute(
+                """
+                INSERT OR IGNORE INTO fills (
+                    fill_id, client_order_id, instrument, side, qty, price,
+                    fee, ts
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    fill.fill_id,
+                    fill.client_order_id,
+                    _instrument_to_text(fill.instrument),
+                    fill.side.value,
+                    str(fill.qty),
+                    str(fill.price),
+                    str(fill.fee),
+                    fill.ts,
+                ),
+            )
+
+    def set_state(self, key: str, value: str) -> None:
+        """Set the engine-state ``value`` for ``key`` (UPSERT by ``key``).
+
+        A small string key/value scratchpad for engine state (e.g. the last
+        reconcile timestamp). Both columns are TEXT.
+
+        Parameters
+        ----------
+        key : str
+            The state key.
+        value : str
+            The value to store (callers serialise non-string state themselves).
+
+        """
+        with self._conn() as conn:
+            conn.execute(
+                """
+                INSERT INTO state (key, value) VALUES (?, ?)
+                ON CONFLICT(key) DO UPDATE SET value = excluded.value
+                """,
+                (key, value),
+            )
+
+    # --- read API ---------------------------------------------------------- #
+
+    def get_order(self, client_order_id: str) -> Order | None:
+        """Return the stored :class:`Order` for ``client_order_id``, or ``None``.
+
+        The order is rebuilt **directly** from the stored row — the dataclass is
+        constructed and ``status`` / ``filled_qty`` / ``avg_fill_price`` /
+        ``venue_order_id`` are set to the persisted values (the state machine is
+        *not* replayed; the row is the truth). All money is exact
+        :class:`~decimal.Decimal`.
+        """
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT * FROM orders WHERE client_order_id = ?",
+                (client_order_id,),
+            ).fetchone()
+        return None if row is None else _row_to_order(row)
+
+    def orders(self) -> list[Order]:
+        """Return every stored order, rebuilt as domain :class:`Order` objects.
+
+        Returns
+        -------
+        list of Order
+            All persisted orders (one row per ``client_order_id``), insertion
+            order. Money exact.
+
+        """
+        with self._conn() as conn:
+            rows = conn.execute("SELECT * FROM orders ORDER BY rowid").fetchall()
+        return [_row_to_order(r) for r in rows]
+
+    def fills(self, since_ms: int | None = None) -> list[Fill]:
+        """Return stored fills, optionally only those at/after ``since_ms``.
+
+        Parameters
+        ----------
+        since_ms : int, optional
+            Lower time bound as **milliseconds since the Unix epoch (UTC)**,
+            inclusive. ``None`` (default) returns every stored fill.
+
+        Returns
+        -------
+        list of Fill
+            The matching fills, in insertion (execution) order. Money exact.
+
+        """
+        with self._conn() as conn:
+            if since_ms is None:
+                rows = conn.execute(
+                    "SELECT * FROM fills ORDER BY rowid"
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM fills WHERE ts >= ? ORDER BY rowid",
+                    (since_ms,),
+                ).fetchall()
+        return [_row_to_fill(r) for r in rows]
+
+    def get_state(self, key: str) -> str | None:
+        """Return the stored value for ``key``, or ``None`` if the key is unknown."""
+        with self._conn() as conn:
+            row = conn.execute(
+                "SELECT value FROM state WHERE key = ?", (key,)
+            ).fetchone()
+        return None if row is None else str(row["value"])
+
+    # --- bus integration --------------------------------------------------- #
+
+    def attach(self, event_bus: EventBus) -> None:
+        """Subscribe the store to ``event_bus`` so it fills from the event stream.
+
+        A thin adapter: it subscribes one handler that routes
+        :class:`~trading_bot.application.events.OrderEvent` to
+        :meth:`upsert_order` and :class:`~trading_bot.application.events.
+        FillEvent` to :meth:`record_fill` (other events are ignored). The store
+        works standalone without a bus; this just wires the engine's order/fill
+        stream straight into the history.
+
+        Parameters
+        ----------
+        event_bus : EventBus
+            The bus to subscribe to.
+
+        """
+        # Imported lazily so the storage module never hard-depends on the
+        # application layer (it works standalone); only ``attach`` needs it.
+        from trading_bot.application.events import FillEvent, OrderEvent
+
+        def _on_event(event: Event) -> None:
+            if isinstance(event, OrderEvent):
+                self.upsert_order(event.order)
+            elif isinstance(event, FillEvent):
+                self.record_fill(event.fill)
+
+        event_bus.subscribe(_on_event)
+
+    # --- lifecycle --------------------------------------------------------- #
+
+    def close(self) -> None:
+        """Close the store.
+
+        A no-op for connection state (each operation opens and closes its own
+        connection), provided so callers can treat the store as a closable
+        resource symmetrically with a real connection-holding store.
+        """
+        # Nothing to release: connections are per-operation (see ``_conn``).
+
+    def __enter__(self) -> SqliteStore:
+        """Enter the runtime context, returning the store."""
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        """Exit the runtime context, closing the store."""
+        self.close()
+
+
+def _row_to_order(row: sqlite3.Row) -> Order:
+    """Rebuild an :class:`Order` from a stored ``orders`` row (exact Decimal).
+
+    Constructs the dataclass from the immutable fields, then sets the mutable
+    lifecycle fields (``status`` / ``filled_qty`` / ``avg_fill_price`` /
+    ``venue_order_id``) directly to the stored values — the persisted row is the
+    truth, so the state machine is not replayed.
+    """
+    limit_raw = row["limit_price"]
+    stop_raw = row["stop_price"]
+    avg_raw = row["avg_fill_price"]
+    order = Order(
+        client_order_id=str(row["client_order_id"]),
+        instrument=_instrument_from_text(str(row["instrument"])),
+        side=OrderSide(row["side"]),
+        qty=money(str(row["qty"])),
+        type=OrderType(row["type"]),
+        limit_price=None if limit_raw is None else money(str(limit_raw)),
+        stop_price=None if stop_raw is None else money(str(stop_raw)),
+    )
+    order.filled_qty = money(str(row["filled_qty"]))
+    order.avg_fill_price = None if avg_raw is None else money(str(avg_raw))
+    order.status = OrderStatus(row["status"])
+    venue = row["venue_order_id"]
+    order.venue_order_id = None if venue is None else str(venue)
+    return order
+
+
+def _row_to_fill(row: sqlite3.Row) -> Fill:
+    """Rebuild a :class:`Fill` from a stored ``fills`` row (exact Decimal)."""
+    return Fill(
+        fill_id=str(row["fill_id"]),
+        client_order_id=str(row["client_order_id"]),
+        instrument=_instrument_from_text(str(row["instrument"])),
+        side=OrderSide(row["side"]),
+        qty=money(str(row["qty"])),
+        price=money(str(row["price"])),
+        fee=money(str(row["fee"])),
+        ts=int(row["ts"]),
+    )

--- a/trading_bot/tests/storage/test_sqlite_store.py
+++ b/trading_bot/tests/storage/test_sqlite_store.py
@@ -1,0 +1,410 @@
+"""Tests for the :class:`~trading_bot.storage.sqlite_store.SqliteStore`.
+
+These prove the store's persistence contract end to end:
+
+* orders round-trip through ``upsert_order``/``get_order`` to an **equal** domain
+  :class:`~trading_bot.domain.order.Order` (status, ``filled_qty``, exact
+  ``Decimal`` qty/prices), and re-upserting the same ``client_order_id`` updates
+  the single row to its latest state (no duplicate);
+* fills round-trip through ``record_fill``/``fills`` to equal immutable
+  :class:`~trading_bot.domain.fill.Fill`\\ s, re-recording a ``fill_id`` is a
+  no-op (append-only), and ``fills(since_ms=...)`` filters by ``ts``;
+* ``set_state``/``get_state`` round-trips and a missing key is ``None``;
+* **no float**: a price like ``money("0.1")`` round-trips exactly and the raw
+  stored column is TEXT (``str``);
+* ``attach(bus)`` wires the store to an :class:`~trading_bot.application.events.
+  EventBus` so emitted ``OrderEvent``/``FillEvent``\\ s populate it;
+* a realistic engine sequence driven through
+  :class:`~trading_bot.application.order_router.OrderRouter` ->
+  :class:`~trading_bot.brokers.paper.PaperBroker` (store attached to the bus),
+  then **reopened from the file**, persists the orders/fills, and
+  :meth:`Position.from_fills` over the stored fills matches the live tracker's
+  position.
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from trading_bot.application import (
+    EventBus,
+    FillEvent,
+    LogEvent,
+    OrderEvent,
+    OrderRouter,
+    PositionTracker,
+)
+from trading_bot.brokers import PaperBroker
+from trading_bot.domain import (
+    Fill,
+    Instrument,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Position,
+    Symbol,
+    money,
+)
+from trading_bot.storage import SqliteStore
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+ETH_USD = Instrument(Symbol("ETH", "USD"))
+
+
+def _store(tmp_path) -> SqliteStore:
+    return SqliteStore(tmp_path / "engine.db")
+
+
+def _order(
+    *,
+    cid: str = "cid-1",
+    side: OrderSide = OrderSide.BUY,
+    qty: str = "2",
+    otype: OrderType = OrderType.LIMIT,
+    limit_price: str | None = "30000",
+    stop_price: str | None = None,
+    instrument: Instrument = BTC_USD,
+) -> Order:
+    return Order(
+        client_order_id=cid,
+        instrument=instrument,
+        side=side,
+        qty=money(qty),
+        type=otype,
+        limit_price=None if limit_price is None else money(limit_price),
+        stop_price=None if stop_price is None else money(stop_price),
+    )
+
+
+def _fill(
+    *,
+    fill_id: str,
+    cid: str = "cid-1",
+    side: OrderSide = OrderSide.BUY,
+    qty: str = "1",
+    price: str = "30000",
+    fee: str = "3",
+    ts: int = 1_700_000_000_000,
+    instrument: Instrument = BTC_USD,
+) -> Fill:
+    return Fill(
+        fill_id=fill_id,
+        client_order_id=cid,
+        instrument=instrument,
+        side=side,
+        qty=money(qty),
+        price=money(price),
+        fee=money(fee),
+        ts=ts,
+    )
+
+
+def _assert_orders_equal(got: Order | None, expected: Order) -> None:
+    assert got is not None
+    assert got.client_order_id == expected.client_order_id
+    assert got.instrument == expected.instrument
+    assert got.side == expected.side
+    assert got.type == expected.type
+    assert got.qty == expected.qty
+    assert got.limit_price == expected.limit_price
+    assert got.stop_price == expected.stop_price
+    assert got.status == expected.status
+    assert got.filled_qty == expected.filled_qty
+    assert got.avg_fill_price == expected.avg_fill_price
+    assert got.venue_order_id == expected.venue_order_id
+
+
+def _assert_fills_equal(got: Fill, expected: Fill) -> None:
+    assert got == expected  # frozen dataclass: structural equality
+    # And money fields are exact Decimal (== on Decimal is value-exact).
+    assert got.qty == expected.qty
+    assert got.price == expected.price
+    assert got.fee == expected.fee
+
+
+# --- orders: round-trip + upsert ------------------------------------------- #
+
+
+def test_upsert_order_round_trip(tmp_path) -> None:
+    """A NEW order round-trips to an equal domain Order."""
+    store = _store(tmp_path)
+    order = _order()
+    store.upsert_order(order)
+    _assert_orders_equal(store.get_order("cid-1"), order)
+
+
+def test_get_order_missing_is_none(tmp_path) -> None:
+    """An unknown client_order_id yields None."""
+    store = _store(tmp_path)
+    assert store.get_order("nope") is None
+
+
+def test_upsert_order_persists_lifecycle_state(tmp_path) -> None:
+    """status / filled_qty / avg_fill_price / venue_order_id round-trip exactly."""
+    store = _store(tmp_path)
+    order = _order()
+    order.submit()
+    order.open("VID-9")
+    order.apply_fill(money("1"), money("30100"))
+    store.upsert_order(order)
+
+    got = store.get_order("cid-1")
+    assert got is not None
+    assert got.status is OrderStatus.PARTIALLY_FILLED
+    assert got.filled_qty == money("1")
+    assert got.avg_fill_price == money("30100")
+    assert got.venue_order_id == "VID-9"
+
+
+def test_re_upsert_updates_single_row(tmp_path) -> None:
+    """Re-upserting the same client_order_id updates one row to the latest state."""
+    store = _store(tmp_path)
+    order = _order()
+    store.upsert_order(order)  # NEW
+
+    order.submit()
+    order.open("VID-1")
+    order.apply_fill(money("2"), money("30000"))  # fully filled
+    store.upsert_order(order)  # FILLED
+
+    assert len(store.orders()) == 1
+    got = store.get_order("cid-1")
+    assert got is not None
+    assert got.status is OrderStatus.FILLED
+    assert got.filled_qty == money("2")
+    assert got.venue_order_id == "VID-1"
+
+
+def test_orders_lists_all(tmp_path) -> None:
+    """orders() returns every distinct order."""
+    store = _store(tmp_path)
+    store.upsert_order(_order(cid="a"))
+    store.upsert_order(_order(cid="b", instrument=ETH_USD))
+    cids = {o.client_order_id for o in store.orders()}
+    assert cids == {"a", "b"}
+
+
+def test_order_stop_loss_round_trip(tmp_path) -> None:
+    """A STOP_LOSS order (stop_price set, limit None) round-trips exactly."""
+    store = _store(tmp_path)
+    order = _order(
+        cid="sl-1",
+        side=OrderSide.SELL,
+        otype=OrderType.STOP_LOSS,
+        limit_price=None,
+        stop_price="25000",
+    )
+    store.upsert_order(order)
+    got = store.get_order("sl-1")
+    assert got is not None
+    assert got.type is OrderType.STOP_LOSS
+    assert got.stop_price == money("25000")
+    assert got.limit_price is None
+
+
+# --- fills: append-only + filter ------------------------------------------- #
+
+
+def test_record_fill_round_trip(tmp_path) -> None:
+    """A fill round-trips to an equal immutable Fill (Decimal exact)."""
+    store = _store(tmp_path)
+    fill = _fill(fill_id="T1")
+    store.record_fill(fill)
+    got = store.fills()
+    assert len(got) == 1
+    _assert_fills_equal(got[0], fill)
+
+
+def test_record_fill_is_append_only(tmp_path) -> None:
+    """Re-recording the same fill_id is a no-op (no duplicate)."""
+    store = _store(tmp_path)
+    fill = _fill(fill_id="T1")
+    store.record_fill(fill)
+    store.record_fill(fill)  # duplicate fill_id
+    # A different-content fill under the same id is also ignored (append-only).
+    store.record_fill(_fill(fill_id="T1", qty="99", price="1"))
+    got = store.fills()
+    assert len(got) == 1
+    _assert_fills_equal(got[0], fill)  # original wins, untouched
+
+
+def test_fills_filter_since_ms(tmp_path) -> None:
+    """fills(since_ms=...) returns only fills at/after the bound (inclusive)."""
+    store = _store(tmp_path)
+    store.record_fill(_fill(fill_id="T1", ts=100))
+    store.record_fill(_fill(fill_id="T2", ts=200))
+    store.record_fill(_fill(fill_id="T3", ts=300))
+
+    assert [f.fill_id for f in store.fills()] == ["T1", "T2", "T3"]
+    assert [f.fill_id for f in store.fills(since_ms=200)] == ["T2", "T3"]
+    assert [f.fill_id for f in store.fills(since_ms=301)] == []
+
+
+# --- state ----------------------------------------------------------------- #
+
+
+def test_state_round_trip(tmp_path) -> None:
+    """set_state/get_state round-trips; a missing key is None; updates overwrite."""
+    store = _store(tmp_path)
+    assert store.get_state("last_reconcile") is None
+    store.set_state("last_reconcile", "1700000000000")
+    assert store.get_state("last_reconcile") == "1700000000000"
+    store.set_state("last_reconcile", "1800000000000")
+    assert store.get_state("last_reconcile") == "1800000000000"
+
+
+# --- money is TEXT, never float -------------------------------------------- #
+
+
+def test_money_is_text_and_decimal_exact(tmp_path) -> None:
+    """A price like 0.1 round-trips exactly and the raw stored column is TEXT."""
+    db = tmp_path / "engine.db"
+    store = SqliteStore(db)
+    order = _order(cid="dust", qty="0.1", limit_price="0.1")
+    store.upsert_order(order)
+    store.record_fill(_fill(fill_id="Tx", cid="dust", qty="0.1", price="0.1", fee="0"))
+
+    got_order = store.get_order("dust")
+    assert got_order is not None
+    assert got_order.qty == money("0.1")
+    assert got_order.limit_price == money("0.1")
+    got_fill = store.fills()[0]
+    assert got_fill.qty == money("0.1")
+    assert got_fill.price == money("0.1")
+
+    # Assert the raw stored columns are TEXT (str), not REAL/float.
+    raw = sqlite3.connect(str(db))
+    try:
+        o_qty, o_lim = raw.execute(
+            "SELECT qty, limit_price FROM orders WHERE client_order_id='dust'"
+        ).fetchone()
+        f_qty, f_price = raw.execute(
+            "SELECT qty, price FROM fills WHERE fill_id='Tx'"
+        ).fetchone()
+    finally:
+        raw.close()
+    assert isinstance(o_qty, str) and o_qty == "0.1"
+    assert isinstance(o_lim, str) and o_lim == "0.1"
+    assert isinstance(f_qty, str) and f_qty == "0.1"
+    assert isinstance(f_price, str) and f_price == "0.1"
+
+
+# --- bus integration ------------------------------------------------------- #
+
+
+def test_attach_populates_from_events(tmp_path) -> None:
+    """Emitting OrderEvent/FillEvent on an attached bus fills the store."""
+    store = _store(tmp_path)
+    bus = EventBus()
+    store.attach(bus)
+
+    order = _order()
+    bus.emit(OrderEvent(order))
+    bus.emit(FillEvent(_fill(fill_id="T1")))
+    bus.emit(LogEvent(message="ignored"))  # non-order/fill: ignored
+
+    assert store.get_order("cid-1") is not None
+    assert len(store.fills()) == 1
+    assert len(store.orders()) == 1
+
+
+def test_attach_tracks_latest_order_state(tmp_path) -> None:
+    """A second OrderEvent for the same id updates the persisted row."""
+    store = _store(tmp_path)
+    bus = EventBus()
+    store.attach(bus)
+
+    order = _order()
+    bus.emit(OrderEvent(order))
+    order.submit()
+    order.open("VID-1")
+    bus.emit(OrderEvent(order))
+
+    assert len(store.orders()) == 1
+    got = store.get_order("cid-1")
+    assert got is not None
+    assert got.status is OrderStatus.OPEN
+    assert got.venue_order_id == "VID-1"
+
+
+# --- verification on real data: reopen the file ---------------------------- #
+
+
+async def test_engine_sequence_survives_reopen(tmp_path) -> None:
+    """Drive OrderRouter->PaperBroker (store attached), reopen the file, verify.
+
+    Submits a realistic mixed sequence (a full buy, then a partial buy that
+    leaves a live remainder, then a sell) through the router to the paper
+    broker, with the store attached to the bus so it records orders + fills as
+    they flow. Then a **fresh** ``SqliteStore`` on the same file must report the
+    same orders/fills, and ``Position.from_fills`` over the persisted fills must
+    equal the live :class:`PositionTracker`'s position — proving the store is a
+    faithful, reopenable reconciliation source.
+    """
+    db = tmp_path / "engine.db"
+    bus = EventBus()
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        fee_bps=money("10"),
+        event_bus=bus,  # broker emits FillEvent onto the bus
+    )
+    router = OrderRouter(broker, bus)
+    tracker = PositionTracker(event_bus=bus)
+    store = SqliteStore(db)
+    store.attach(bus)
+
+    # 1) full buy of 2 BTC @ 30000 (immediate fill model).
+    await router.submit(
+        _order(cid="o1", side=OrderSide.BUY, qty="2", limit_price="30000")
+    )
+    # 2) partial buy: arm a 0.5 ratio so only half the 2 BTC fills, remainder open.
+    broker.arm_partial(money("0.5"))
+    await router.submit(
+        _order(cid="o2", side=OrderSide.BUY, qty="2", limit_price="31000")
+    )
+    # 3) sell 1 BTC @ 32000.
+    await router.submit(
+        _order(cid="o3", side=OrderSide.SELL, qty="1", limit_price="32000")
+    )
+
+    # Persist the post-submit order snapshots (the router emitted them as NEW->
+    # OPEN; re-upsert the final tracked state for good measure / a real engine
+    # would on each transition).
+    for o in router.tracked_orders().values():
+        store.upsert_order(o)
+
+    live_pos = tracker.position(BTC_USD)
+    live_fill_ids = [f.fill_id for f in await broker.fills()]
+    store.close()
+
+    # --- reopen the file in a fresh store and compare --- #
+    reopened = SqliteStore(db)
+
+    # Orders survived: same ids, with the venue id the router obtained. The
+    # router owns only the write path (NEW->SUBMITTED->OPEN); it never ingests
+    # fills onto the Order (that is the tracker's job), so a router-tracked
+    # order is OPEN with venue_order_id set — exactly what we persisted.
+    persisted_orders = {o.client_order_id: o for o in reopened.orders()}
+    assert set(persisted_orders) == {"o1", "o2", "o3"}
+    for cid in ("o1", "o2", "o3"):
+        live = router.get(cid)
+        assert live is not None
+        _assert_orders_equal(persisted_orders[cid], live)
+    assert persisted_orders["o2"].venue_order_id is not None
+
+    # Fills survived in execution order, byte-for-byte.
+    persisted_fills = reopened.fills()
+    assert [f.fill_id for f in persisted_fills] == live_fill_ids
+    assert all(isinstance(f.price, type(money("1"))) for f in persisted_fills)
+
+    # Position rebuilt from the *persisted* fills equals the live tracker's.
+    rebuilt = Position.from_fills(persisted_fills)
+    assert live_pos is not None
+    assert rebuilt.net_qty == live_pos.net_qty
+    assert rebuilt.avg_entry_price == live_pos.avg_entry_price
+    assert rebuilt.realised_pnl == live_pos.realised_pnl
+    assert rebuilt.fees_paid == live_pos.fees_paid
+    reopened.close()


### PR DESCRIPTION
## Summary
- First leaf of **E6**: opens `trading_bot/storage/` — `SqliteStore` (stdlib sqlite3, WAL).
- Persists `orders` (UPSERT by client-order-id — latest state), `fills` (append-only, `INSERT OR IGNORE`), and key/value `state`. **All money/qty as TEXT** (`str(Decimal)`), never float. Optional `attach(event_bus)` to self-fill from `OrderEvent`/`FillEvent`.

## Why
- SQLite's only numerics are INTEGER/REAL (binary float) — a price through REAL reintroduces the rounding error `money` refuses, so TEXT is the only lossless option. Orders are stateful (UPSERT); fills are immutable facts (append-only no-op on replay). The store is the reconciliation source. See `doc/dev/03-decisions.md`.

## Changes
- `storage/sqlite_store.py` + export; `tests/storage/test_sqlite_store.py` (14 tests).

## Changelog
Added: `storage.SqliteStore` — append-only SQLite order/fill history + state (Decimal as TEXT).

## Test plan
- [x] `.venv/bin/python -m pytest` (397 passed, 0 unexpected skips)
- [x] money-as-TEXT verified (`0.1` stored as TEXT, round-trips exactly)
- [x] reopen-file persistence: orders/fills survive; `Position.from_fills(store.fills())` matches the live tracker
- [x] `ruff` + `mypy` clean