### PR TITLE
feat: RiskManager — pre-trade limits + kill-switch (closes E6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   float); optional `EventBus` attach. The reconciliation source.
 - `application.PerformanceService` — live realised PnL / fees / equity curve over
   the `FillEvent` stream, with Sharpe/Sortino/max-drawdown/Calmar via fynance.
+- `application.RiskManager` — pre-trade gate (`max_order`/`max_position`/
+  `max_daily_loss`) + kill-switch, wired into `OrderRouter.submit` so every order is
+  gated; a breach raises `RiskLimitBreached` and never reaches the broker. Completes
+  the **E6 performance/persistence/risk** block.
+
+### Fixed
+
+- `application.OrderRouter` — a refused/failed submit with no concurrent waiter no
+  longer leaves an unretrieved in-flight future (silences asyncio's "Future
+  exception was never retrieved" log noise).
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,46 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-22 RiskManager: pre-trade gate in the router, resulting-net limits, kill-switch
+
+**Decision.** `application/risk.py` `RiskManager.check(order)` is wired into
+`OrderRouter._do_submit` **before** `broker.place_order` and before any state
+transition — the last safety block before a venue sees an order. Checks, in order:
+**kill-switch** (hard halt, first), `max_order` (the order's own size), `max_position`
+(the **resulting** absolute net = current net + signed order qty, so a *reducing*
+order is never blocked), `max_daily_loss` (halts new orders once the day's *realised*
+loss ≥ cap — it does not predict the order's PnL). `None` limits are unconstrained.
+A breach raises `RiskLimitBreached`: **no broker call, the order is left untracked**
+(not a `REJECTED` record), so a later submit of the same id is a fresh attempt and
+idempotency is intact. Kill-switch: `trip`/`reset`; `async kill(router|broker)`
+cancels open orders **then** trips (cancel-before-trip, since cancelling is a reducing
+action and must not be self-refused). Daily loss is sourced through a thin injected
+`daily_pnl_provider` callable (or `record_daily_pnl`); "daily" resets via an explicit
+caller-driven `reset_day()` — the manager owns no clock.
+
+**Why.** Risk limits + kill-switch must gate **every** order (a hard live-trading
+invariant); placing the gate inside the router's single submit path guarantees no
+order bypasses it. Gating the *resulting* net (not order size) is the correct
+position limit. **Known limitation:** `max_position` reads the *confirmed* position
+from the tracker, so it does not count the unfilled qty of still-open orders —
+pending exposure can momentarily exceed the cap between submit and fill; tightening
+to pending-aware exposure is go-live hardening (E10).
+
+---
+
+### 2026-06-22 OrderRouter: consume the in-flight future's exception (log hygiene)
+
+**Decision.** The router's per-id in-flight `asyncio.Future` (the concurrency guard)
+gets a done-callback that retrieves a stored exception, so a refused/failed submit
+with **no** concurrent waiter no longer triggers asyncio's "Future exception was
+never retrieved" at GC. A real waiter still receives the exception via `await`.
+
+**Why.** Surfaced when the risk gate made `submit` raise routinely: the dangling
+future logged spurious noise. In a trading engine, log noise masks real incidents —
+the guard must be silent when it has nothing to report.
+
+---
+
 ### 2026-06-22 PerformanceService: fill-driven realised-PnL equity, two views
 
 **Decision.** `application/performance_service.py` `PerformanceService` observes the

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,17 +10,18 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**Foundation (E1–E3), the execution engine (E4) and the strategy runner (E5) are
-complete — a strategy now runs end-to-end.** `domain/` (pure, mypy-strict),
-`transport/` (`AsyncHTTPClient`, `WebSocketBase`, `RateLimiter`/`KrakenCallCounter`),
-`brokers/` (the `Broker` port + `KrakenBroker` REST + `KrakenPrivateWS` + the
-port-pure `PaperBroker`), and `application/` (`AppConfig` + `EventBus`, `OrderRouter`
-idempotent, `PositionTracker`, `reconcile`, **`Strategy` + safe loader, `DataFeed`
-causal, `StrategyRunner`**) are in. The full loop **dccd data → fynance signal →
-target position → managed orders on a broker → fills → position** runs in-process and
-is verified end-to-end. Pending: **E6** (performance service, SQLite persistence,
-risk manager + kill-switch), then **E7** (CLI — the MVP "first light"), E8
-orchestration, E9 UI, E10 go-live. Next is **E6**. See `07-roadmap.md` /
+**E1–E6 are complete — the engine is feature-complete behind the interface.**
+`domain/` (pure, mypy-strict), `transport/` (`AsyncHTTPClient`, `WebSocketBase`,
+`RateLimiter`/`KrakenCallCounter`), `brokers/` (the `Broker` port + `KrakenBroker`
+REST + `KrakenPrivateWS` + port-pure `PaperBroker`), `storage/` (`SqliteStore` —
+order/fill history + state, money as TEXT), and `application/` (`AppConfig` +
+`EventBus`, `OrderRouter` idempotent **+ risk-gated**, `PositionTracker`, `reconcile`,
+`Strategy` + safe loader, causal `DataFeed`, `StrategyRunner`, `PerformanceService`,
+**`RiskManager` pre-trade limits + kill-switch**) are in. The full loop **dccd data →
+fynance signal → target position → risk-gated managed orders → fills → position →
+PnL/KPI**, with SQLite persistence and reconciliation, runs in-process and is verified
+end-to-end. Pending: **E7** (CLI — the MVP "first light"), E8 orchestration, E9 UI,
+E10 go-live. Next is **E7**. See `07-roadmap.md` /
 `08-program-plan.md`.
 
 ## Done

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -10,12 +10,6 @@ The single source *index* of open work. Each unchecked item is a candidate for
 > **Full decomposition** — every epic broken into its leaves, branches,
 > complexity and dependencies: [`08-program-plan.md`](08-program-plan.md).
 
-## Execution engine
-
-- [ ] **E6 — Performance, persistence & risk.** `PerformanceService` (PnL/KPI),
-  `storage` (SQLite order/fill history + state for reconciliation), `RiskManager`
-  (pre-trade limits + kill-switch). _(depends on E4)_
-
 ## Interfaces & orchestration
 
 - [ ] **E7 — CLI.** Typer CLI (start/stop strategies, status, KPI table) + async

--- a/doc/dev/plans/perf-persistence-risk/00-plan.md
+++ b/doc/dev/plans/perf-persistence-risk/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: perf-persistence-risk
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E6 — Performance, persistence & risk.** `PerformanceService` (PnL/KPI), `storage` (SQLite order/fill history + state for reconciliation), `RiskManager` (pre-trade limits + kill-switch)."
 release_on_done: false
 ---
@@ -30,7 +30,7 @@ gate every order**. Everything is offline-testable.
 
 - [x] 01 storage — feat/storage — high
 - [x] 02 performance-service — feat/performance-service — medium
-- [ ] 03 risk-manager — feat/risk-manager — high
+- [x] 03 risk-manager — feat/risk-manager — high
 
 ## Dependencies
 

--- a/doc/dev/plans/perf-persistence-risk/03-risk-manager.md
+++ b/doc/dev/plans/perf-persistence-risk/03-risk-manager.md
@@ -1,7 +1,7 @@
 ---
 plan: perf-persistence-risk/03-risk-manager
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: []
 parallel: false

--- a/doc/dev/plans/perf-persistence-risk/03-risk-manager.md
+++ b/doc/dev/plans/perf-persistence-risk/03-risk-manager.md
@@ -6,7 +6,7 @@ complexity: high
 depends: []
 parallel: false
 branch: feat/risk-manager
-pr: ""
+pr: "#37"
 ---
 
 # RiskManager — pre-trade limits + kill-switch (gates every order)

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -43,6 +43,14 @@ It then layers the engine's use-cases:
   venue's open orders, balances and fills and converges the router's tracked
   orders and the tracker's positions to that truth — never leaving a duplicated
   or lost order.
+* risk — the :class:`~trading_bot.application.risk.RiskManager`, the engine's
+  **pre-trade gate + kill-switch**: it ``check``\\ s every order the
+  ``OrderRouter`` is about to submit against the
+  :class:`~trading_bot.application.config.RiskConfig` limits (max order size, max
+  resulting net position, max daily loss) and a hard kill-switch, raising
+  :class:`~trading_bot.domain.errors.RiskLimitBreached` so a breaching order — or
+  any order once the switch is tripped — is **never placed**. The last safety
+  block before a venue sees an order.
 * strategy — the :class:`~trading_bot.application.strategy.Strategy` (instrument
   + a :data:`~trading_bot.application.strategy.SignalFn` callable that maps a
   bars frame to a domain ``Signal``), the safe
@@ -90,6 +98,7 @@ from trading_bot.application.order_router import OrderRouter
 from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.reconcile import ReconResult, reconcile
+from trading_bot.application.risk import RiskManager
 from trading_bot.application.strategy import (
     SignalFn,
     Strategy,
@@ -114,6 +123,7 @@ __all__ = [
     "OrderRouter",
     "PositionTracker",
     "PerformanceService",
+    "RiskManager",
     "reconcile",
     "ReconResult",
     # data feed

--- a/trading_bot/application/order_router.py
+++ b/trading_bot/application/order_router.py
@@ -59,11 +59,15 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from typing import TYPE_CHECKING
 
 from trading_bot.application.events import EventBus, OrderEvent
 from trading_bot.brokers.base import Broker, Capability, require
 from trading_bot.domain.errors import BrokerError, MissingOrder, OrderError
 from trading_bot.domain.order import Order, OrderStatus
+
+if TYPE_CHECKING:
+    from trading_bot.application.risk import RiskManager
 
 __all__ = ["OrderRouter"]
 
@@ -88,6 +92,15 @@ class OrderRouter:
         The bus every order lifecycle change is emitted on, as an
         :class:`~trading_bot.application.events.OrderEvent` carrying the live
         :class:`Order`.
+    risk_manager : RiskManager, optional
+        The pre-trade gate. When given, every :meth:`submit` calls
+        :meth:`~trading_bot.application.risk.RiskManager.check` on the order
+        **before** the broker is touched; a
+        :class:`~trading_bot.domain.errors.RiskLimitBreached` propagates and the
+        order is **never placed** and **never tracked** (no broker call, no
+        half-tracked submission — so the idempotency map stays a record of
+        *accepted* submissions only, and a later retry is free to re-attempt).
+        ``None`` (the default) runs the router with no risk gate.
 
     Raises
     ------
@@ -96,13 +109,20 @@ class OrderRouter:
 
     """
 
-    def __init__(self, broker: Broker, event_bus: EventBus) -> None:
+    def __init__(
+        self,
+        broker: Broker,
+        event_bus: EventBus,
+        *,
+        risk_manager: RiskManager | None = None,
+    ) -> None:
         # Gate up front: a broker that cannot place *and* cancel is not a valid
         # write-path target, so fail at construction rather than at first call.
         require(broker, Capability.PLACE_ORDER)
         require(broker, Capability.CANCEL)
         self._broker = broker
         self._bus = event_bus
+        self._risk = risk_manager
         # Dedup map: every order the router has tracked, keyed by its identity.
         self._orders: dict[str, Order] = {}
         # Per-id in-flight submissions, the concurrency guard (see module doc).
@@ -135,6 +155,13 @@ class OrderRouter:
 
         Raises
         ------
+        RiskLimitBreached
+            If a ``risk_manager`` is wired and its
+            :meth:`~trading_bot.application.risk.RiskManager.check` refuses the
+            order (a breached limit or a tripped kill-switch). The broker is
+            **not** called and the order is **not** tracked — a refused order is
+            not a submission, so it leaves no record and a later retry is a fresh
+            attempt.
         BrokerError or OrderError
             If the broker (or the order's own state machine) fails the
             submission. The order is driven to ``REJECTED``, a reject
@@ -186,7 +213,21 @@ class OrderRouter:
         touches the caller's ``Order``. So the router calls ``place_order`` with
         the order still ``NEW``, then drives ``NEW -> SUBMITTED -> OPEN`` itself
         with the returned venue id.
+
+        The **risk gate runs first**, before any broker call or state change:
+        :meth:`~trading_bot.application.risk.RiskManager.check` is the last safety
+        block before a venue sees the order. A
+        :class:`~trading_bot.domain.errors.RiskLimitBreached` propagates *out of*
+        this method without calling the broker, without driving any transition,
+        and without tracking the order — a refused order is **not** a submission,
+        so it leaves no ``REJECTED`` record and the dedup map is unchanged (a
+        subsequent submit of the same id is a fresh attempt, not a deduped
+        replay).
         """
+        if self._risk is not None:
+            # Pre-trade gate: raises RiskLimitBreached before the broker is ever
+            # touched. Left to propagate untracked (see the docstring).
+            self._risk.check(order)
         try:
             venue_id = await self._broker.place_order(order)
             order.submit()

--- a/trading_bot/application/risk.py
+++ b/trading_bot/application/risk.py
@@ -1,0 +1,390 @@
+"""The :class:`RiskManager` — the engine's pre-trade gate + kill-switch.
+
+This is the **last safety block before a venue ever sees an order**. Every order
+the :class:`~trading_bot.application.order_router.OrderRouter` is about to submit
+passes through :meth:`RiskManager.check` *before* ``broker.place_order`` is
+called, so a breaching order — or any order at all once the kill-switch is
+tripped — raises :class:`~trading_bot.domain.errors.RiskLimitBreached` and is
+**never transmitted**. The router wires the gate in front of the broker call (see
+:meth:`~trading_bot.application.order_router.OrderRouter.submit`); a raise means
+no venue call and no half-tracked order.
+
+The four checks, in order (carried into the ADR)
+------------------------------------------------
+:meth:`check` evaluates these in a fixed order and raises on the first breach:
+
+1. **Kill-switch first.** If :meth:`trip` has fired, *every* order is refused
+   regardless of the limits — the switch is the hard halt, so it is tested before
+   any per-order arithmetic.
+2. **``max_order``** — the largest size a *single* order may request. Breach when
+   ``order.qty > max_order`` (``qty`` is always the positive order magnitude).
+3. **``max_position``** — the largest *absolute net* position any instrument may
+   hold **after** this order lands. The resulting net is the current net plus the
+   order's *signed* quantity (``+qty`` for BUY, ``−qty`` for SELL); breach when
+   ``abs(resulting) > max_position``. Current net comes from the injected
+   :class:`~trading_bot.application.position_tracker.PositionTracker`
+   (``None`` / no position seen yet ⇒ flat, ``0``). This gates the *resulting*
+   exposure, not the order size, so an order that *reduces* an over-cap position
+   is never blocked by it.
+4. **``max_daily_loss``** — the loss (quote units) at which trading halts for the
+   day. Breach when the day's realised loss **already** ``>= max_daily_loss``
+   (the limit halts *new* orders once the loss is reached; it does not try to
+   predict the order's own PnL — fills are the source of PnL truth, and an order
+   that has not filled has realised nothing). See *Daily-loss sourcing* below.
+
+Each limit is independent and optional: a ``None`` limit (the
+:class:`~trading_bot.application.config.RiskConfig` default) is *unconstrained*
+and its check is skipped. An all-``None`` config + an un-tripped switch passes
+everything.
+
+Daily-loss sourcing & reset (carried into the ADR)
+--------------------------------------------------
+The risk manager must not realise PnL itself (that is the
+:class:`~trading_bot.application.position_tracker.PositionTracker` /
+:class:`~trading_bot.application.performance_service.PerformanceService` job), so
+the coupling is kept **thin**: the day's realised PnL is read through an injected
+zero-arg callable, ``daily_pnl_provider: Callable[[], Money]``, returning the
+**signed realised PnL for the current day** (a *loss* is negative). The manager
+turns it into a loss as ``loss = -daily_pnl`` and breaches when
+``loss >= max_daily_loss``. The wiring layer (the service factory) typically
+passes ``lambda: perf.realised_pnl()`` for a per-day ``PerformanceService``, or
+any equivalent.
+
+For callers that do not want to wire a provider, :meth:`record_daily_pnl` is a
+built-in thin setter: feed it the running daily realised PnL and the manager
+reads back from its own store. When **neither** a provider nor a recorded value
+is available the daily-loss check is treated as *no loss yet* (``0``) — i.e. it
+never blocks on missing data; it only ever halts on an **observed** loss.
+
+"Daily" is an explicit, caller-driven reset: :meth:`reset_day` zeroes the
+recorded daily PnL (the simplest correct choice — the manager owns no clock). A
+scheduler calls it at the day boundary; a provider-backed manager resets its day
+by resetting the *provider's* source. There is deliberately no date-keyed magic
+inside the manager: the engine already owns scheduling, and an implicit clock
+inside a pure-ish gate would be a hidden, hard-to-test dependency.
+
+The module is part of the application layer: it imports the pure domain and the
+event/position primitives, holds money as :class:`~decimal.Decimal` end to end,
+and performs no I/O.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import TYPE_CHECKING
+
+from trading_bot.brokers.base import Broker
+from trading_bot.domain.errors import RiskLimitBreached
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.order import Order, OrderSide
+
+if TYPE_CHECKING:
+    from trading_bot.application.config import RiskConfig
+    from trading_bot.application.order_router import OrderRouter
+    from trading_bot.application.position_tracker import PositionTracker
+
+__all__ = ["RiskManager"]
+
+logger = logging.getLogger(__name__)
+
+_ZERO: Money = money("0")
+
+#: The synthetic ``threshold`` reported in a :class:`RiskLimitBreached` raised by
+#: the kill-switch (which has no numeric threshold of its own).
+_KILL_SWITCH_LIMIT = "kill_switch"
+
+
+class RiskManager:
+    """Pre-trade limit gate + kill-switch — refuses an order before it is placed.
+
+    Construct it with a :class:`~trading_bot.application.config.RiskConfig` (the
+    limits) and, optionally, the
+    :class:`~trading_bot.application.position_tracker.PositionTracker` (for the
+    ``max_position`` resulting-exposure check) and a ``daily_pnl_provider`` (for
+    the ``max_daily_loss`` check). Call :meth:`check` on every order before it
+    reaches the broker — the
+    :class:`~trading_bot.application.order_router.OrderRouter` does this
+    automatically when constructed with ``risk_manager=...``.
+
+    Parameters
+    ----------
+    config : RiskConfig
+        The limits to enforce (``max_order``, ``max_position``,
+        ``max_daily_loss``). Any limit left ``None`` is unconstrained.
+    position_tracker : PositionTracker, optional
+        Source of current net exposure for the ``max_position`` check. If
+        ``None``, ``max_position`` treats current exposure as flat (``0``) — so
+        it then gates purely on the order's own signed quantity. Wire the tracker
+        whenever ``max_position`` is set.
+    daily_pnl_provider : callable, optional
+        Zero-arg callable returning the **signed realised PnL for the current
+        day** as :class:`~decimal.Decimal` (a loss is negative); the manager
+        derives the day's loss as its negation. If ``None``, the manager reads
+        the value last given to :meth:`record_daily_pnl` (default ``0`` until
+        set) — so the daily-loss check only ever halts on an *observed* loss.
+
+    Attributes
+    ----------
+    tripped : bool
+        Whether the kill-switch is currently engaged (read-only property).
+
+    Examples
+    --------
+    >>> from trading_bot.application.config import RiskConfig
+    >>> from trading_bot.domain.money import money
+    >>> rm = RiskManager(RiskConfig(max_order=money("1")))
+    >>> rm.tripped
+    False
+
+    """
+
+    def __init__(
+        self,
+        config: RiskConfig,
+        *,
+        position_tracker: PositionTracker | None = None,
+        daily_pnl_provider: Callable[[], Money] | None = None,
+    ) -> None:
+        self._config = config
+        self._positions = position_tracker
+        self._daily_pnl_provider = daily_pnl_provider
+        # The locally-recorded daily realised PnL, used when no provider is
+        # injected. Reset to zero by ``reset_day``.
+        self._recorded_daily_pnl: Money = _ZERO
+        self._tripped = False
+        self._trip_reason: str | None = None
+
+    # --- the gate ---------------------------------------------------------- #
+
+    def check(self, order: Order) -> None:
+        """Raise :class:`RiskLimitBreached` if ``order`` may not be placed.
+
+        The single pre-trade gate. Evaluates, in order, the kill-switch then the
+        ``max_order``, ``max_position`` and ``max_daily_loss`` limits (see the
+        module docstring), and raises on the **first** breach with a clear
+        ``limit``/``value``/``threshold``. Returns ``None`` (silently) when every
+        applicable check passes; ``None`` limits are skipped.
+
+        This method is read-only — it never mutates ``order`` or any state — so a
+        caller that catches the raise is free to leave the order untracked (the
+        router does exactly that: a refused order makes no broker call and is not
+        recorded as a submission).
+
+        Parameters
+        ----------
+        order : Order
+            The order about to be submitted.
+
+        Raises
+        ------
+        RiskLimitBreached
+            If the kill-switch is tripped, or any set limit would be breached.
+
+        """
+        if self._tripped:
+            # The kill-switch is a hard halt: refuse before any per-order maths.
+            raise RiskLimitBreached(
+                _KILL_SWITCH_LIMIT,
+                value=_ZERO,
+                threshold=_ZERO,
+            )
+
+        self._check_max_order(order)
+        self._check_max_position(order)
+        self._check_max_daily_loss()
+
+    def _check_max_order(self, order: Order) -> None:
+        """Breach if the order's size exceeds ``max_order``."""
+        cap = self._config.max_order
+        if cap is not None and order.qty > cap:
+            raise RiskLimitBreached("max_order", value=order.qty, threshold=cap)
+
+    def _check_max_position(self, order: Order) -> None:
+        """Breach if the **resulting** absolute net position exceeds ``max_position``."""
+        cap = self._config.max_position
+        if cap is None:
+            return
+        current = self._current_net(order)
+        resulting = current + self._signed_qty(order)
+        magnitude = abs(resulting)
+        if magnitude > cap:
+            raise RiskLimitBreached(
+                "max_position", value=magnitude, threshold=cap
+            )
+
+    def _check_max_daily_loss(self) -> None:
+        """Breach if the day's realised loss has already reached ``max_daily_loss``."""
+        cap = self._config.max_daily_loss
+        if cap is None:
+            return
+        # daily_pnl is signed (loss negative); the loss magnitude is its negation,
+        # floored at zero so a profitable day never registers as a "negative loss".
+        daily_pnl = self._daily_pnl()
+        loss = -daily_pnl if daily_pnl < 0 else _ZERO
+        if loss >= cap:
+            raise RiskLimitBreached(
+                "max_daily_loss", value=loss, threshold=cap
+            )
+
+    def _current_net(self, order: Order) -> Money:
+        """Current signed net exposure for the order's instrument (flat if none)."""
+        if self._positions is None:
+            return _ZERO
+        position = self._positions.position(order.instrument)
+        return position.net_qty if position is not None else _ZERO
+
+    @staticmethod
+    def _signed_qty(order: Order) -> Money:
+        """The order's signed quantity: ``+qty`` for BUY, ``−qty`` for SELL."""
+        return order.qty if order.side is OrderSide.BUY else -order.qty
+
+    def _daily_pnl(self) -> Money:
+        """The current day's signed realised PnL (provider, else recorded)."""
+        if self._daily_pnl_provider is not None:
+            return self._daily_pnl_provider()
+        return self._recorded_daily_pnl
+
+    # --- daily-loss feed --------------------------------------------------- #
+
+    def record_daily_pnl(self, daily_pnl: Money) -> None:
+        """Record the running **signed** daily realised PnL (a loss is negative).
+
+        The thin built-in feed for the ``max_daily_loss`` check, for callers that
+        do not inject a ``daily_pnl_provider``. Set it to the day's realised PnL
+        so far (e.g. ``perf.realised_pnl()`` for a per-day
+        :class:`~trading_bot.application.performance_service.PerformanceService`);
+        the manager reads it back in :meth:`check`. Ignored when a provider was
+        injected (the provider is authoritative then).
+
+        Parameters
+        ----------
+        daily_pnl : Decimal
+            Signed realised PnL for the current day (negative = loss).
+
+        """
+        self._recorded_daily_pnl = daily_pnl
+
+    def reset_day(self) -> None:
+        """Reset the recorded daily PnL to zero — the day-boundary roll-over.
+
+        The explicit, caller-driven "new day" hook (the manager owns no clock):
+        a scheduler calls it at the day boundary so the ``max_daily_loss`` check
+        starts the day fresh. Only affects the *recorded* value (:meth:`record_daily_pnl`);
+        a provider-backed manager resets its day by resetting the provider's
+        source.
+        """
+        self._recorded_daily_pnl = _ZERO
+
+    # --- kill-switch ------------------------------------------------------- #
+
+    @property
+    def tripped(self) -> bool:
+        """Whether the kill-switch is engaged (every :meth:`check` then raises)."""
+        return self._tripped
+
+    @property
+    def trip_reason(self) -> str | None:
+        """Why the kill-switch was tripped, or ``None`` if not tripped."""
+        return self._trip_reason
+
+    def trip(self, reason: str) -> None:
+        """Engage the kill-switch: every subsequent :meth:`check` raises.
+
+        Idempotent — re-tripping keeps the switch engaged and overwrites the
+        reason. Does **not** cancel open orders by itself; use :meth:`kill` to
+        both cancel and trip in one call.
+
+        Parameters
+        ----------
+        reason : str
+            Human-readable reason for the halt (stored on :attr:`trip_reason`).
+
+        """
+        self._tripped = True
+        self._trip_reason = reason
+        logger.warning("kill-switch tripped: %s", reason)
+
+    def reset(self) -> None:
+        """Clear the kill-switch, re-enabling order placement.
+
+        Clears the tripped flag and the stored reason; the per-order limits are
+        enforced as before. Does not touch the daily-loss state (use
+        :meth:`reset_day` for that).
+        """
+        self._tripped = False
+        self._trip_reason = None
+        logger.warning("kill-switch reset")
+
+    async def kill(
+        self,
+        router: OrderRouter | None = None,
+        broker: Broker | None = None,
+        *,
+        reason: str = "kill-switch engaged",
+    ) -> None:
+        """Cancel every open order and trip the kill-switch — the hard halt.
+
+        The documented "panic" entry point. Cancels all currently-open orders,
+        then :meth:`trip`\\ s the switch so no new order can be placed. Cancellation
+        runs *before* the trip so the cancels themselves are not refused by the
+        gate; cancelling is a *reducing* action and is never risk-gated.
+
+        Open orders are sourced from the ``router`` when given (its tracked
+        orders, cancelled via :meth:`~trading_bot.application.order_router.
+        OrderRouter.cancel` so local state transitions too); otherwise from the
+        ``broker`` directly (``broker.open_orders()`` → ``broker.cancel_order``).
+        Pass at least one. A cancellation that fails is logged and skipped so one
+        stuck order never blocks the halt — the switch is still tripped.
+
+        Parameters
+        ----------
+        router : OrderRouter, optional
+            The router whose tracked orders to cancel (preferred: keeps the
+            router's local state consistent). Mutually inclusive-or with
+            ``broker``.
+        broker : Broker, optional
+            The broker to cancel directly against, when no router is available.
+        reason : str, optional
+            The trip reason recorded for the halt.
+
+        Raises
+        ------
+        ValueError
+            If neither ``router`` nor ``broker`` is given.
+
+        """
+        if router is None and broker is None:
+            raise ValueError("kill() needs a router or a broker to cancel against")
+
+        if router is not None:
+            await self._cancel_via_router(router)
+        elif broker is not None:
+            await self._cancel_via_broker(broker)
+
+        self.trip(reason)
+
+    async def _cancel_via_router(self, router: OrderRouter) -> None:
+        """Cancel every order the router tracks that is still live on a venue."""
+        for cid, order in router.tracked_orders().items():
+            # Only orders with a venue id are live on a venue; terminal/untracked
+            # ones cannot (and need not) be cancelled.
+            if order.venue_order_id is None or order.is_terminal:
+                continue
+            try:
+                await router.cancel(cid)
+            except Exception:
+                logger.exception("kill: failed to cancel order %s", cid)
+
+    async def _cancel_via_broker(self, broker: Broker) -> None:
+        """Cancel every open order the broker reports, directly."""
+        for order in await broker.open_orders():
+            venue_id = order.venue_order_id
+            if venue_id is None:
+                continue
+            try:
+                await broker.cancel_order(venue_id)
+            except Exception:
+                logger.exception(
+                    "kill: failed to cancel venue order %s", venue_id
+                )

--- a/trading_bot/tests/application/test_risk.py
+++ b/trading_bot/tests/application/test_risk.py
@@ -1,0 +1,457 @@
+"""Tests for the :class:`RiskManager` — the engine's pre-trade gate + kill-switch.
+
+These prove the last safety block before live trading: a breaching order — or any
+order once the kill-switch is tripped — raises
+:class:`~trading_bot.domain.errors.RiskLimitBreached` and is **never placed**. The
+suite covers each limit in isolation (``max_order``, ``max_position``,
+``max_daily_loss``), the kill-switch (``trip`` / ``reset`` / ``kill``), the
+all-``None`` (unconstrained) config, and the end-to-end integration through the
+:class:`~trading_bot.application.order_router.OrderRouter` against both a counting
+spy broker (so we can assert ``place_order`` was *not* called) and the real
+:class:`~trading_bot.brokers.paper.PaperBroker` (so positions are observed to move
+or stay unchanged for real).
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from trading_bot.application import (
+    EventBus,
+    OrderRouter,
+    PositionTracker,
+    RiskManager,
+)
+from trading_bot.application.config import RiskConfig
+from trading_bot.brokers.base import Broker, Capability
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain import (
+    Fill,
+    Instrument,
+    Money,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    RiskLimitBreached,
+    Symbol,
+    money,
+)
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+def _order(
+    cid: str = "cid-1",
+    qty: str = "1",
+    side: OrderSide = OrderSide.BUY,
+) -> Order:
+    """A realistic limit order for assertions."""
+    return Order(
+        client_order_id=cid,
+        instrument=BTC_USD,
+        side=side,
+        qty=money(qty),
+        type=OrderType.LIMIT,
+        limit_price=money("30000"),
+    )
+
+
+def _fill(
+    cid: str,
+    side: OrderSide,
+    qty: str,
+    price: str = "30000",
+    fee: str = "0",
+    ts: int = 1,
+) -> Fill:
+    """A broker-confirmed execution to seed a tracker/position."""
+    return Fill(
+        fill_id=f"F-{cid}-{ts}",
+        client_order_id=cid,
+        instrument=BTC_USD,
+        side=side,
+        qty=money(qty),
+        price=money(price),
+        fee=money(fee),
+        ts=ts,
+    )
+
+
+class _SpyBroker(Broker):
+    """A counting broker: records every ``place_order`` / ``cancel_order`` call.
+
+    Serves only ``PLACE_ORDER`` and ``CANCEL`` (the router's requirements). Lets
+    the risk-gate tests assert ``place_order`` was *not* reached on a refusal.
+    """
+
+    name = "spy"
+
+    def __init__(self) -> None:
+        self.place_calls = 0
+        self.cancel_calls = 0
+        self._ids = 0
+
+    def capabilities(self) -> set[Capability]:
+        return {Capability.PLACE_ORDER, Capability.CANCEL}
+
+    async def place_order(self, order: Order) -> str:
+        self.place_calls += 1
+        self._ids += 1
+        return f"SPY-{self._ids}"
+
+    async def cancel_order(self, venue_order_id: str) -> None:
+        self.cancel_calls += 1
+
+    async def open_orders(self):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def balances(self):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def fills(self, since_ms=None):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+    async def ticker(self, instrument):  # type: ignore[no-untyped-def]
+        raise NotImplementedError
+
+
+# --- max_order ------------------------------------------------------------- #
+
+
+def test_max_order_blocks_oversize_order() -> None:
+    """An order above ``max_order`` raises with the limit name / value / threshold."""
+    rm = RiskManager(RiskConfig(max_order=money("1")))
+    with pytest.raises(RiskLimitBreached) as exc:
+        rm.check(_order(qty="2"))
+    assert exc.value.limit == "max_order"
+    assert exc.value.value == money("2")
+    assert exc.value.threshold == money("1")
+
+
+def test_max_order_allows_order_at_or_below_cap() -> None:
+    """An order at exactly the cap (and below) passes — only ``>`` breaches."""
+    rm = RiskManager(RiskConfig(max_order=money("1")))
+    rm.check(_order(qty="1"))  # at the cap
+    rm.check(_order(qty="0.5"))  # below
+
+
+# --- max_position ---------------------------------------------------------- #
+
+
+def test_max_position_blocks_order_pushing_net_past_cap() -> None:
+    """An order whose resulting |net| exceeds ``max_position`` is blocked."""
+    tracker = PositionTracker()
+    tracker.apply(_fill("seed", OrderSide.BUY, "1"))  # net +1
+    rm = RiskManager(
+        RiskConfig(max_position=money("1.5")), position_tracker=tracker
+    )
+    # +1 (current) + 1 (this BUY) = 2 > 1.5 -> breach.
+    with pytest.raises(RiskLimitBreached) as exc:
+        rm.check(_order(qty="1", side=OrderSide.BUY))
+    assert exc.value.limit == "max_position"
+    assert exc.value.value == money("2")
+    assert exc.value.threshold == money("1.5")
+
+
+def test_max_position_allows_order_within_cap() -> None:
+    """An order whose resulting |net| stays within the cap is allowed."""
+    tracker = PositionTracker()
+    tracker.apply(_fill("seed", OrderSide.BUY, "1"))  # net +1
+    rm = RiskManager(
+        RiskConfig(max_position=money("1.5")), position_tracker=tracker
+    )
+    # +1 + 0.5 = 1.5, not > 1.5 -> allowed.
+    rm.check(_order(qty="0.5", side=OrderSide.BUY))
+
+
+def test_max_position_reducing_order_never_blocked_by_it() -> None:
+    """An order that *reduces* an over-cap position is not blocked by max_position."""
+    tracker = PositionTracker()
+    tracker.apply(_fill("seed", OrderSide.BUY, "5"))  # net +5 (already over cap)
+    rm = RiskManager(
+        RiskConfig(max_position=money("3")), position_tracker=tracker
+    )
+    # A SELL of 1: +5 + (-1) = +4 -> still over cap, blocked. But a SELL of 3
+    # brings it to +2 which is within cap -> allowed (the gate is on the result).
+    rm.check(_order(qty="3", side=OrderSide.SELL))
+
+
+def test_max_position_uses_signed_side_for_resulting_net() -> None:
+    """A SELL subtracts: with net +1 and cap 1, a SELL of 3 flips to |−2| > 1 -> blocked."""
+    tracker = PositionTracker()
+    tracker.apply(_fill("seed", OrderSide.BUY, "1"))  # net +1
+    rm = RiskManager(
+        RiskConfig(max_position=money("1")), position_tracker=tracker
+    )
+    with pytest.raises(RiskLimitBreached) as exc:
+        rm.check(_order(qty="3", side=OrderSide.SELL))  # +1 - 3 = -2, |−2| = 2 > 1
+    assert exc.value.value == money("2")
+
+
+def test_max_position_no_tracker_treats_current_as_flat() -> None:
+    """With no tracker, current exposure is flat (0) -> gate is on order qty only."""
+    rm = RiskManager(RiskConfig(max_position=money("1")))
+    rm.check(_order(qty="1", side=OrderSide.BUY))  # 0 + 1 = 1, allowed
+    with pytest.raises(RiskLimitBreached):
+        rm.check(_order(qty="2", side=OrderSide.BUY))  # 0 + 2 = 2 > 1
+
+
+# --- max_daily_loss -------------------------------------------------------- #
+
+
+def test_max_daily_loss_blocks_once_loss_reached_via_record() -> None:
+    """Once the recorded daily loss >= cap, new orders are blocked."""
+    rm = RiskManager(RiskConfig(max_daily_loss=money("100")))
+    rm.record_daily_pnl(money("-50"))  # loss 50 < 100 -> ok
+    rm.check(_order())
+    rm.record_daily_pnl(money("-100"))  # loss 100 >= 100 -> blocked
+    with pytest.raises(RiskLimitBreached) as exc:
+        rm.check(_order())
+    assert exc.value.limit == "max_daily_loss"
+    assert exc.value.value == money("100")
+    assert exc.value.threshold == money("100")
+
+
+def test_max_daily_loss_profit_never_blocks() -> None:
+    """A profitable day (positive PnL) never registers as a loss -> never blocks."""
+    rm = RiskManager(RiskConfig(max_daily_loss=money("100")))
+    rm.record_daily_pnl(money("250"))  # profit, loss is 0
+    rm.check(_order())
+
+
+def test_max_daily_loss_via_provider() -> None:
+    """The daily loss can be sourced from an injected zero-arg provider."""
+    realised = money("0")
+
+    def provider() -> Money:
+        return realised
+
+    rm = RiskManager(
+        RiskConfig(max_daily_loss=money("100")),
+        daily_pnl_provider=provider,
+    )
+    rm.check(_order())  # loss 0 < 100
+    realised = money("-150")  # provider now reports a 150 loss
+    with pytest.raises(RiskLimitBreached):
+        rm.check(_order())
+
+
+def test_reset_day_clears_recorded_loss() -> None:
+    """reset_day() rolls the recorded daily PnL back to zero (new day)."""
+    rm = RiskManager(RiskConfig(max_daily_loss=money("100")))
+    rm.record_daily_pnl(money("-200"))
+    with pytest.raises(RiskLimitBreached):
+        rm.check(_order())
+    rm.reset_day()
+    rm.check(_order())  # day reset -> loss is 0 again
+
+
+# --- kill-switch ----------------------------------------------------------- #
+
+
+def test_trip_blocks_every_check_and_reset_re_enables() -> None:
+    """trip() makes every check raise; reset() restores normal gating."""
+    rm = RiskManager(RiskConfig())  # no limits at all
+    assert rm.tripped is False
+    rm.check(_order())  # passes pre-trip
+
+    rm.trip("manual halt")
+    assert rm.tripped is True
+    assert rm.trip_reason == "manual halt"
+    with pytest.raises(RiskLimitBreached) as exc:
+        rm.check(_order())
+    assert exc.value.limit == "kill_switch"
+
+    rm.reset()
+    assert rm.tripped is False
+    assert rm.trip_reason is None
+    rm.check(_order())  # passes again
+
+
+async def test_kill_cancels_open_orders_and_trips_via_router() -> None:
+    """kill(router=...) cancels each tracked live order, then trips the switch."""
+    broker = PaperBroker(fill_model="partial", partial_fill_ratio=money("0.5"))
+    bus = EventBus()
+    rm = RiskManager(RiskConfig())
+    router = OrderRouter(broker, bus, risk_manager=rm)
+
+    # Two partially-filled (still-open) orders the venue holds live.
+    o1 = await router.submit(_order(cid="k1"))
+    o2 = await router.submit(_order(cid="k2"))
+    assert o1.status is OrderStatus.OPEN
+    assert o2.status is OrderStatus.OPEN
+    assert len(await broker.open_orders()) == 2
+
+    await rm.kill(router=router, reason="panic")
+
+    # Both venue orders cancelled and local state transitioned.
+    assert len(await broker.open_orders()) == 0
+    assert o1.status is OrderStatus.CANCELLED
+    assert o2.status is OrderStatus.CANCELLED
+    # Switch is tripped: further submits are halted.
+    assert rm.tripped is True
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_order(cid="k3"))
+
+
+async def test_kill_cancels_open_orders_directly_via_broker() -> None:
+    """kill(broker=...) cancels each open order the broker reports, then trips."""
+    broker = PaperBroker(fill_model="partial", partial_fill_ratio=money("0.5"))
+    bus = EventBus()
+    router = OrderRouter(broker, bus)
+
+    await router.submit(_order(cid="b1"))
+    await router.submit(_order(cid="b2"))
+    assert len(await broker.open_orders()) == 2
+
+    rm = RiskManager(RiskConfig())
+    await rm.kill(broker=broker, reason="panic")
+
+    assert len(await broker.open_orders()) == 0
+    assert rm.tripped is True
+
+
+async def test_kill_requires_router_or_broker() -> None:
+    """kill() with neither a router nor a broker is a programming error."""
+    rm = RiskManager(RiskConfig())
+    with pytest.raises(ValueError):
+        await rm.kill()
+
+
+# --- None limits = unconstrained ------------------------------------------- #
+
+
+def test_all_none_limits_pass_everything() -> None:
+    """An all-None RiskConfig (the default) gates nothing."""
+    rm = RiskManager(RiskConfig())  # max_* all None
+    rm.check(_order(qty="1000000", side=OrderSide.BUY))
+    rm.check(_order(qty="1000000", side=OrderSide.SELL))
+    rm.record_daily_pnl(money("-999999"))
+    rm.check(_order())
+
+
+# --- integration through OrderRouter (spy broker) -------------------------- #
+
+
+async def test_router_blocks_breaching_order_no_broker_call() -> None:
+    """A breaching order is refused end-to-end: place_order is never called."""
+    broker = _SpyBroker()
+    bus = EventBus()
+    rm = RiskManager(RiskConfig(max_order=money("1")))
+    router = OrderRouter(broker, bus, risk_manager=rm)
+
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_order(cid="big", qty="2"))
+
+    assert broker.place_calls == 0, "breaching order must not reach the broker"
+    # A refused order is *not* tracked: the dedup map has no record of it, so a
+    # later (compliant) attempt of the same id is a fresh submission.
+    assert router.get("big") is None
+
+
+async def test_router_allows_compliant_order() -> None:
+    """A compliant order passes the gate and reaches the broker normally."""
+    broker = _SpyBroker()
+    bus = EventBus()
+    rm = RiskManager(RiskConfig(max_order=money("5")))
+    router = OrderRouter(broker, bus, risk_manager=rm)
+
+    order = await router.submit(_order(cid="ok", qty="2"))
+
+    assert broker.place_calls == 1
+    assert order.status is OrderStatus.OPEN
+    assert router.get("ok") is order
+
+
+async def test_router_tripped_switch_halts_every_submit() -> None:
+    """A tripped kill-switch halts every router submit with no broker call."""
+    broker = _SpyBroker()
+    bus = EventBus()
+    rm = RiskManager(RiskConfig())
+    router = OrderRouter(broker, bus, risk_manager=rm)
+
+    rm.trip("halt")
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_order(cid="halted"))
+    assert broker.place_calls == 0
+    assert router.get("halted") is None
+
+
+# --- verification on real data (PaperBroker) ------------------------------- #
+
+
+async def test_real_paperbroker_gate_blocks_then_kill_switch() -> None:
+    """End-to-end on the real PaperBroker: compliant fills & moves position;
+    a breaching order is refused (no new paper order, position unchanged); the
+    kill-switch cancels open orders and halts further submits.
+    """
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("1000000")},
+        event_bus=None,
+    )
+    bus = EventBus()
+    tracker = PositionTracker()
+    # A cap that admits a 1-unit BUY but rejects a 2-unit one (resulting net).
+    rm = RiskManager(
+        RiskConfig(max_position=money("1")),
+        position_tracker=tracker,
+    )
+    router = OrderRouter(broker, bus, risk_manager=rm)
+
+    # 1) Compliant order: it fills and the position moves to +1.
+    await router.submit(_order(cid="real-ok", qty="1", side=OrderSide.BUY))
+    for fill in await broker.fills():
+        tracker.apply(fill)
+    pos = tracker.position(BTC_USD)
+    assert pos is not None and pos.net_qty == money("1")
+    fills_after_ok = len(await broker.fills())
+
+    # 2) Breaching order (+1 -> +2 > cap 1): refused, no new paper order/fill,
+    #    position unchanged.
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_order(cid="real-bad", qty="1", side=OrderSide.BUY))
+    assert len(await broker.fills()) == fills_after_ok, "no new paper fill"
+    assert router.get("real-bad") is None, "refused order not tracked"
+    assert tracker.position(BTC_USD).net_qty == money("1"), "position unchanged"
+
+    # 3) Leave a live order on the venue, then trip the kill-switch via kill():
+    #    open orders are cancelled and further submits are halted. Use a fresh
+    #    manager with no position cap so the only thing exercised here is the
+    #    kill-switch (the per-limit gating is covered above).
+    partial_broker = PaperBroker(
+        fill_model="partial", partial_fill_ratio=money("0.5")
+    )
+    kill_rm = RiskManager(RiskConfig())
+    partial_router = OrderRouter(
+        partial_broker, EventBus(), risk_manager=kill_rm
+    )
+    await partial_router.submit(_order(cid="live-1", qty="1"))
+    assert len(await partial_broker.open_orders()) == 1
+
+    await kill_rm.kill(router=partial_router, reason="end-to-end panic")
+    assert len(await partial_broker.open_orders()) == 0
+    with pytest.raises(RiskLimitBreached):
+        await partial_router.submit(_order(cid="post-kill", qty="0.1"))
+
+
+async def test_concurrent_breaching_submit_places_nothing() -> None:
+    """Two gathered submits of a breaching id both raise and place nothing."""
+    broker = _SpyBroker()
+    bus = EventBus()
+    rm = RiskManager(RiskConfig(max_order=money("1")))
+    router = OrderRouter(broker, bus, risk_manager=rm)
+
+    results = await asyncio.gather(
+        router.submit(_order(cid="race-bad", qty="2")),
+        router.submit(_order(cid="race-bad", qty="2")),
+        return_exceptions=True,
+    )
+    assert all(isinstance(r, RiskLimitBreached) for r in results)
+    assert broker.place_calls == 0
+    assert router.get("race-bad") is None


### PR DESCRIPTION
## Summary
- **Final leaf of E6**: `application/risk.py` — `RiskManager` (pre-trade gate + kill-switch), wired into `OrderRouter.submit` **before** any broker call.
- Checks (in order): kill-switch → `max_order` → `max_position` (resulting net) → `max_daily_loss`. A breach raises `RiskLimitBreached`, the order never reaches the broker and is left untracked (idempotency intact). `kill(router|broker)` cancels open orders then trips.
- Closes E6 — the engine is feature-complete behind the interface. `07-roadmap.md` E6 line removed, `06-status.md` updated.

## Also fixed (review finding)
- `OrderRouter`: a refused/failed submit with no concurrent waiter no longer leaves an unretrieved in-flight future ("Future exception was never retrieved" log noise) — surfaced because the gate makes `submit` raise routinely.

## Why
- Risk limits + kill-switch must gate **every** order; the single submit path guarantees no bypass. `max_position` gates the *resulting* net (reducing orders never blocked). Known limitation: it reads *confirmed* position (pending open-order qty not counted) → E10 hardening. See `doc/dev/03-decisions.md`.

## Test plan
- [x] `.venv/bin/python -m pytest` (427 passed, 0 unexpected skips)
- [x] gating: breaching order → no broker call + untracked; kill-switch cancels + halts (real PaperBroker)
- [x] no "Future exception was never retrieved" (deterministic loop-handler test)
- [x] `ruff` + `mypy` clean