### PR TITLE
docs: plan cli (E7 — the MVP)

### DIFF
--- a/doc/dev/plans/cli/00-plan.md
+++ b/doc/dev/plans/cli/00-plan.md
@@ -1,0 +1,48 @@
+---
+plan: cli
+kind: global
+status: planning
+roadmap: "- [ ] **E7 — CLI.** Typer CLI (start/stop strategies, status, KPI table) + async orchestration replacing the legacy multiprocessing server. Declare the `trading-bot` console script. Delete superseded legacy modules."
+release_on_done: false
+---
+
+# E7 — CLI & async orchestration (MVP "first light")
+
+## Goal
+
+Make the engine **runnable from a command line** — the MVP. A single
+`service_factory` wires the whole application (config → brokers → router + risk +
+tracker + perf + store), a **Typer** `trading-bot` CLI drives it (run a strategy,
+show status/KPI), and an **async orchestration** entrypoint runs one+ strategy loops
+concurrently with graceful shutdown — replacing the legacy multiprocessing
+server/clients. Finally, the now-superseded legacy modules are deleted.
+
+**Invariants**: paper-trading by default (live requires explicit opt-in + creds +
+confirmation); everything offline-testable (Typer `CliRunner` + `PaperBroker`).
+
+## Decomposition
+
+1. **cli-skeleton** — `interfaces/cli/` Typer app + `application/service_factory.py` (single wiring point) + the `trading-bot` console script.
+2. **cli-commands** — `run` / `status` / `kpi` / `version` commands (rich tables), replacing the legacy blessed CLI.
+3. **async-orchestration** — async engine lifecycle: run StrategyRunner loops concurrently + graceful shutdown.
+4. **legacy-removal** — delete the superseded `trading_bot/legacy/` modules; tidy packaging/docs/README.
+
+## Leaf checklist
+
+- [ ] 01 cli-skeleton — feat/cli-skeleton — high
+- [ ] 02 cli-commands — feat/cli-commands — medium (depends on 01)
+- [ ] 03 async-orchestration — feat/async-orchestration — high (depends on 01)
+- [ ] 04 legacy-removal — chore/remove-legacy — low (depends on 02, 03)
+
+## Dependencies
+
+- 02 and 03 both depend on 01; 04 depends on 02 + 03. Serial in the main worktree.
+
+## Done criteria
+
+- `trading-bot --help` works (console script installed); `trading-bot run <config>`
+  runs a strategy on the `PaperBroker` to completion and `status`/`kpi` report it.
+- The async orchestration runs a strategy loop with clean Ctrl-C shutdown; no
+  multiprocessing server.
+- The superseded `legacy/` modules are gone; `ruff`/`mypy`/`pytest` green via `.venv`.
+- Last leaf (04) removes the E7 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/cli/01-cli-skeleton.md
+++ b/doc/dev/plans/cli/01-cli-skeleton.md
@@ -1,0 +1,70 @@
+---
+plan: cli/01-cli-skeleton
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: feat/cli-skeleton
+pr: ""
+---
+
+# CLI skeleton — service_factory + Typer app + console script
+
+## Goal
+
+The single **wiring point** (`application/service_factory.py`) that assembles the
+whole engine from an `AppConfig`, plus a minimal **Typer** app under
+`interfaces/cli/` and the `trading-bot` console script. No business logic here —
+just construction + entrypoint.
+
+## Files to change
+
+- `trading_bot/application/service_factory.py` — new; `build_engine(config) -> Engine` (or a small wiring dataclass).
+- `trading_bot/interfaces/__init__.py`, `trading_bot/interfaces/cli/__init__.py`, `trading_bot/interfaces/cli/main.py` — new; Typer `app` with a `version` command.
+- `pyproject.toml` — add `[project.scripts] trading-bot = "trading_bot.interfaces.cli.main:app"`; add `typer`/`rich` to the `daemon` extra (and `dev` if needed for tests).
+- `trading_bot/tests/interfaces/__init__.py`, `trading_bot/tests/interfaces/test_cli_skeleton.py` — new.
+- `trading_bot/tests/application/test_service_factory.py` — new.
+
+## Steps
+
+1. Read `application/config.py` (`AppConfig`, `BrokerConfig`, `StrategyConfig`,
+   `RiskConfig`), `application/{events,order_router,position_tracker,performance_service}.py`,
+   `application/risk.py`, `application/strategy.py`, `storage/sqlite_store.py`,
+   `brokers/{base,registry,paper,kraken}.py`.
+2. `service_factory.build_engine(config, *, db_path=None)`:
+   - one `EventBus`;
+   - a broker from `config` via a registry: **`PaperBroker` by default** (paper mode);
+     `KrakenBroker` only when `config.mode == "live"` (explicit opt-in) — in this leaf,
+     constructing a live broker without creds should raise/refuse clearly (no live by
+     accident);
+   - `PositionTracker`, `PerformanceService`, `SqliteStore` (if `db_path`) all attached
+     to the bus; a `RiskManager(config.risk, position_tracker=...)`; an
+     `OrderRouter(broker, bus, risk_manager=...)`.
+   - return a small `Engine`/wiring object exposing these (bus, broker, router, tracker,
+     perf, risk, store) so the CLI/orchestration can use them. Keep it a dataclass.
+3. `interfaces/cli/main.py`: a Typer `app` with `version` (prints `trading_bot.__version__`).
+   Keep commands minimal — the real commands land in leaf 02.
+4. Add the console script + deps to `pyproject.toml`.
+
+## Tests (via `.venv`)
+
+- `build_engine(AppConfig())` (default → paper) returns an `Engine` whose broker is a
+  `PaperBroker`, with router/risk/tracker/perf wired to one bus; `db_path` set → a
+  `SqliteStore` attached.
+- `config.mode == "live"` without credentials → `build_engine` refuses clearly (no
+  accidental live broker).
+- Typer `CliRunner`: `trading-bot version` exits 0 and prints the version.
+- The console-script entry import path resolves (`trading_bot.interfaces.cli.main:app`).
+
+## Verification on real data
+
+In-process. `build_engine` a paper engine, submit one order through its `router` and
+assert a fill reaches its `tracker`/`perf` (the wiring is live end-to-end). Run the
+CLI `version` via `CliRunner`. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`service_factory` wiring + Typer `trading-bot` CLI skeleton + console script."
+- ADR: the single-wiring-point factory + paper-default broker selection (live needs opt-in).
+- Status/roadmap: deferred to leaf 04.

--- a/doc/dev/plans/cli/02-cli-commands.md
+++ b/doc/dev/plans/cli/02-cli-commands.md
@@ -1,0 +1,65 @@
+---
+plan: cli/02-cli-commands
+kind: leaf
+status: planned
+complexity: medium
+depends: [01]
+parallel: false
+branch: feat/cli-commands
+pr: ""
+---
+
+# CLI commands — run / status / kpi
+
+## Goal
+
+The user-facing Typer commands on top of the skeleton: `run` a strategy from a
+config, show `status` (positions/open orders), and a `kpi` table (PnL/KPI via
+**rich**). Replaces the legacy `blessed` CLI. Paper-by-default.
+
+## Files to change
+
+- `trading_bot/interfaces/cli/main.py` — add the commands.
+- `trading_bot/interfaces/cli/_render.py` — new (optional); rich table helpers.
+- `trading_bot/tests/interfaces/test_cli_commands.py` — new.
+- (A tiny example config + example signal reference for `run`, if helpful — reuse the E5 `ma_crossover_signal`.)
+
+## Steps
+
+1. Read `interfaces/cli/main.py` + `service_factory.build_engine` (leaf 01),
+   `application/strategy.py` (`load_strategy`), `application/data_feed.py`
+   (`InMemoryFeed`/`DccdFeed`), `application/strategy_runner.py`,
+   the legacy `legacy/cli.py` for the command set it offered (start/stop/status/KPI).
+2. `run` command: load an `AppConfig` (from a YAML path), `build_engine`, load the
+   strategy (`load_strategy(config, signal_ref)`), build a `DataFeed` (a `DccdFeed`
+   for a real run, or an `InMemoryFeed` from a bars file/fixture for offline/backtest —
+   support at least the offline path so it's testable), run the `StrategyRunner`,
+   print a short summary (orders submitted, final position). **Paper by default**;
+   `--live` must require explicit confirmation + credentials (refuse otherwise).
+3. `status` command: build/attach to an engine and print current positions + open
+   orders (rich table). For the MVP this can report a just-run in-process engine
+   (a persisted-state read can come later).
+4. `kpi` command: print a rich table of realised PnL / fees / equity / Sharpe /
+   Sortino / max-drawdown / Calmar from a `PerformanceService` over a run (or a stored
+   fill history via `SqliteStore`). Numbers formatted; money as Decimal strings.
+5. Keep all rendering in helpers so commands stay thin and testable.
+
+## Tests (via `.venv`, Typer `CliRunner`, offline)
+
+- `trading-bot run` over an `InMemoryFeed` fixture (MA-crossover strategy, paper) →
+  exits 0, prints a summary, and the position moved as expected.
+- `--live` without confirmation/creds → exits non-zero with a clear refusal (no order placed).
+- `status` prints positions/open orders (rich table) for a known engine state.
+- `kpi` prints the KPI table with the expected realised PnL for a known fill sequence.
+
+## Verification on real data
+
+In-process (offline feed + PaperBroker is the engine's real data). Run
+`trading-bot run` over a realistic OHLC fixture via `CliRunner`, then `kpi`, and
+assert the reported PnL/position match an independent computation. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`trading-bot` CLI commands — `run`/`status`/`kpi` (rich tables)."
+- ADR: the `--live` opt-in/confirmation flow, if non-trivial.
+- Status/roadmap: deferred to leaf 04.

--- a/doc/dev/plans/cli/03-async-orchestration.md
+++ b/doc/dev/plans/cli/03-async-orchestration.md
@@ -1,0 +1,63 @@
+---
+plan: cli/03-async-orchestration
+kind: leaf
+status: planned
+complexity: high
+depends: [01]
+parallel: false
+branch: feat/async-orchestration
+pr: ""
+---
+
+# Async orchestration — concurrent strategy loops + graceful shutdown
+
+## Goal
+
+The async engine lifecycle that runs **one or more** `StrategyRunner` loops
+concurrently with **graceful shutdown** (signal handling), replacing the legacy
+multiprocessing server/clients (`legacy/bot_manager.py` + `legacy/_server.py`).
+This is what `trading-bot run` drives for a live/continuous run.
+
+## Files to change
+
+- `trading_bot/application/orchestrator.py` — new; `Orchestrator` (or `run_engine`).
+- `trading_bot/application/__init__.py` — export it.
+- `trading_bot/tests/application/test_orchestrator.py` — new.
+
+## Steps
+
+1. Read `application/strategy_runner.py` (`StrategyRunner.run`), `service_factory`
+   (leaf 01), `application/events.py`, and the legacy `bot_manager.py`/`_server.py`
+   for the concept it replaces (multiple strategy clients under one manager).
+2. `Orchestrator(engine)`:
+   - `add(runner)` / accept a list of `StrategyRunner`s (one per strategy);
+   - `async run()` — run all runners **concurrently** (`asyncio.gather` / task group),
+     each over its own `DataFeed`; aggregate their completion;
+   - `async shutdown()` / a `stop_event` — request all runners to stop and await a
+     clean drain (no half-submitted state); install **SIGINT/SIGTERM** handlers (only
+     when run as the process entrypoint) that trigger `shutdown` so Ctrl-C is graceful.
+   - Surface a runner exception without silently killing the others (log + cancel
+     siblings cleanly, or use a task group's structured semantics — document).
+3. Keep signal handling optional/injectable so tests don't depend on real signals.
+
+## Tests (via `.venv`)
+
+- Two `StrategyRunner`s over two `InMemoryFeed`s run concurrently via the
+  `Orchestrator` and both reach completion; their positions update independently.
+- A `stop_event`/`shutdown()` ends a long/looping run promptly with no exception and
+  no partial submission left mid-flight.
+- A runner that raises does not leave siblings hung (documented behaviour: siblings
+  cancelled/drained, error surfaced).
+- Signal handling is exercised via the injected hook (no real SIGINT needed).
+
+## Verification on real data
+
+In-process. Orchestrate two paper strategies over realistic OHLC fixtures
+concurrently; assert both produce the expected positions and that a `shutdown()`
+mid-run stops them cleanly (final state consistent, fills all accounted). Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.Orchestrator` — concurrent strategy loops with graceful shutdown (replaces the legacy multiprocessing server)."
+- ADR: the concurrency model (gather/taskgroup) + shutdown/signal handling + per-runner failure policy.
+- Status/roadmap: deferred to leaf 04.

--- a/doc/dev/plans/cli/04-legacy-removal.md
+++ b/doc/dev/plans/cli/04-legacy-removal.md
@@ -1,0 +1,67 @@
+---
+plan: cli/04-legacy-removal
+kind: leaf
+status: planned
+complexity: low
+depends: [02, 03]
+parallel: false
+branch: chore/remove-legacy
+pr: ""
+---
+
+# Legacy removal — delete the superseded pre-2026 tree
+
+## Goal
+
+Delete the `trading_bot/legacy/` modules now fully superseded by the rewrite (the
+whole order→fill→position→strategy→CLI path exists natively), and tidy
+packaging/docs/README. The last E7 leaf — closes the E7 roadmap line and marks the
+MVP. **Reference, not deletion-by-default**: remove only what is truly superseded and
+referenced nowhere outside `legacy/`.
+
+## Files to change
+
+- `trading_bot/legacy/` — remove the superseded modules: `strategy_manager.py`,
+  `orders.py`, `orders_manager.py`, `performance.py`, `cli.py`, `bot_manager.py`,
+  `_server.py`, `_client.py`, `_connection.py`, `_containers.py`, `data_requests.py`,
+  `exchanges/`, `order/`, `tools/` (and `_exceptions.py`, `logging.ini`) — i.e. retire
+  the legacy tree once nothing live imports it.
+- `pyproject.toml` — drop the now-unneeded `--ignore=trading_bot/legacy` /
+  `legacy` excludes from pytest/ruff/mypy/coverage/interrogate config if the tree is gone.
+- `README.md`, `doc/dev/01-overview.md`, `doc/dev/02-architecture.md` — remove the
+  "parked under legacy/" framing; the rewrite is the implementation now.
+- `.gitignore`, `MANIFEST.in` — drop legacy-specific lines.
+
+## Steps
+
+1. **Prove nothing live references legacy**: grep the package (excluding
+   `legacy/` itself and tests that intentionally target it) for
+   `trading_bot.legacy` / `from trading_bot.legacy` — must be **zero** hits outside
+   legacy. If anything still imports it, STOP and surface it (that capability isn't
+   actually reimplemented yet).
+2. `git rm -r` the superseded legacy modules. If a sub-bit is still genuinely useful
+   as reference (unlikely), keep only that file with a one-line note — but default to
+   removing the lot.
+3. Remove the legacy exclusions from `pyproject.toml` tooling config and re-run all
+   gates to confirm nothing depended on the excludes.
+4. Update README + `doc/dev/01-overview.md`/`02-architecture.md` to drop the
+   "legacy parked" language (keep a one-line historical note pointing at git history).
+
+## Tests (via `.venv`)
+
+- The full suite stays green with the legacy tree gone and the excludes removed
+  (`.venv/bin/python -m pytest -q`).
+- `ruff`/`mypy` now scan the whole package (no legacy exclude) and pass.
+- A grep asserts there is no `trading_bot.legacy` import anywhere in the live package.
+
+## Verification on real data
+
+The engine's behaviour is unchanged (legacy was never imported by the live path) —
+re-run the end-to-end `trading-bot run` over an OHLC fixture and confirm identical
+results to before removal. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Removed): "Deleted the superseded pre-2026 `trading_bot/legacy/` tree (rewrite complete through the MVP CLI)."
+- ADR: note the MVP "first light" reached; the legacy reference tree retired (history in git).
+- Status/roadmap: **remove the E7 line** from `07-roadmap.md`; mark E7 done + the MVP reached in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E7 — CLI & async orchestration** — the MVP "first light": the engine becomes runnable from a command line.

## Goal
A single `service_factory` wires the whole app; a **Typer** `trading-bot` CLI drives it (`run`/`status`/`kpi`); an **async orchestration** runs strategy loops concurrently with graceful shutdown (replacing the legacy multiprocessing server); then the superseded `legacy/` tree is deleted.

## Leaves
- [ ] 01 cli-skeleton — feat/cli-skeleton — high
- [ ] 02 cli-commands — feat/cli-commands — medium (depends on 01)
- [ ] 03 async-orchestration — feat/async-orchestration — high (depends on 01)
- [ ] 04 legacy-removal — chore/remove-legacy — low (depends on 02, 03)

Paper-by-default (live needs explicit opt-in). Everything offline-testable (Typer `CliRunner` + `PaperBroker`); declares the `trading-bot` console script. typer+rich now in the venv.
After merge: `/execute-leaf cli next`.