### PR TITLE
fix: land OrderRouter future-exception consumer (code for the #37 ADR)

### DIFF
--- a/trading_bot/application/order_router.py
+++ b/trading_bot/application/order_router.py
@@ -74,6 +74,18 @@ __all__ = ["OrderRouter"]
 logger = logging.getLogger(__name__)
 
 
+def _consume_exception(future: "asyncio.Future[Order]") -> None:
+    """Mark a done future's exception retrieved (silences asyncio's GC warning).
+
+    Used as an in-flight future's done-callback: a submission that failed with no
+    concurrent waiter would otherwise trigger "Future exception was never
+    retrieved" at GC. Reading ``.exception()`` marks it retrieved; a real waiter
+    has already consumed it via ``await``.
+    """
+    if not future.cancelled():
+        future.exception()
+
+
 class OrderRouter:
     """Idempotent order submission + lifecycle driving over a :class:`Broker`.
 
@@ -189,6 +201,13 @@ class OrderRouter:
         # concurrently-scheduled submit of the same id finds it above.
         loop = asyncio.get_running_loop()
         future: asyncio.Future[Order] = loop.create_future()
+        # A failed submission (e.g. RiskLimitBreached, BrokerError) stores its
+        # exception on this future for any concurrent waiter. When there is *no*
+        # waiter, asyncio would log a spurious "Future exception was never
+        # retrieved" at GC — log noise that, in a trading engine, can mask real
+        # incidents. This callback consumes the exception so it is always marked
+        # retrieved; a real waiter still gets it via ``await`` beforehand.
+        future.add_done_callback(_consume_exception)
         self._inflight[cid] = future
         try:
             result = await self._do_submit(order)

--- a/trading_bot/tests/application/test_risk.py
+++ b/trading_bot/tests/application/test_risk.py
@@ -354,6 +354,38 @@ async def test_router_blocks_breaching_order_no_broker_call() -> None:
     assert router.get("big") is None
 
 
+async def test_breaching_submit_leaves_no_unretrieved_future() -> None:
+    """A refused submit (no concurrent waiter) logs no asyncio future warning.
+
+    The router stores a failed submission's exception on its in-flight future for
+    any concurrent waiter; with no waiter, asyncio would log "Future exception was
+    never retrieved" at GC — log noise that can mask real incidents in a trading
+    engine. The future's done-callback consumes the exception, so the loop's
+    exception handler is never invoked.
+    """
+    import gc
+
+    broker = _SpyBroker()
+    bus = EventBus()
+    rm = RiskManager(RiskConfig(max_order=money("1")))
+    router = OrderRouter(broker, bus, risk_manager=rm)
+
+    handled: list[dict[str, object]] = []
+    asyncio.get_running_loop().set_exception_handler(
+        lambda _loop, context: handled.append(context)
+    )
+
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_order(cid="big", qty="2"))
+
+    # Force collection of the (now-dropped) in-flight future, then let the loop
+    # run so any scheduled handler call would fire.
+    gc.collect()
+    await asyncio.sleep(0)
+
+    assert handled == [], f"unexpected loop exception handler calls: {handled}"
+
+
 async def test_router_allows_compliant_order() -> None:
     """A compliant order passes the gate and reaches the broker normally."""
     broker = _SpyBroker()


### PR DESCRIPTION
## Summary
Lands the **code** for a fix that #37 already documented but whose implementation was dropped from that PR by a staging mistake (the closeout `git add` staged only the docs, not `order_router.py`/`test_risk.py`). `develop`'s CHANGELOG (`### Fixed`) and the `03-decisions.md` "OrderRouter: consume the in-flight future's exception" ADR describe this fix — this PR makes the code match.

## What
- `OrderRouter`: the per-id in-flight `asyncio.Future` now gets a done-callback (`_consume_exception`) that retrieves a stored exception, so a refused/failed submit with **no concurrent waiter** no longer triggers asyncio's "Future exception was never retrieved" at GC. A real waiter still gets the exception via `await`.
- Test: `test_breaching_submit_leaves_no_unretrieved_future` — a breaching submit, with a custom loop exception handler + forced GC, records **no** handler call.

## Why it matters
Log noise masks real incidents in a trading engine; the concurrency guard must be silent when it has nothing to report.

## Test plan
- [x] `.venv/bin/python -m pytest` (427 passed, 0 unexpected skips)
- [x] the deterministic loop-handler test passes
- [x] `ruff` + `mypy` clean