### PR TITLE
feat: PerformanceService (live PnL/KPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `storage.SqliteStore` — append-only SQLite order/fill history + key/value state
   (orders UPSERTed, fills append-only, money as TEXT — exact `Decimal`, never
   float); optional `EventBus` attach. The reconciliation source.
+- `application.PerformanceService` — live realised PnL / fees / equity curve over
+  the `FillEvent` stream, with Sharpe/Sortino/max-drawdown/Calmar via fynance.
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,25 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-22 PerformanceService: fill-driven realised-PnL equity, two views
+
+**Decision.** `application/performance_service.py` `PerformanceService` observes the
+`FillEvent` stream (read-side; never trades) and keeps **two views of one stream**: a
+global arrival-order fill list driving an aggregate **realised-PnL equity curve**
+(`equity_k = v0 + cumulative realised PnL through fill k`, one point per fill), and
+per-instrument lists driving `position()` via `Position.from_fills`. KPIs
+(Sharpe/Sortino/max-drawdown/Calmar) delegate to `domain.performance` (fynance) over
+that curve; a series with `< 2` points returns `0.0` (guarded, no raise).
+`domain.performance.equity_curve` (single-instrument mark-to-market) was **not** used —
+the same `v0 + cumulative-PnL` shape is rebuilt from fills.
+
+**Why.** Realised PnL is additive across instruments and fills, so the aggregate total
+equals the sum of per-instrument `Position.from_fills(...).realised_pnl` — a fill-driven
+step curve needs no external mark prices (which we don't have for a cross-instrument
+aggregate stream). Short-series-safe KPIs keep the service callable from the first fill.
+
+---
+
 ### 2026-06-22 Storage: SQLite, money as TEXT, orders UPSERT / fills append-only
 
 **Decision.** `trading_bot/storage/sqlite_store.py` `SqliteStore` (stdlib `sqlite3`,

--- a/doc/dev/plans/perf-persistence-risk/00-plan.md
+++ b/doc/dev/plans/perf-persistence-risk/00-plan.md
@@ -29,7 +29,7 @@ gate every order**. Everything is offline-testable.
 ## Leaf checklist
 
 - [x] 01 storage — feat/storage — high
-- [ ] 02 performance-service — feat/performance-service — medium
+- [x] 02 performance-service — feat/performance-service — medium
 - [ ] 03 risk-manager — feat/risk-manager — high
 
 ## Dependencies

--- a/doc/dev/plans/perf-persistence-risk/02-performance-service.md
+++ b/doc/dev/plans/perf-persistence-risk/02-performance-service.md
@@ -1,7 +1,7 @@
 ---
 plan: perf-persistence-risk/02-performance-service
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false

--- a/doc/dev/plans/perf-persistence-risk/02-performance-service.md
+++ b/doc/dev/plans/perf-persistence-risk/02-performance-service.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/performance-service
-pr: ""
+pr: "#36"
 ---
 
 # PerformanceService — live PnL/KPI over the fill stream

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -31,6 +31,12 @@ It then layers the engine's use-cases:
   applied explicitly) into a live net
   :class:`~trading_bot.domain.position.Position` per instrument, the owner of
   exposure and realised PnL.
+* performance_service — the
+  :class:`~trading_bot.application.performance_service.PerformanceService`, the
+  read-side performance view: it observes the same confirmed ``Fill``\\ s and
+  reports aggregate realised PnL / fees, an equity curve (``v0`` + cumulative
+  realised PnL) and the fynance-backed KPI ratios (Sharpe, Sortino, max drawdown,
+  Calmar). Observational only — it never places an order.
 * reconcile — :func:`~trading_bot.application.reconcile.reconcile` (and its
   :class:`~trading_bot.application.reconcile.ReconResult`): the *reconcile,
   don't assume* pass that, on startup or after a disconnect, refetches the
@@ -81,6 +87,7 @@ from trading_bot.application.events import (
     OrderEvent,
 )
 from trading_bot.application.order_router import OrderRouter
+from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.reconcile import ReconResult, reconcile
 from trading_bot.application.strategy import (
@@ -106,6 +113,7 @@ __all__ = [
     # use-cases
     "OrderRouter",
     "PositionTracker",
+    "PerformanceService",
     "reconcile",
     "ReconResult",
     # data feed

--- a/trading_bot/application/performance_service.py
+++ b/trading_bot/application/performance_service.py
@@ -1,0 +1,373 @@
+"""The :class:`PerformanceService` — live PnL/KPI over the fill stream.
+
+The service is the **read-side performance view** of execution: it observes the
+venue's confirmed fills (the PnL source of truth) and reports realised PnL, fees
+paid, an equity curve and the KPI ratios (Sharpe, Sortino, max drawdown, Calmar).
+It is purely observational — it *never* places, amends or cancels an order. Where
+the :class:`~trading_bot.application.position_tracker.PositionTracker` answers
+"what do we hold?", the performance service answers "how have we *done*?".
+
+Fill ingestion — the boundary
+-----------------------------
+Fills reach the service the same two ways as the tracker, both landing in
+:meth:`apply`:
+
+* **Subscribed** — constructed with an
+  :class:`~trading_bot.application.events.EventBus`, the service subscribes to
+  :class:`~trading_bot.application.events.FillEvent` and ``apply``\\ s each one
+  automatically (other event types are ignored). The
+  :class:`~trading_bot.brokers.paper.PaperBroker` (and, later, a live broker's
+  private fill stream) emits ``FillEvent``\\ s, so the order -> fill ->
+  performance flow is wired end to end with no polling.
+* **Explicit** — a caller (e.g. a reconciliation pass that drains
+  :meth:`~trading_bot.brokers.base.Broker.fills`) feeds each fill to
+  :meth:`apply` directly. No bus required.
+
+Aggregation model (carried into the ADR)
+----------------------------------------
+The service keeps **two** views of the same fill stream:
+
+* a **global ordered fill list** — every fill in arrival order, across all
+  instruments. This drives the *aggregate* realised-PnL / equity series.
+* a **per-instrument ordered fill list** — for :meth:`position`, computed via
+  :meth:`~trading_bot.domain.position.Position.from_fills` exactly like the
+  :class:`PositionTracker`.
+
+Realised PnL is **additive across instruments and across fills** (each fill
+contributes an independent close-PnL term and an independent fee term — see the
+:class:`~trading_bot.domain.position.Position` sign convention), so the *total*
+realised PnL after the k-th global fill is the sum over instruments of
+``Position.from_fills(fills_of_that_instrument_seen_through_k).realised_pnl``.
+The service therefore builds its equity series **step-by-step from realised PnL**
+rather than from a mark-to-market price path: the equity after the k-th fill is
+
+    equity_k = v0 + total_realised_pnl_through_k
+
+This is the natural curve for a fill-driven view — it moves only when a close
+locks PnL in (or a fee is charged), needs no external mark price series, and
+reconciles exactly to :meth:`~trading_bot.domain.position.Position.from_fills`
+summed across instruments. (The pure
+:func:`trading_bot.domain.performance.equity_curve` is a *single-instrument
+mark-to-market* curve that needs an aligned price series; it is not used here
+because the aggregate fill stream spans instruments and we have no per-step mark
+price. We reuse the same *value = v0 + cumulative-PnL* shape it defines.)
+
+Short-series KPI policy (carried into the ADR)
+----------------------------------------------
+The KPI ratios are statistical estimators over a *returns* path. fynance needs at
+least two equity points (one return) to produce a meaningful number; with fewer,
+the estimator is undefined (and fynance would divide by a zero / empty variance).
+The service therefore **guards before delegating**: if the equity curve has fewer
+than two points (i.e. 0 or 1 fills, so 0 returns), every KPI method returns
+``0.0`` rather than raising. With two or more points the call is delegated to
+:mod:`trading_bot.domain.performance` (fynance-backed) and its result returned
+verbatim.
+
+Money stays :class:`~decimal.Decimal` through the PnL core (realised PnL, fees,
+equity curve); only the KPI series crosses to ``float`` at the
+:func:`trading_bot.domain.performance.equity_array` boundary, exactly as the
+domain layer already does.
+
+The module is part of the application layer: it imports the pure domain and the
+event bus, holds money as :class:`~decimal.Decimal` end to end, and is
+deterministic in fill order.
+"""
+
+from __future__ import annotations
+
+from trading_bot.application.events import Event, EventBus, FillEvent
+from trading_bot.domain import performance as perf
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.position import Position
+
+__all__ = ["PerformanceService"]
+
+_ZERO: Money = money("0")
+
+
+class PerformanceService:
+    """Live performance view (PnL / equity / KPIs) folded from confirmed fills.
+
+    Construct it bare (and call :meth:`apply` for each fill) or with an
+    :class:`~trading_bot.application.events.EventBus` (then it subscribes to
+    :class:`~trading_bot.application.events.FillEvent` and applies fills
+    automatically). Read realised PnL and fees with :meth:`realised_pnl` /
+    :meth:`fees_paid`, the per-instrument exposure with :meth:`position`, the
+    account-value path with :meth:`equity_curve`, and the risk ratios with
+    :meth:`sharpe` / :meth:`sortino` / :meth:`max_drawdown` / :meth:`calmar`.
+
+    Read-side only: the service observes fills and reports performance; it never
+    submits, amends or cancels an order.
+
+    Parameters
+    ----------
+    v0 : Money, optional
+        Initial account capital, anchoring the equity curve
+        (``equity = v0 + cumulative realised PnL``). Defaults to ``money("0")``,
+        so the curve is the bare cumulative realised PnL.
+    event_bus : EventBus, optional
+        If given, the service subscribes to it and applies every
+        :class:`~trading_bot.application.events.FillEvent` as it is emitted. With
+        ``None`` (the default) the service is driven only by explicit
+        :meth:`apply` calls.
+
+    Examples
+    --------
+    >>> from trading_bot.domain.fill import Fill
+    >>> from trading_bot.domain.instrument import Instrument, Symbol
+    >>> from trading_bot.domain.money import money
+    >>> from trading_bot.domain.order import OrderSide
+    >>> inst = Instrument(Symbol("BTC", "USD"))
+    >>> svc = PerformanceService(v0=money("1000"))
+    >>> svc.apply(
+    ...     Fill("T1", "cid-1", inst, OrderSide.BUY, money("2"), money("30000"),
+    ...          money("6"), 1)
+    ... )
+    >>> svc.fees_paid()
+    Decimal('6')
+    >>> svc.realised_pnl()
+    Decimal('-6')
+
+    """
+
+    def __init__(
+        self, *, v0: Money = _ZERO, event_bus: EventBus | None = None
+    ) -> None:
+        self._v0: Money = v0
+        # Global arrival-order fill list — drives the aggregate equity series.
+        self._fills: list[Fill] = []
+        # Per-instrument arrival-order fill lists — drive position()/realised_pnl.
+        self._by_instrument: dict[Instrument, list[Fill]] = {}
+        # Running aggregate realised PnL after each global fill (one entry per
+        # fill). Rebuilt incrementally so equity_curve() is O(1) to read.
+        self._equity: list[Money] = []
+        # Running totals, kept incrementally (each fill's contribution to total
+        # realised PnL is the delta of its instrument's position realised PnL).
+        self._realised_pnl: Money = _ZERO
+        self._fees_paid: Money = _ZERO
+        self._bus = event_bus
+        if event_bus is not None:
+            event_bus.subscribe(self._on_event)
+
+    def _on_event(self, event: Event) -> None:
+        """Bus handler: apply the fill of a :class:`FillEvent`, ignore the rest.
+
+        Subscribed to the :class:`~trading_bot.application.events.EventBus`, which
+        fans out every event type; the service only cares about
+        :class:`~trading_bot.application.events.FillEvent`.
+        """
+        if isinstance(event, FillEvent):
+            self.apply(event.fill)
+
+    def apply(self, fill: Fill) -> None:
+        """Fold ``fill`` into the aggregate and per-instrument performance views.
+
+        Appends the fill to the global arrival-order list and to its instrument's
+        list, recomputes that instrument's
+        :class:`~trading_bot.domain.position.Position` via
+        :meth:`~trading_bot.domain.position.Position.from_fills`, and updates the
+        running aggregate realised PnL / fees / equity step by the **delta** the
+        fill introduced to its instrument's realised PnL (so totals stay the sum
+        across instruments, and the equity series gains exactly one point).
+
+        The service does **not** dedup by ``fill_id`` — the broker's fill stream
+        is the de-duplicated source, mirroring the
+        :class:`~trading_bot.application.position_tracker.PositionTracker`.
+
+        Parameters
+        ----------
+        fill : Fill
+            A broker-confirmed execution (the PnL source of truth).
+
+        """
+        instrument = fill.instrument
+        inst_fills = self._by_instrument.setdefault(instrument, [])
+
+        # Realised PnL / fees the instrument had *before* this fill.
+        prev_realised = _ZERO
+        prev_fees = _ZERO
+        if inst_fills:
+            prev = Position.from_fills(inst_fills)
+            prev_realised = prev.realised_pnl
+            prev_fees = prev.fees_paid
+
+        inst_fills.append(fill)
+        self._fills.append(fill)
+
+        # Realised PnL / fees after the fill; the deltas fold into the aggregate.
+        now = Position.from_fills(inst_fills)
+        self._realised_pnl += now.realised_pnl - prev_realised
+        self._fees_paid += now.fees_paid - prev_fees
+
+        # One new equity point: v0 + total realised PnL through this fill.
+        self._equity.append(self._v0 + self._realised_pnl)
+
+    def realised_pnl(self) -> Money:
+        """Aggregate realised PnL across all instruments, **net of fees**.
+
+        Consistent with :meth:`~trading_bot.domain.position.Position.from_fills`:
+        equals the sum over instruments of that instrument's
+        ``Position.from_fills(...).realised_pnl``.
+
+        Returns
+        -------
+        Money
+            The total realised PnL (exact :class:`~decimal.Decimal`). Zero when
+            no fill has been applied.
+
+        """
+        return self._realised_pnl
+
+    def fees_paid(self) -> Money:
+        """Aggregate fees paid across all instruments and all fills.
+
+        Equals the sum over instruments of
+        ``Position.from_fills(...).fees_paid``.
+
+        Returns
+        -------
+        Money
+            The total fees paid (exact :class:`~decimal.Decimal`). Zero when no
+            fill has been applied.
+
+        """
+        return self._fees_paid
+
+    def position(self, instrument: Instrument) -> Position | None:
+        """Return the net :class:`Position` for ``instrument``, or ``None``.
+
+        Computed via :meth:`~trading_bot.domain.position.Position.from_fills` over
+        exactly the fills seen for ``instrument``, in arrival order.
+
+        Parameters
+        ----------
+        instrument : Instrument
+            The instrument to read.
+
+        Returns
+        -------
+        Position or None
+            The folded position, or ``None`` if no fill for ``instrument`` has
+            been applied yet.
+
+        """
+        fills = self._by_instrument.get(instrument)
+        if not fills:
+            return None
+        return Position.from_fills(fills)
+
+    def equity_curve(self) -> tuple[Money, ...]:
+        """The account-value path: ``v0`` + cumulative realised PnL per fill.
+
+        One point per applied fill, in arrival order, each equal to ``v0`` plus
+        the aggregate realised PnL through that fill (see the module docstring for
+        why a realised-PnL step series is the natural fill-driven curve). Empty
+        until the first fill is applied.
+
+        Returns
+        -------
+        tuple of Money
+            The equity at each fill step (exact :class:`~decimal.Decimal`).
+
+        """
+        return tuple(self._equity)
+
+    # --- KPI ratios — delegate to domain.performance (fynance-backed) -------- #
+
+    def sharpe(self, *, rf: float = 0.0, period: int = 252, log: bool = False) -> float:
+        """Annualised Sharpe ratio of the equity curve.
+
+        Delegates to :func:`trading_bot.domain.performance.sharpe`. Returns
+        ``0.0`` when the equity curve has fewer than two points (no return to
+        measure) — see the short-series policy in the module docstring.
+
+        Parameters
+        ----------
+        rf : float, optional
+            Annualised risk-free rate. Default ``0``.
+        period : int, optional
+            Periods per year for annualisation. Default ``252``.
+        log : bool, optional
+            Use log-returns instead of simple returns. Default ``False``.
+
+        Returns
+        -------
+        float
+            The Sharpe ratio, or ``0.0`` for a too-short series.
+
+        """
+        if len(self._equity) < 2:
+            return 0.0
+        return perf.sharpe(self._equity, rf=rf, period=period, log=log)
+
+    def sortino(
+        self, *, rf: float = 0.0, period: int = 252, log: bool = False
+    ) -> float:
+        """Annualised Sortino ratio of the equity curve.
+
+        Delegates to :func:`trading_bot.domain.performance.sortino`. Returns
+        ``0.0`` for a series with fewer than two points (short-series policy).
+
+        Parameters
+        ----------
+        rf : float, optional
+            Annualised risk-free rate. Default ``0``.
+        period : int, optional
+            Periods per year. Default ``252``.
+        log : bool, optional
+            Use log-returns. Default ``False``.
+
+        Returns
+        -------
+        float
+            The Sortino ratio, or ``0.0`` for a too-short series.
+
+        """
+        if len(self._equity) < 2:
+            return 0.0
+        return perf.sortino(self._equity, rf=rf, period=period, log=log)
+
+    def max_drawdown(self, *, raw: bool = False) -> float:
+        """Maximum drawdown of the equity curve.
+
+        Delegates to :func:`trading_bot.domain.performance.max_drawdown`. Returns
+        ``0.0`` for a series with fewer than two points (short-series policy).
+
+        Parameters
+        ----------
+        raw : bool, optional
+            If ``True`` return the absolute decline; otherwise (default) the
+            fractional drawdown.
+
+        Returns
+        -------
+        float
+            The maximum drawdown, or ``0.0`` for a too-short series.
+
+        """
+        if len(self._equity) < 2:
+            return 0.0
+        return perf.max_drawdown(self._equity, raw=raw)
+
+    def calmar(self, *, period: int = 252) -> float:
+        """Calmar ratio of the equity curve.
+
+        Delegates to :func:`trading_bot.domain.performance.calmar`. Returns
+        ``0.0`` for a series with fewer than two points (short-series policy).
+
+        Parameters
+        ----------
+        period : int, optional
+            Periods per year. Default ``252``.
+
+        Returns
+        -------
+        float
+            The Calmar ratio, or ``0.0`` for a too-short series.
+
+        """
+        if len(self._equity) < 2:
+            return 0.0
+        return perf.calmar(self._equity, period=period)

--- a/trading_bot/tests/application/test_performance_service.py
+++ b/trading_bot/tests/application/test_performance_service.py
@@ -1,0 +1,356 @@
+"""Tests for the :class:`~trading_bot.application.performance_service.PerformanceService`.
+
+These prove the service's read-side performance contract:
+
+* a known fill sequence (buy, add, partial close, **flip**, across one *and* two
+  instruments) folds to ``realised_pnl()`` / ``fees_paid()`` that match
+  hand-computed ``Decimal`` values and equal the sum of
+  :meth:`~trading_bot.domain.position.Position.from_fills` per instrument;
+* ``equity_curve()`` matches a hand-built ``v0 + cumulative realised PnL`` series;
+* the KPI methods delegate to :mod:`trading_bot.domain.performance` over the
+  equity curve and equal calling those functions directly (they **run** — fynance
+  is installed in the venv);
+* the short-series policy: 0 or 1 fills -> every KPI returns ``0.0``, no raise;
+* ``EventBus`` subscription drives the view (other events are ignored);
+* an end-to-end run where an
+  :class:`~trading_bot.application.order_router.OrderRouter` submits to a
+  :class:`~trading_bot.brokers.paper.PaperBroker` whose emitted fills update the
+  service, with realised PnL + equity endpoint + KPIs checked against an
+  independent computation from the broker's reported fills.
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from trading_bot.application import (
+    EventBus,
+    FillEvent,
+    LogEvent,
+    OrderRouter,
+    PerformanceService,
+)
+from trading_bot.brokers import PaperBroker
+from trading_bot.domain import (
+    Fill,
+    Instrument,
+    Order,
+    OrderSide,
+    OrderType,
+    Position,
+    Symbol,
+    money,
+)
+from trading_bot.domain import performance as perf
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+ETH_USD = Instrument(Symbol("ETH", "USD"))
+
+
+def _fill(
+    *,
+    fill_id: str,
+    side: OrderSide,
+    qty: str,
+    price: str,
+    fee: str = "0",
+    ts: int = 1,
+    instrument: Instrument = BTC_USD,
+    cid: str = "cid-1",
+) -> Fill:
+    return Fill(
+        fill_id=fill_id,
+        client_order_id=cid,
+        instrument=instrument,
+        side=side,
+        qty=money(qty),
+        price=money(price),
+        fee=money(fee),
+        ts=ts,
+    )
+
+
+# --- empty / short state --------------------------------------------------- #
+
+
+def test_empty_service_is_flat() -> None:
+    """A fresh service has zero PnL/fees, an empty curve, and no positions."""
+    svc = PerformanceService(v0=money("1000"))
+    assert svc.realised_pnl() == Decimal("0")
+    assert svc.fees_paid() == Decimal("0")
+    assert svc.equity_curve() == ()
+    assert svc.position(BTC_USD) is None
+
+
+def test_short_series_kpis_return_zero_no_raise() -> None:
+    """0 or 1 fills (< 2 equity points) -> every KPI is the safe value 0.0."""
+    svc = PerformanceService(v0=money("1000"))
+    # Zero fills.
+    assert svc.sharpe() == 0.0
+    assert svc.sortino() == 0.0
+    assert svc.max_drawdown() == 0.0
+    assert svc.calmar() == 0.0
+
+    # One fill -> one equity point -> still no return to measure.
+    svc.apply(_fill(fill_id="T1", side=OrderSide.BUY, qty="1", price="30000", fee="6"))
+    assert len(svc.equity_curve()) == 1
+    assert svc.sharpe() == 0.0
+    assert svc.sortino() == 0.0
+    assert svc.max_drawdown() == 0.0
+    assert svc.calmar() == 0.0
+
+
+# --- realised PnL / fees / equity over a known single-instrument sequence --- #
+
+
+def test_single_instrument_pnl_fees_equity_hand_computed() -> None:
+    """buy -> add -> partial close -> flip: PnL/fees/equity match by hand.
+
+    Sequence (all BTC/USD), fee 0 to keep the gross numbers clean except where
+    noted:
+
+    * F1 BUY  2 @ 30000 fee 6   -> long 2 @ 30000, realised -6 (fee)
+    * F2 BUY  1 @ 33000 fee 3   -> long 3 @ 31000, realised -9 (fees)
+    * F3 SELL 1 @ 35000 fee 0   -> close 1 of the long: (35000-31000)*1 = +4000
+                                   realised -9 + 4000 = 3991
+    * F4 SELL 4 @ 36000 fee 0   -> flip: close remaining long 2:
+                                   (36000-31000)*2 = +10000; realised 3991+10000
+                                   = 13991; remainder 2 opens short @ 36000.
+    """
+    fills = [
+        _fill(fill_id="F1", side=OrderSide.BUY, qty="2", price="30000", fee="6"),
+        _fill(fill_id="F2", side=OrderSide.BUY, qty="1", price="33000", fee="3"),
+        _fill(fill_id="F3", side=OrderSide.SELL, qty="1", price="35000", fee="0"),
+        _fill(fill_id="F4", side=OrderSide.SELL, qty="4", price="36000", fee="0"),
+    ]
+    svc = PerformanceService(v0=money("100000"))
+    for f in fills:
+        svc.apply(f)
+
+    # Hand-computed totals.
+    assert svc.realised_pnl() == Decimal("13991")
+    assert svc.fees_paid() == Decimal("9")
+
+    # Consistent with Position.from_fills over the whole instrument sequence.
+    pos = Position.from_fills(fills)
+    assert svc.realised_pnl() == pos.realised_pnl
+    assert svc.fees_paid() == pos.fees_paid
+
+    # Equity curve = v0 + cumulative realised PnL, one point per fill.
+    # Running realised PnL: -6, -9, 3991, 13991.
+    assert svc.equity_curve() == (
+        Decimal("99994"),   # 100000 - 6
+        Decimal("99991"),   # 100000 - 9
+        Decimal("103991"),  # 100000 + 3991
+        Decimal("113991"),  # 100000 + 13991
+    )
+
+    # position() reflects the flipped short remainder.
+    p = svc.position(BTC_USD)
+    assert p is not None
+    assert p.net_qty == Decimal("-2")
+    assert p.avg_entry_price == Decimal("36000")
+
+
+# --- aggregate across multiple instruments --------------------------------- #
+
+
+def test_multi_instrument_aggregate_equals_sum_of_positions() -> None:
+    """Two instruments interleaved: aggregate = sum of per-instrument folds."""
+    btc = [
+        _fill(fill_id="B1", side=OrderSide.BUY, qty="2", price="30000", fee="6",
+              instrument=BTC_USD, cid="btc"),
+        _fill(fill_id="B2", side=OrderSide.SELL, qty="1", price="31000", fee="3.1",
+              instrument=BTC_USD, cid="btc"),
+    ]
+    eth = [
+        _fill(fill_id="E1", side=OrderSide.BUY, qty="10", price="2000", fee="2",
+              instrument=ETH_USD, cid="eth"),
+        _fill(fill_id="E2", side=OrderSide.SELL, qty="10", price="2100", fee="2.1",
+              instrument=ETH_USD, cid="eth"),
+    ]
+    svc = PerformanceService(v0=money("0"))
+    # Interleave to prove arrival order per instrument is what is folded.
+    svc.apply(btc[0])
+    svc.apply(eth[0])
+    svc.apply(btc[1])
+    svc.apply(eth[1])
+
+    btc_pos = Position.from_fills(btc)
+    eth_pos = Position.from_fills(eth)
+    expected_realised = btc_pos.realised_pnl + eth_pos.realised_pnl
+    expected_fees = btc_pos.fees_paid + eth_pos.fees_paid
+
+    assert svc.realised_pnl() == expected_realised
+    assert svc.fees_paid() == expected_fees
+
+    # Per-instrument positions exposed independently and exactly.
+    p_btc = svc.position(BTC_USD)
+    p_eth = svc.position(ETH_USD)
+    assert p_btc is not None and p_btc.realised_pnl == btc_pos.realised_pnl
+    assert p_eth is not None and p_eth.realised_pnl == eth_pos.realised_pnl
+
+    # Equity curve: v0 + running aggregate realised PnL after each global fill.
+    # After B1: btc -6.
+    # After E1: btc -6, eth -2 -> -8.
+    # After B2: btc closes 1: (31000-30000)*1=+1000, fees -6-3.1 -> 990.9; eth -2
+    #           -> 988.9.
+    # After E2: eth closes 10: (2100-2000)*10=+1000, fees -2-2.1 -> 995.9; btc
+    #           990.9 -> 1986.8.
+    assert svc.equity_curve() == (
+        Decimal("-6"),
+        Decimal("-8"),
+        Decimal("988.9"),
+        Decimal("1986.8"),
+    )
+    # Endpoint equals total realised PnL (v0 = 0).
+    assert svc.equity_curve()[-1] == svc.realised_pnl()
+
+
+# --- KPIs delegate to domain.performance over the equity curve ------------- #
+
+
+def test_kpis_equal_domain_performance_over_equity_curve() -> None:
+    """KPI methods equal calling domain.performance directly on the curve.
+
+    A monotonic-up equity curve gives a finite, strictly-positive Sharpe and a
+    zero max drawdown — concrete assertions that prove the wrappers ran fynance.
+    """
+    # A win, a win, a bigger win across one instrument (all closes from flat).
+    fills = [
+        _fill(fill_id="F1", side=OrderSide.BUY, qty="1", price="100", fee="0"),
+        _fill(fill_id="F2", side=OrderSide.SELL, qty="1", price="110", fee="0"),
+        _fill(fill_id="F3", side=OrderSide.BUY, qty="1", price="110", fee="0"),
+        _fill(fill_id="F4", side=OrderSide.SELL, qty="1", price="125", fee="0"),
+        _fill(fill_id="F5", side=OrderSide.BUY, qty="1", price="125", fee="0"),
+        _fill(fill_id="F6", side=OrderSide.SELL, qty="1", price="150", fee="0"),
+    ]
+    svc = PerformanceService(v0=money("1000"))
+    for f in fills:
+        svc.apply(f)
+
+    curve = svc.equity_curve()
+    # Realised PnL steps: 0 (open), +10, 0 (open), +15, 0 (open), +25 -> equity
+    # 1000, 1010, 1010, 1025, 1025, 1050 (monotonic non-decreasing).
+    assert curve == (
+        Decimal("1000"),
+        Decimal("1010"),
+        Decimal("1010"),
+        Decimal("1025"),
+        Decimal("1025"),
+        Decimal("1050"),
+    )
+
+    # Each KPI method equals the domain function over the same curve.
+    assert svc.sharpe() == perf.sharpe(curve)
+    assert svc.sortino() == perf.sortino(curve)
+    assert svc.max_drawdown() == perf.max_drawdown(curve)
+    assert svc.calmar() == perf.calmar(curve)
+
+    # Concrete properties of a non-decreasing curve.
+    assert svc.sharpe() > 0.0
+    import math
+
+    assert math.isfinite(svc.sharpe())
+    assert svc.max_drawdown() == 0.0
+
+
+def test_max_drawdown_nonzero_on_dip() -> None:
+    """A curve that dips has a positive fractional max drawdown matching domain."""
+    fills = [
+        # +10 (peak), then -30 (dip), then +50 (recover).
+        _fill(fill_id="F1", side=OrderSide.BUY, qty="1", price="100", fee="0"),
+        _fill(fill_id="F2", side=OrderSide.SELL, qty="1", price="110", fee="0"),  # +10
+        _fill(fill_id="F3", side=OrderSide.BUY, qty="1", price="110", fee="0"),
+        _fill(fill_id="F4", side=OrderSide.SELL, qty="1", price="80", fee="0"),   # -30
+        _fill(fill_id="F5", side=OrderSide.BUY, qty="1", price="80", fee="0"),
+        _fill(fill_id="F6", side=OrderSide.SELL, qty="1", price="130", fee="0"),  # +50
+    ]
+    svc = PerformanceService(v0=money("1000"))
+    for f in fills:
+        svc.apply(f)
+    curve = svc.equity_curve()
+    assert svc.max_drawdown() == perf.max_drawdown(curve)
+    assert svc.max_drawdown() > 0.0
+
+
+# --- EventBus subscription -------------------------------------------------- #
+
+
+def test_event_bus_subscription_drives_view() -> None:
+    """Emitting FillEvents updates the performance view; other events ignored."""
+    bus = EventBus()
+    svc = PerformanceService(v0=money("100000"), event_bus=bus)
+
+    bus.emit(LogEvent(message="noise"))  # ignored
+    bus.emit(FillEvent(_fill(fill_id="F1", side=OrderSide.BUY, qty="1",
+                             price="30000", fee="3")))
+    bus.emit(FillEvent(_fill(fill_id="F2", side=OrderSide.SELL, qty="1",
+                             price="31000", fee="3.1")))
+
+    # close 1: (31000-30000)*1 = +1000; fees -3 -3.1 -> realised 993.9.
+    assert svc.realised_pnl() == Decimal("993.9")
+    assert svc.fees_paid() == Decimal("6.1")
+    assert svc.equity_curve() == (Decimal("99997"), Decimal("100993.9"))
+
+
+# --- verification on real data: OrderRouter -> PaperBroker -> service ------- #
+
+
+async def test_end_to_end_router_paperbroker_drives_performance() -> None:
+    """End-to-end: router -> PaperBroker -> bus -> PerformanceService.
+
+    A realistic buy -> add -> partial-close sequence is routed through the *real*
+    ``PaperBroker`` (which emits a ``FillEvent`` per simulated fill). The service,
+    subscribed to the bus, must report:
+
+    * realised PnL == sum of ``Position.from_fills`` over the broker's reported
+      fills (the source of truth);
+    * an equity endpoint == ``v0`` + that realised PnL;
+    * KPIs == ``domain.performance`` over the service's equity curve (they run —
+      fynance present).
+    """
+    bus = EventBus()
+    svc = PerformanceService(v0=money("1000000"), event_bus=bus)
+    broker = PaperBroker(
+        fill_model="immediate",
+        starting_balances={"USD": money("5000000"), "BTC": money("0")},
+        event_bus=bus,
+    )
+    router = OrderRouter(broker, bus)
+
+    def _limit(cid: str, side: OrderSide, qty: str, price: str) -> Order:
+        return Order(
+            client_order_id=cid,
+            instrument=BTC_USD,
+            side=side,
+            qty=money(qty),
+            type=OrderType.LIMIT,
+            limit_price=money(price),
+        )
+
+    await router.submit(_limit("buy-1", OrderSide.BUY, "2", "30000"))
+    await router.submit(_limit("buy-2", OrderSide.BUY, "1", "31500"))
+    await router.submit(_limit("sell-1", OrderSide.SELL, "1", "33000"))
+
+    # The broker is the source of truth for the fills.
+    broker_fills = await broker.fills()
+    assert len(broker_fills) == 3
+
+    # Independent computation from exactly those fills.
+    expected_pos = Position.from_fills(broker_fills)
+    assert svc.realised_pnl() == expected_pos.realised_pnl
+    assert svc.fees_paid() == expected_pos.fees_paid
+
+    # Equity endpoint = v0 + realised PnL.
+    curve = svc.equity_curve()
+    assert len(curve) == 3
+    assert curve[-1] == money("1000000") + expected_pos.realised_pnl
+
+    # KPIs equal domain.performance over the same curve (they ran).
+    assert svc.sharpe() == perf.sharpe(curve)
+    assert svc.max_drawdown() == perf.max_drawdown(curve)
+    # max drawdown is a finite fraction in [0, 1].
+    assert 0.0 <= svc.max_drawdown() <= 1.0


### PR DESCRIPTION
## Summary
- Second leaf of **E6**: `application/performance_service.py` — `PerformanceService`.
- Read-side: subscribes to `FillEvent`, exposes realised PnL / fees / equity curve (`v0 + cumulative realised PnL`, one point per fill) and KPIs (Sharpe/Sortino/max-drawdown/Calmar via fynance). Never trades.

## Why
- Realised PnL is additive across instruments, so an aggregate fill-driven step curve reconciles to `Position.from_fills` per instrument with no external mark prices. Short-series-safe KPIs (< 2 points → 0.0). See `doc/dev/03-decisions.md`.

## Changes
- `application/performance_service.py` (100% cov) + export; `tests/application/test_performance_service.py` (8 tests; KPI tests RUN — fynance present).

## Changelog
Added: `application.PerformanceService` — live PnL/KPI over the fill stream.

## Test plan
- [x] `.venv/bin/python -m pytest` (405 passed, 0 unexpected skips; KPI tests ran)
- [x] end-to-end via OrderRouter→PaperBroker→bus: realised PnL + equity match `Position.from_fills`; `sharpe()`/`max_drawdown()` match `domain.performance`
- [x] `ruff` + `mypy` clean