### PR TITLE
feat: service_factory + Typer CLI skeleton + console script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `max_daily_loss`) + kill-switch, wired into `OrderRouter.submit` so every order is
   gated; a breach raises `RiskLimitBreached` and never reaches the broker. Completes
   the **E6 performance/persistence/risk** block.
+- `application.service_factory.build_engine` — single wiring point assembling the
+  whole engine (bus, broker, router+risk, tracker, perf, store) from an `AppConfig`
+  (paper-by-default; live needs credentials), plus a Typer `trading-bot` CLI skeleton
+  and the `trading-bot` console script.
 
 ### Fixed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,26 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-23 service_factory: single wiring point, no live broker by accident
+
+**Decision.** `application/service_factory.py` `build_engine(config, *, db_path=None)
+-> Engine` is the **one** place the engine is assembled: one `EventBus` shared by
+`PositionTracker`, `PerformanceService`, `OrderRouter` (holding the `RiskManager` gate)
+and (when `db_path`) `SqliteStore`. Broker selection enforces **paper-by-default** —
+`PaperBroker` unless `config.mode == "live"` **and** the configured venue
+(`KrakenBroker`) `has_credentials`; a credential-less / unknown / unconfigured live
+venue raises `BrokerError` (never a silent paper fallback, never a live broker that
+can't trade). `Engine` is a frozen dataclass the CLI/orchestration consume. The Typer
+`app` needs a no-op `@app.callback()` so a single command stays a multi-command group.
+
+**Why.** Centralising construction (order matters: tracker subscribes before fills
+flow, the router carries the gate) means the CLI, tests and a future daemon all build
+an identically-wired engine, and the interfaces layer never news-up a use-case. The
+broker rule makes the paper-default invariant structural — going live is an explicit,
+credential-checked choice. Mirrors dccd's `application` wiring.
+
+---
+
 ### 2026-06-22 RiskManager: pre-trade gate in the router, resulting-net limits, kill-switch
 
 **Decision.** `application/risk.py` `RiskManager.check(order)` is wired into

--- a/doc/dev/plans/cli/00-plan.md
+++ b/doc/dev/plans/cli/00-plan.md
@@ -29,7 +29,7 @@ confirmation); everything offline-testable (Typer `CliRunner` + `PaperBroker`).
 
 ## Leaf checklist
 
-- [ ] 01 cli-skeleton — feat/cli-skeleton — high
+- [x] 01 cli-skeleton — feat/cli-skeleton — high
 - [ ] 02 cli-commands — feat/cli-commands — medium (depends on 01)
 - [ ] 03 async-orchestration — feat/async-orchestration — high (depends on 01)
 - [ ] 04 legacy-removal — chore/remove-legacy — low (depends on 02, 03)

--- a/doc/dev/plans/cli/01-cli-skeleton.md
+++ b/doc/dev/plans/cli/01-cli-skeleton.md
@@ -1,7 +1,7 @@
 ---
 plan: cli/01-cli-skeleton
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: []
 parallel: false

--- a/doc/dev/plans/cli/01-cli-skeleton.md
+++ b/doc/dev/plans/cli/01-cli-skeleton.md
@@ -6,7 +6,7 @@ complexity: high
 depends: []
 parallel: false
 branch: feat/cli-skeleton
-pr: ""
+pr: "#40"
 ---
 
 # CLI skeleton — service_factory + Typer app + console script

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ triptych = [
 ]
 daemon = [
     "typer>=0.12",
+    "rich>=13.0",
     "uvicorn[standard]>=0.29",
     "fastapi>=0.110",
     "jinja2>=3.1",
@@ -53,6 +54,9 @@ dev = [
     "mypy>=1.0",
     "interrogate>=1.5",
     "pyyaml>=6.0",
+    # The CLI (Typer + Rich) so the unit suite / CI can import and exercise it.
+    "typer>=0.12",
+    "rich>=13.0",
 ]
 doc = [
     "sphinx>=7.0",
@@ -62,6 +66,9 @@ doc = [
     "sphinx-copybutton",
     "autodoc-pydantic>=2.0",
 ]
+
+[project.scripts]
+trading-bot = "trading_bot.interfaces.cli.main:app"
 
 [project.urls]
 Homepage = "https://github.com/ArthurBernard/Trading_Bot"

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -99,6 +99,7 @@ from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.reconcile import ReconResult, reconcile
 from trading_bot.application.risk import RiskManager
+from trading_bot.application.service_factory import Engine, build_engine
 from trading_bot.application.strategy import (
     SignalFn,
     Strategy,
@@ -139,4 +140,7 @@ __all__ = [
     # strategy runner
     "StrategyRunner",
     "OrderFactory",
+    # wiring
+    "Engine",
+    "build_engine",
 ]

--- a/trading_bot/application/service_factory.py
+++ b/trading_bot/application/service_factory.py
@@ -1,0 +1,235 @@
+"""The service factory — the engine's **single wiring point**.
+
+:func:`build_engine` is the one place the whole engine is assembled from a
+validated :class:`~trading_bot.application.config.AppConfig`. It constructs every
+use-case (the :class:`~trading_bot.application.order_router.OrderRouter`, the
+:class:`~trading_bot.application.position_tracker.PositionTracker`, the
+:class:`~trading_bot.application.performance_service.PerformanceService`, the
+:class:`~trading_bot.application.risk.RiskManager`), the
+:class:`~trading_bot.brokers.base.Broker` adapter, the shared
+:class:`~trading_bot.application.events.EventBus` and an optional
+:class:`~trading_bot.storage.sqlite_store.SqliteStore`, wires them onto **one**
+bus, and returns them packaged in a frozen :class:`Engine`.
+
+Why a single wiring point (carried into the ADR)
+------------------------------------------------
+Construction order matters — the tracker must subscribe to the bus before fills
+flow, the router must hold the risk gate, the store must attach to the same bus
+the broker emits on. Concentrating that ordering in one factory keeps every
+caller (the CLI, tests, a future daemon) building an identically-wired engine,
+and gives the codebase a single seam to evolve when a new collaborator is added.
+Mirrors dccd's ``application`` wiring: the interfaces layer never news-up a
+use-case itself; it asks the factory.
+
+Broker selection — paper by default, live only on explicit opt-in
+-----------------------------------------------------------------
+The **paper-by-default** invariant lives here. The broker is chosen by
+``config.mode`` and the configured venue:
+
+* ``mode == "paper"`` (the :class:`AppConfig` default) → always a
+  :class:`~trading_bot.brokers.paper.PaperBroker`. No venue, no key, no network
+  — a fresh config can never trade real money.
+* ``mode == "live"`` → the configured venue's adapter is built **only if it has
+  credentials**. The first :class:`~trading_bot.application.config.BrokerConfig`
+  selects the venue (``exchange``); a known live venue (``"kraken"``) without
+  credentials, an unknown venue, or no broker configured at all each raise a
+  clear :class:`~trading_bot.domain.errors.BrokerError` — the factory **never**
+  silently falls back to paper and **never** trades live by accident.
+
+A ``"paper"`` exchange entry is also honoured under either mode, so a config can
+name the simulator explicitly.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass
+
+from trading_bot.application.config import AppConfig, BrokerConfig
+from trading_bot.application.events import EventBus
+from trading_bot.application.order_router import OrderRouter
+from trading_bot.application.performance_service import PerformanceService
+from trading_bot.application.position_tracker import PositionTracker
+from trading_bot.application.risk import RiskManager
+from trading_bot.brokers.base import Broker
+from trading_bot.brokers.kraken import KrakenBroker
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain.errors import BrokerError
+from trading_bot.storage.sqlite_store import SqliteStore
+
+__all__ = ["Engine", "build_engine"]
+
+#: Venue keys recognised as live (non-simulated) adapters.
+_LIVE_VENUES = ("kraken",)
+#: The venue key for the in-process simulator.
+_PAPER_VENUE = "paper"
+
+
+@dataclass(frozen=True, slots=True)
+class Engine:
+    """The assembled engine — every wired collaborator, ready to run.
+
+    A frozen bundle returned by :func:`build_engine`: the single object the
+    interfaces layer (CLI, future daemon) holds to drive the engine. Every field
+    shares the one :class:`~trading_bot.application.events.EventBus`, so an
+    :class:`~trading_bot.application.events.OrderEvent` /
+    :class:`~trading_bot.application.events.FillEvent` emitted by the broker or
+    the router reaches the tracker, the performance service and (when present)
+    the store automatically.
+
+    Attributes
+    ----------
+    config : AppConfig
+        The validated configuration the engine was built from.
+    bus : EventBus
+        The shared pub/sub bus every collaborator emits on / subscribes to.
+    broker : Broker
+        The selected venue adapter — a
+        :class:`~trading_bot.brokers.paper.PaperBroker` in paper mode, the live
+        venue adapter (e.g. :class:`~trading_bot.brokers.kraken.KrakenBroker`)
+        in live mode.
+    router : OrderRouter
+        The idempotent write path, gated by ``risk`` and routing to ``broker``.
+    tracker : PositionTracker
+        The live net-position view, subscribed to the bus's fills.
+    perf : PerformanceService
+        The read-side PnL/KPI view, subscribed to the bus's fills.
+    risk : RiskManager
+        The pre-trade gate + kill-switch the router consults before every order.
+    store : SqliteStore or None
+        The append-only order/fill history, attached to the bus. ``None`` when
+        no ``db_path`` was given to :func:`build_engine`.
+
+    """
+
+    config: AppConfig
+    bus: EventBus
+    broker: Broker
+    router: OrderRouter
+    tracker: PositionTracker
+    perf: PerformanceService
+    risk: RiskManager
+    store: SqliteStore | None
+
+
+def build_engine(
+    config: AppConfig, *, db_path: str | pathlib.Path | None = None
+) -> Engine:
+    """Assemble a fully-wired :class:`Engine` from ``config``.
+
+    The single wiring point: builds one :class:`~trading_bot.application.events.
+    EventBus`, selects the broker per ``config.mode`` (paper by default; live
+    only with credentials — see the module docstring), constructs the tracker,
+    performance service, risk manager and router onto that bus, optionally
+    attaches a :class:`~trading_bot.storage.sqlite_store.SqliteStore`, and
+    returns them in a frozen :class:`Engine`.
+
+    Parameters
+    ----------
+    config : AppConfig
+        The validated engine configuration (mode, brokers, risk limits).
+    db_path : str or pathlib.Path, optional
+        Where to persist order/fill history. When given, a
+        :class:`~trading_bot.storage.sqlite_store.SqliteStore` is created and
+        attached to the bus (so it fills itself from the event stream); when
+        ``None`` (default) the engine runs with no store
+        (:attr:`Engine.store` is ``None``).
+
+    Returns
+    -------
+    Engine
+        The wired engine — every collaborator sharing one bus.
+
+    Raises
+    ------
+    BrokerError
+        In live mode, if the configured venue lacks credentials, is unknown, or
+        no broker is configured at all. The factory never falls back to paper.
+
+    """
+    bus = EventBus()
+
+    broker = _build_broker(config, bus)
+
+    tracker = PositionTracker(event_bus=bus)
+    perf = PerformanceService(event_bus=bus)
+    risk = RiskManager(config.risk, position_tracker=tracker)
+    router = OrderRouter(broker, bus, risk_manager=risk)
+
+    store: SqliteStore | None = None
+    if db_path is not None:
+        store = SqliteStore(db_path)
+        store.attach(bus)
+
+    return Engine(
+        config=config,
+        bus=bus,
+        broker=broker,
+        router=router,
+        tracker=tracker,
+        perf=perf,
+        risk=risk,
+        store=store,
+    )
+
+
+def _build_broker(config: AppConfig, bus: EventBus) -> Broker:
+    """Select and construct the broker for ``config`` — paper-by-default.
+
+    In paper mode (the default), always a bus-wired
+    :class:`~trading_bot.brokers.paper.PaperBroker`. In live mode, the configured
+    venue's adapter, built only when it has credentials; an explicit ``"paper"``
+    venue entry yields the simulator under either mode. Refuses (raises
+    :class:`~trading_bot.domain.errors.BrokerError`) rather than falling back to
+    paper for a live venue that cannot trade.
+    """
+    venue = _selected_venue(config)
+
+    if config.mode == "paper" or venue == _PAPER_VENUE:
+        # Paper-by-default: the simulator, wired to the bus so its fills fan out.
+        return PaperBroker(event_bus=bus)
+
+    # mode == "live" with a non-paper venue: build the real adapter, but only if
+    # it can actually trade. Never silently downgrade to paper.
+    if venue in _LIVE_VENUES:
+        broker = _build_live_venue(venue)
+        if not broker.has_credentials:
+            raise BrokerError(
+                f"live mode requires credentials for venue {venue!r}; "
+                "set the venue's API key/secret in the environment "
+                "(refusing to trade live without credentials)"
+            )
+        return broker
+
+    raise BrokerError(
+        f"live mode: unknown venue {venue!r}; "
+        f"known live venues are {sorted(_LIVE_VENUES)!r}"
+    )
+
+
+def _selected_venue(config: AppConfig) -> str:
+    """The venue key the engine should use — the first configured broker's.
+
+    Paper mode needs no configured broker (it always uses the simulator), so a
+    missing broker defaults to ``"paper"`` there. Live mode with no broker
+    configured is an error surfaced by :func:`_build_broker`.
+    """
+    first: BrokerConfig | None = config.brokers[0] if config.brokers else None
+    if first is None:
+        if config.mode == "live":
+            raise BrokerError(
+                "live mode requires a configured broker, but none was given "
+                "(refusing to trade live without an explicit venue)"
+            )
+        return _PAPER_VENUE
+    return first.exchange.lower()
+
+
+def _build_live_venue(venue: str) -> KrakenBroker:
+    """Construct the live adapter for ``venue`` (reads credentials from env)."""
+    if venue == "kraken":
+        # KrakenBroker reads KRAKEN_API_KEY / KRAKEN_API_SECRET from the
+        # environment; ``has_credentials`` reports whether both are present.
+        return KrakenBroker()
+    # Unreachable: callers gate on ``_LIVE_VENUES`` first. Defensive only.
+    raise BrokerError(f"no live adapter for venue {venue!r}")

--- a/trading_bot/interfaces/__init__.py
+++ b/trading_bot/interfaces/__init__.py
@@ -1,0 +1,17 @@
+"""trading_bot interfaces layer — the engine's outer edges (CLI, API, UI).
+
+The outermost ring of the hexagon: it depends on the
+:mod:`trading_bot.application` layer (and through it the inner layers) but
+nothing depends on it. It turns human / network input into engine actions and
+renders engine state back out, holding **no** business logic of its own — every
+action is delegated to a use-case the
+:func:`~trading_bot.application.service_factory.build_engine` factory wired.
+
+* cli — the Typer command-line app (:mod:`trading_bot.interfaces.cli`), the
+  console-script entrypoint (``trading-bot``). Starts minimal (a ``version``
+  command) and grows the real start/stop/status/KPI commands in later leaves.
+
+The FastAPI + Jinja2 dashboard (``api`` / ``ui``) lands later.
+"""
+
+from __future__ import annotations

--- a/trading_bot/interfaces/cli/__init__.py
+++ b/trading_bot/interfaces/cli/__init__.py
@@ -1,0 +1,16 @@
+"""trading_bot CLI — the Typer command-line interface.
+
+The ``trading-bot`` console script. The Typer application lives in
+:mod:`trading_bot.interfaces.cli.main` and is exposed here as :data:`app` so the
+console-script target ``trading_bot.interfaces.cli.main:app`` and importers alike
+resolve a single object.
+
+This leaf ships only the skeleton (a ``version`` command); the real
+start/stop/status/KPI commands land in the next CLI leaf.
+"""
+
+from __future__ import annotations
+
+from trading_bot.interfaces.cli.main import app
+
+__all__ = ["app"]

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -1,0 +1,49 @@
+"""The Typer ``trading-bot`` application — the CLI entrypoint (skeleton).
+
+This module defines :data:`app`, the :class:`typer.Typer` instance the
+``trading-bot`` console script points at (target
+``trading_bot.interfaces.cli.main:app``). It is intentionally minimal in this
+leaf — a single ``version`` command — so the wiring (console script,
+:func:`~trading_bot.application.service_factory.build_engine`) is provable end to
+end before the real commands (``start`` / ``stop`` / ``status`` / KPI table)
+land in the next CLI leaf.
+
+The CLI holds no business logic: commands delegate to the use-cases the
+:func:`~trading_bot.application.service_factory.build_engine` factory wires.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from trading_bot import __version__
+
+app = typer.Typer(
+    name="trading-bot",
+    help="Execution & orchestration engine of the trading triptych.",
+    no_args_is_help=True,
+    add_completion=False,
+)
+
+
+@app.callback()
+def _main() -> None:
+    """``trading-bot`` — the engine's command-line interface.
+
+    A no-op group callback. Its sole purpose is to keep Typer treating the app
+    as a *multi-command* group even while only one command (``version``) exists:
+    without it, a lone command is collapsed into the root callback and
+    ``trading-bot version`` would reject ``version`` as an extra argument. As the
+    real commands (``start`` / ``stop`` / ``status`` / KPI) land, they slot in
+    alongside ``version`` with no change here.
+    """
+
+
+@app.command()
+def version() -> None:
+    """Print the installed ``trading_bot`` version and exit."""
+    typer.echo(__version__)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation only
+    app()

--- a/trading_bot/tests/application/test_service_factory.py
+++ b/trading_bot/tests/application/test_service_factory.py
@@ -1,0 +1,196 @@
+"""Tests for the service factory — the engine's single wiring point.
+
+These prove the wiring contract:
+
+* a default (paper) :class:`AppConfig` builds a :class:`PaperBroker`, with the
+  router / risk / tracker / perf all sharing the **one** bus and no store unless
+  a ``db_path`` is given;
+* the **paper-by-default** invariant holds — a ``live``-mode config whose venue
+  lacks credentials *refuses* (raises) instead of returning a broker;
+* the assembled engine is **live end to end**: an order submitted through the
+  engine's router produces a fill that reaches the tracker (position moves) and
+  the performance service (realised PnL / fees folded in) — the verification on
+  real data, in-process against the simulator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trading_bot.application.config import AppConfig, BrokerConfig
+from trading_bot.application.events import EventBus
+from trading_bot.application.order_router import OrderRouter
+from trading_bot.application.performance_service import PerformanceService
+from trading_bot.application.position_tracker import PositionTracker
+from trading_bot.application.risk import RiskManager
+from trading_bot.application.service_factory import Engine, build_engine
+from trading_bot.brokers.kraken import KrakenBroker
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain.errors import BrokerError
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.storage.sqlite_store import SqliteStore
+
+_BTCUSD = Instrument(Symbol("BTC", "USD"))
+
+
+def test_default_config_builds_paper_engine() -> None:
+    """A default (paper) config wires a PaperBroker + every use-case on one bus."""
+    engine = build_engine(AppConfig())
+
+    assert isinstance(engine, Engine)
+    assert isinstance(engine.broker, PaperBroker)
+    assert isinstance(engine.bus, EventBus)
+    assert isinstance(engine.router, OrderRouter)
+    assert isinstance(engine.tracker, PositionTracker)
+    assert isinstance(engine.perf, PerformanceService)
+    assert isinstance(engine.risk, RiskManager)
+    # No db_path → no store.
+    assert engine.store is None
+
+
+def test_paper_engine_shares_one_bus() -> None:
+    """Tracker + perf subscribe to the *same* bus the broker emits fills on.
+
+    A fill emitted on ``engine.bus`` must reach both read-side views without any
+    further wiring — proof they share the single bus, not separate ones.
+    """
+    engine = build_engine(AppConfig())
+    # Emitting a fill on the shared bus must fan out to tracker + perf.
+    from trading_bot.application.events import FillEvent
+    from trading_bot.domain.fill import Fill
+
+    fill = Fill(
+        fill_id="F1",
+        client_order_id="cid-bus",
+        instrument=_BTCUSD,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        price=money("100"),
+        fee=money("0"),
+        ts=1,
+    )
+    engine.bus.emit(FillEvent(fill))
+
+    assert engine.tracker.position(_BTCUSD) is not None
+    assert engine.tracker.position(_BTCUSD).net_qty == money("1")
+    assert engine.perf.position(_BTCUSD) is not None
+
+
+def test_db_path_attaches_sqlite_store(tmp_path) -> None:
+    """A db_path builds and attaches a SqliteStore; events flow into it."""
+    db = tmp_path / "engine.db"
+    engine = build_engine(AppConfig(), db_path=db)
+
+    assert isinstance(engine.store, SqliteStore)
+
+    # The store is attached to the bus: an OrderEvent persists the order.
+    from trading_bot.application.events import OrderEvent
+
+    order = Order(
+        client_order_id="cid-store",
+        instrument=_BTCUSD,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        type=OrderType.MARKET,
+    )
+    engine.bus.emit(OrderEvent(order))
+
+    assert engine.store.get_order("cid-store") is not None
+
+
+def test_live_mode_without_credentials_refuses() -> None:
+    """A live-mode config whose venue lacks credentials raises — no broker back.
+
+    The paper-by-default invariant: live trading is opt-in *and* gated on
+    credentials. Without them the factory must refuse, never silently fall back
+    to paper and never return a live broker that cannot trade.
+    """
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
+    )
+
+    # No KRAKEN_API_KEY/SECRET in the test env → KrakenBroker has no credentials.
+    # Build it directly to assert the precondition the factory relies on.
+    assert not KrakenBroker().has_credentials
+
+    with pytest.raises(BrokerError):
+        build_engine(cfg)
+
+
+def test_live_mode_with_credentials_builds_live_broker(monkeypatch) -> None:
+    """Live mode + credentials present → the live venue adapter is built."""
+    monkeypatch.setenv("KRAKEN_API_KEY", "k")
+    monkeypatch.setenv("KRAKEN_API_SECRET", "c2VjcmV0")  # base64("secret")
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
+    )
+
+    engine = build_engine(cfg)
+    assert isinstance(engine.broker, KrakenBroker)
+    assert engine.broker.has_credentials
+
+
+def test_live_mode_unknown_venue_refuses() -> None:
+    """Live mode with an unknown venue raises clearly (no silent fallback)."""
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="x", exchange="not-a-venue")],
+    )
+    with pytest.raises(BrokerError):
+        build_engine(cfg)
+
+
+def test_live_mode_no_broker_configured_refuses() -> None:
+    """Live mode with no configured broker raises — never trade without a venue."""
+    cfg = AppConfig(mode="live")
+    with pytest.raises(BrokerError):
+        build_engine(cfg)
+
+
+def test_paper_venue_named_explicitly_builds_paper() -> None:
+    """An explicit 'paper' venue yields the simulator (even under live mode)."""
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="sim", exchange="paper")],
+    )
+    engine = build_engine(cfg)
+    assert isinstance(engine.broker, PaperBroker)
+
+
+async def test_engine_is_live_end_to_end() -> None:
+    """Verification on real data: order → fill → tracker + perf, in-process.
+
+    Submit one real order through the wired router against the PaperBroker and
+    assert the broker-confirmed fill moved the tracker's position *and* folded
+    into the performance service — proof the factory wired a live engine, not a
+    bag of disconnected objects.
+    """
+    engine = build_engine(AppConfig())
+    # The PaperBroker needs a mark price to fill a MARKET order.
+    engine.broker.set_price(_BTCUSD, money("100"))
+
+    order = Order(
+        client_order_id="cid-e2e",
+        instrument=_BTCUSD,
+        side=OrderSide.BUY,
+        qty=money("2"),
+        type=OrderType.MARKET,
+    )
+    tracked = await engine.router.submit(order)
+
+    # Router drove the lifecycle.
+    assert tracked.client_order_id == "cid-e2e"
+    assert tracked.venue_order_id is not None
+
+    # The fill fanned out to the tracker: position moved to +2 BTC.
+    position = engine.tracker.position(_BTCUSD)
+    assert position is not None
+    assert position.net_qty == money("2")
+
+    # And to the performance service: a fee was charged (realised PnL net of it).
+    assert engine.perf.fees_paid() > money("0")
+    assert len(engine.perf.equity_curve()) == 1

--- a/trading_bot/tests/interfaces/test_cli_skeleton.py
+++ b/trading_bot/tests/interfaces/test_cli_skeleton.py
@@ -1,0 +1,44 @@
+"""Tests for the Typer CLI skeleton + the console-script target.
+
+These prove the entrypoint wiring:
+
+* the console-script target ``trading_bot.interfaces.cli.main:app`` imports and
+  is a Typer app;
+* the ``version`` command exits 0 and prints ``trading_bot.__version__``.
+
+Real commands (start/stop/status/KPI) arrive in the next CLI leaf; this leaf
+only proves the skeleton resolves and runs.
+"""
+
+from __future__ import annotations
+
+import typer
+from typer.testing import CliRunner
+
+from trading_bot import __version__
+from trading_bot.interfaces.cli.main import app
+
+runner = CliRunner()
+
+
+def test_console_script_target_imports() -> None:
+    """The console-script target resolves to a Typer app."""
+    # This is exactly what `[project.scripts] trading-bot = ...:app` resolves.
+    from trading_bot.interfaces.cli.main import app as target
+
+    assert isinstance(target, typer.Typer)
+
+
+def test_version_command_prints_version() -> None:
+    """`trading-bot version` exits 0 and prints the package version."""
+    result = runner.invoke(app, ["version"])
+
+    assert result.exit_code == 0
+    assert __version__ in result.stdout
+
+
+def test_no_args_shows_help() -> None:
+    """Bare invocation shows help (no_args_is_help) rather than erroring out."""
+    result = runner.invoke(app, [])
+    # Typer exits 0 (or 2) showing help; the help banner must mention the app.
+    assert "trading-bot" in result.stdout or "Usage" in result.stdout


### PR DESCRIPTION
## Summary
- First leaf of **E7 (the MVP)**: `application/service_factory.py` — `build_engine(config, *, db_path=None) -> Engine`, the single wiring point (one bus shared by tracker/perf/router+risk/store). Plus a Typer `trading-bot` CLI skeleton (`version`) and the `[project.scripts] trading-bot` console script (typer+rich added to daemon+dev extras).

## Why
- Centralising construction means the CLI, tests and a future daemon build an identically-wired engine. Broker selection enforces **paper-by-default**: live only when `mode=="live"` AND the venue has credentials, else `BrokerError` (no silent fallback, no accidental live). See `doc/dev/03-decisions.md`.

## Changes
- `application/service_factory.py` (`Engine` dataclass) + export; `interfaces/cli/{__init__,main}.py`; `pyproject.toml` console script + extras; tests for the factory + CLI skeleton.

## Changelog
Added: `service_factory.build_engine` + Typer CLI skeleton + console script.

## Test plan
- [x] `.venv/bin/python -m pytest` (439 passed, 0 unexpected skips)
- [x] end-to-end wiring: order→fill reaches tracker + perf off one bus
- [x] `trading-bot version` → 0.2.0.dev0 (console script); live-without-creds refused
- [x] `ruff` + `mypy` clean