### PR TITLE
feat: CLI run/status/kpi commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whole engine (bus, broker, router+risk, tracker, perf, store) from an `AppConfig`
   (paper-by-default; live needs credentials), plus a Typer `trading-bot` CLI skeleton
   and the `trading-bot` console script.
+- `trading-bot` CLI commands — `run` (run a strategy over a bars file / synthetic
+  feed, paper by default; `--live` needs explicit ack **and** credentials), `status`
+  and `kpi` (read a persisted `--db` history; rich tables, money as Decimal).
 
 ### Fixed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,26 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-23 CLI run/status/kpi: double live-guard, fills-as-source for status/kpi
+
+**Decision.** `trading-bot run` defaults to **paper**; `--live` requires **both** an
+explicit `--yes-i-understand` ack (or interactive `typer.confirm`) **and** venue
+credentials — either missing → clear non-zero exit with **no broker built and no order
+placed**. `run` takes a `--bars` file (CSV/parquet → polars → `InMemoryFeed`) or a
+built-in synthetic feed; it prices the example MA-crossover with a LIMIT-at-close order
+factory so the paper run fills offline without a mark feed. `status`/`kpi` read a
+persisted `SqliteStore` (`--db`) and rebuild positions/KPIs from the stored **fills**
+(the PnL source of truth), not a re-run engine. `kpi --capital` anchors `v0 > 0` so the
+equity curve doesn't sign-cross (fynance's annual-return math requires it).
+
+**Why.** A two-gate live opt-in makes "no live by accident" structural at the interface
+too, not just in the factory. Rebuilding from stored fills makes `status`/`kpi`
+inspect real history a prior `run --db` produced (genuinely testable) rather than
+re-simulating. The positive-capital anchor is a fynance constraint, not a choice about
+PnL (realised PnL/fees are capital-independent).
+
+---
+
 ### 2026-06-23 service_factory: single wiring point, no live broker by accident
 
 **Decision.** `application/service_factory.py` `build_engine(config, *, db_path=None)

--- a/doc/dev/plans/cli/00-plan.md
+++ b/doc/dev/plans/cli/00-plan.md
@@ -30,7 +30,7 @@ confirmation); everything offline-testable (Typer `CliRunner` + `PaperBroker`).
 ## Leaf checklist
 
 - [x] 01 cli-skeleton — feat/cli-skeleton — high
-- [ ] 02 cli-commands — feat/cli-commands — medium (depends on 01)
+- [x] 02 cli-commands — feat/cli-commands — medium (depends on 01)
 - [ ] 03 async-orchestration — feat/async-orchestration — high (depends on 01)
 - [ ] 04 legacy-removal — chore/remove-legacy — low (depends on 02, 03)
 

--- a/doc/dev/plans/cli/02-cli-commands.md
+++ b/doc/dev/plans/cli/02-cli-commands.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: [01]
 parallel: false
 branch: feat/cli-commands
-pr: ""
+pr: "#41"
 ---
 
 # CLI commands — run / status / kpi

--- a/doc/dev/plans/cli/02-cli-commands.md
+++ b/doc/dev/plans/cli/02-cli-commands.md
@@ -1,7 +1,7 @@
 ---
 plan: cli/02-cli-commands
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: [01]
 parallel: false

--- a/trading_bot/interfaces/cli/_render.py
+++ b/trading_bot/interfaces/cli/_render.py
@@ -1,0 +1,222 @@
+"""Rich rendering helpers for the ``trading-bot`` CLI — pure, table-building.
+
+The CLI's commands (:mod:`trading_bot.interfaces.cli.main`) stay *thin*: they
+wire the engine, run it, then hand the resulting state to one of the pure helpers
+here to turn into a :class:`rich.table.Table` (or a short string). Keeping the
+rendering out of the command bodies means a table can be unit-tested directly
+from a known state — no :class:`~typer.testing.CliRunner`, no engine — and the
+commands carry no formatting logic.
+
+Money discipline
+----------------
+Every monetary / quantity value is rendered with :func:`fmt_money`, which formats
+the exact :class:`~decimal.Decimal` via ``str`` (optionally normalised to a fixed
+number of places) and **never** routes through ``float``. The KPI *ratios*
+(Sharpe, Sortino, drawdown, Calmar) are genuine floats (statistical estimators
+over a returns path — see :class:`~trading_bot.application.performance_service.
+PerformanceService`) and are rendered with :func:`fmt_ratio`.
+
+These helpers are presentation-only: they read domain/application objects and
+produce :mod:`rich` renderables. They perform no I/O and hold no business logic.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from rich.table import Table
+
+if TYPE_CHECKING:
+    from trading_bot.application.performance_service import PerformanceService
+    from trading_bot.domain.instrument import Instrument
+    from trading_bot.domain.order import Order
+    from trading_bot.domain.position import Position
+
+__all__ = [
+    "fmt_money",
+    "fmt_ratio",
+    "positions_table",
+    "open_orders_table",
+    "kpi_table",
+]
+
+
+def fmt_money(value: Decimal | None, *, places: int | None = None) -> str:
+    """Format an exact :class:`~decimal.Decimal` money/qty value as a string.
+
+    Never goes through ``float`` — the value is rendered from its exact decimal
+    form. With ``places`` given, the value is quantised (display only) to that
+    many decimal places via :meth:`~decimal.Decimal.quantize`; otherwise its
+    natural string form is used.
+
+    Parameters
+    ----------
+    value : Decimal or None
+        The value to format. ``None`` renders as ``"-"`` (e.g. a flat position's
+        average entry price).
+    places : int or None, optional
+        Fixed decimal places for display. ``None`` (default) keeps the value's
+        natural form.
+
+    Returns
+    -------
+    str
+        The formatted value (``"-"`` for ``None``).
+
+    """
+    if value is None:
+        return "-"
+    if places is not None:
+        quantum = Decimal(1).scaleb(-places)
+        return str(value.quantize(quantum))
+    return str(value)
+
+
+def fmt_ratio(value: float, *, places: int = 4) -> str:
+    """Format a KPI ratio (a genuine float) to ``places`` decimal places.
+
+    Parameters
+    ----------
+    value : float
+        The ratio (Sharpe, Sortino, drawdown, Calmar). These are statistical
+        estimators over a returns path and are legitimately ``float``.
+    places : int, optional
+        Decimal places to show. Default ``4``.
+
+    Returns
+    -------
+    str
+        The formatted ratio.
+
+    """
+    return f"{value:.{places}f}"
+
+
+def positions_table(
+    positions: dict[Instrument, Position], *, title: str = "Positions"
+) -> Table:
+    """Build a :class:`rich.table.Table` of net positions, one row per instrument.
+
+    Columns: instrument, net qty, average entry price, realised PnL, fees paid —
+    every numeric column formatted via :func:`fmt_money` (exact, no float). A
+    flat ``avg_entry_price`` (``None``) renders as ``"-"``. An empty mapping
+    yields a header-only table.
+
+    Parameters
+    ----------
+    positions : dict of Instrument to Position
+        The positions to render (e.g. ``PositionTracker.all_positions()``).
+    title : str, optional
+        The table title. Default ``"Positions"``.
+
+    Returns
+    -------
+    rich.table.Table
+        The rendered table.
+
+    """
+    table = Table(title=title)
+    table.add_column("Instrument")
+    table.add_column("Net qty", justify="right")
+    table.add_column("Avg entry", justify="right")
+    table.add_column("Realised PnL", justify="right")
+    table.add_column("Fees", justify="right")
+
+    for instrument in sorted(positions, key=str):
+        pos = positions[instrument]
+        table.add_row(
+            str(instrument),
+            fmt_money(pos.net_qty),
+            fmt_money(pos.avg_entry_price),
+            fmt_money(pos.realised_pnl),
+            fmt_money(pos.fees_paid),
+        )
+    return table
+
+
+def open_orders_table(
+    orders: list[Order], *, title: str = "Open orders"
+) -> Table:
+    """Build a :class:`rich.table.Table` of open orders, one row per order.
+
+    Columns: client-order-id, venue-order-id, instrument, side, type, qty,
+    filled qty, status. Quantities are formatted via :func:`fmt_money`. An empty
+    list yields a header-only table.
+
+    Parameters
+    ----------
+    orders : list of Order
+        The open orders to render (e.g. ``await broker.open_orders()``).
+    title : str, optional
+        The table title. Default ``"Open orders"``.
+
+    Returns
+    -------
+    rich.table.Table
+        The rendered table.
+
+    """
+    table = Table(title=title)
+    table.add_column("Client id")
+    table.add_column("Venue id")
+    table.add_column("Instrument")
+    table.add_column("Side")
+    table.add_column("Type")
+    table.add_column("Qty", justify="right")
+    table.add_column("Filled", justify="right")
+    table.add_column("Status")
+
+    for order in orders:
+        table.add_row(
+            order.client_order_id,
+            order.venue_order_id or "-",
+            str(order.instrument),
+            order.side.value,
+            order.type.value,
+            fmt_money(order.qty),
+            fmt_money(order.filled_qty),
+            order.status.value,
+        )
+    return table
+
+
+def kpi_table(perf: PerformanceService, *, title: str = "Performance (KPI)") -> Table:
+    """Build a :class:`rich.table.Table` of the engine's performance KPIs.
+
+    Two-column metric/value table over a
+    :class:`~trading_bot.application.performance_service.PerformanceService`:
+    realised PnL, fees paid and the equity endpoint as exact
+    :class:`~decimal.Decimal` (via :func:`fmt_money`); Sharpe, Sortino, max
+    drawdown and Calmar as floats (via :func:`fmt_ratio`). The equity endpoint is
+    the last point of :meth:`~trading_bot.application.performance_service.
+    PerformanceService.equity_curve` (``"-"`` when no fill has landed).
+
+    Parameters
+    ----------
+    perf : PerformanceService
+        The performance view to read (after a run, or rebuilt from stored fills).
+    title : str, optional
+        The table title. Default ``"Performance (KPI)"``.
+
+    Returns
+    -------
+    rich.table.Table
+        The rendered KPI table.
+
+    """
+    table = Table(title=title)
+    table.add_column("Metric")
+    table.add_column("Value", justify="right")
+
+    curve = perf.equity_curve()
+    equity_end = curve[-1] if curve else None
+
+    table.add_row("Realised PnL", fmt_money(perf.realised_pnl()))
+    table.add_row("Fees paid", fmt_money(perf.fees_paid()))
+    table.add_row("Equity (end)", fmt_money(equity_end))
+    table.add_row("Sharpe", fmt_ratio(perf.sharpe()))
+    table.add_row("Sortino", fmt_ratio(perf.sortino()))
+    table.add_row("Max drawdown", fmt_ratio(perf.max_drawdown()))
+    table.add_row("Calmar", fmt_ratio(perf.calmar()))
+    return table

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -1,22 +1,71 @@
-"""The Typer ``trading-bot`` application — the CLI entrypoint (skeleton).
+"""The Typer ``trading-bot`` application — the CLI entrypoint.
 
 This module defines :data:`app`, the :class:`typer.Typer` instance the
 ``trading-bot`` console script points at (target
-``trading_bot.interfaces.cli.main:app``). It is intentionally minimal in this
-leaf — a single ``version`` command — so the wiring (console script,
-:func:`~trading_bot.application.service_factory.build_engine`) is provable end to
-end before the real commands (``start`` / ``stop`` / ``status`` / KPI table)
-land in the next CLI leaf.
+``trading_bot.interfaces.cli.main:app``). It carries the user-facing commands:
 
-The CLI holds no business logic: commands delegate to the use-cases the
-:func:`~trading_bot.application.service_factory.build_engine` factory wires.
+* :func:`version` — print the installed package version;
+* :func:`run` — drive a strategy over a bars source through the engine
+  (paper-by-default; ``--live`` is an explicit, guarded opt-in);
+* :func:`status` — show current positions + open orders;
+* :func:`kpi` — show the realised-PnL / fees / KPI table.
+
+The CLI holds **no business logic**: commands delegate to the use-cases the
+:func:`~trading_bot.application.service_factory.build_engine` factory wires, and
+hand the resulting state to the pure rendering helpers in
+:mod:`trading_bot.interfaces.cli._render`. ``run`` builds a strategy + a
+:class:`~trading_bot.application.data_feed.DataFeed`, drives the
+:class:`~trading_bot.application.strategy_runner.StrategyRunner` (via
+:func:`asyncio.run`), and prints a short summary.
+
+Paper-by-default (the invariant)
+--------------------------------
+A ``run`` defaults to **paper** trading — no venue, no key, no network. Going
+``--live`` requires *both* an explicit acknowledgement (``--yes-i-understand``,
+or an interactive confirmation) *and* venue credentials; absent either, ``run``
+**refuses with a non-zero exit and never places an order**. The factory
+(:func:`~trading_bot.application.service_factory.build_engine`) enforces the same
+on its side (it never silently falls back to paper for a credential-less live
+venue), so a missing key cannot trade real money by accident.
+
+Offline-testable bars source
+-----------------------------
+``run`` always supports a fully offline path so the whole command is testable
+without a network: ``--bars <path>`` loads a CSV or Parquet OHLC file into a
+:class:`~trading_bot.application.data_feed.InMemoryFeed`; with no ``--bars`` a
+small built-in **synthetic** trending series is used (enough bars for the
+MA-crossover example to cross), so ``trading-bot run`` does something meaningful
+out of the box.
 """
 
 from __future__ import annotations
 
+import asyncio
+import dataclasses
+import math
+import pathlib
+from collections.abc import Callable
+from decimal import Decimal
+
+import polars as pl
 import typer
+from rich.console import Console
 
 from trading_bot import __version__
+from trading_bot.application.config import AppConfig, StrategyConfig
+from trading_bot.application.data_feed import BARS_SCHEMA, InMemoryFeed
+from trading_bot.application.performance_service import PerformanceService
+from trading_bot.application.service_factory import Engine, build_engine
+from trading_bot.application.strategy import (
+    Strategy,
+    load_strategy,
+    ma_crossover_signal,
+)
+from trading_bot.application.strategy_runner import StrategyRunner
+from trading_bot.domain.instrument import Instrument, parse_kraken_pair
+from trading_bot.domain.money import Money, from_float, money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.interfaces.cli import _render
 
 app = typer.Typer(
     name="trading-bot",
@@ -25,17 +74,21 @@ app = typer.Typer(
     add_completion=False,
 )
 
+#: The shared rich console every command prints through.
+_console = Console()
+
+#: Default synthetic-feed length (bars) when no ``--bars`` file is given — long
+#: enough for the default 10/30 MA windows to warm up and cross at least once.
+_SYNTHETIC_BARS = 80
+
 
 @app.callback()
 def _main() -> None:
     """``trading-bot`` — the engine's command-line interface.
 
-    A no-op group callback. Its sole purpose is to keep Typer treating the app
-    as a *multi-command* group even while only one command (``version``) exists:
-    without it, a lone command is collapsed into the root callback and
-    ``trading-bot version`` would reject ``version`` as an extra argument. As the
-    real commands (``start`` / ``stop`` / ``status`` / KPI) land, they slot in
-    alongside ``version`` with no change here.
+    A no-op group callback so Typer treats the app as a *multi-command* group
+    (without it a lone command collapses into the root callback). The real
+    commands slot in alongside ``version``.
     """
 
 
@@ -43,6 +96,343 @@ def _main() -> None:
 def version() -> None:
     """Print the installed ``trading_bot`` version and exit."""
     typer.echo(__version__)
+
+
+# --- run ------------------------------------------------------------------- #
+
+
+def _load_bars(path: pathlib.Path) -> pl.DataFrame:
+    """Load an OHLC bars file (``.csv`` or ``.parquet``) into a polars frame.
+
+    The file must carry the :data:`~trading_bot.application.data_feed.BARS_SCHEMA`
+    columns (``time, o, h, l, c, v``); :class:`InMemoryFeed` validates that on
+    construction. Raises a :class:`typer.BadParameter` for a missing file or an
+    unknown extension so the CLI surfaces a clean error.
+    """
+    if not path.exists():
+        raise typer.BadParameter(f"bars file not found: {path}")
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return pl.read_csv(path)
+    if suffix in (".parquet", ".pq"):
+        return pl.read_parquet(path)
+    raise typer.BadParameter(
+        f"unsupported bars file type {suffix!r}; use .csv or .parquet"
+    )
+
+
+def _synthetic_bars(n: int = _SYNTHETIC_BARS) -> pl.DataFrame:
+    """Build a deterministic synthetic OHLC frame that trends up then down.
+
+    A self-contained default bars source: a smooth sine-modulated uptrend that
+    rises then falls, so the fast MA crosses the slow MA in both directions and
+    the MA-crossover example actually trades. Deterministic (no randomness) so a
+    ``run`` with no ``--bars`` is reproducible.
+    """
+    times = list(range(n))
+    closes = [100.0 + 20.0 * math.sin(2.0 * math.pi * t / n) for t in times]
+    return pl.DataFrame(
+        {
+            "time": times,
+            "o": closes,
+            "h": [c + 1.0 for c in closes],
+            "l": [c - 1.0 for c in closes],
+            "c": closes,
+            "v": [1.0] * n,
+        }
+    )
+
+
+def _limit_at_close_factory(
+    close_col: str = "c",
+) -> Callable[[Strategy, Money, pl.DataFrame], Order]:
+    """Build an order factory that prices a step's order at the latest close.
+
+    The runner submits MARKET orders by default, which the
+    :class:`~trading_bot.brokers.paper.PaperBroker` can only fill if a mark price
+    has been injected. Pricing each order as a LIMIT at the bar's **close** makes
+    the offline run fully self-contained — the broker fills at that exact close —
+    and keeps the simulated execution price equal to the price the signal saw.
+    The runner overrides the ``client_order_id`` afterwards, so the factory need
+    not set one meaningfully.
+    """
+
+    def _factory(strategy: Strategy, delta: Money, bars: pl.DataFrame) -> Order:
+        close = from_float(float(bars[close_col][-1]))
+        side = OrderSide.BUY if delta > 0 else OrderSide.SELL
+        return Order(
+            client_order_id="pending",  # overridden by the runner
+            instrument=strategy.instrument,
+            side=side,
+            qty=abs(delta),
+            type=OrderType.LIMIT,
+            limit_price=close,
+        )
+
+    return _factory
+
+
+def _build_strategy(config: AppConfig, *, fast: int, slow: int, qty: Money) -> Strategy:
+    """Load the MA-crossover example strategy for the config's first symbol.
+
+    Uses the first configured strategy's ``symbol`` (or a ``BTC/USD`` default),
+    wires the :func:`~trading_bot.application.strategy.ma_crossover_signal`
+    example, and sets ``reference_qty`` (the base-unit scale a fractional
+    exposure resolves against — required for the EXPOSURE-mode example) and
+    ``lookback`` to the slow window (warmup) so no order fires on partial data.
+    """
+    strat_cfg = (
+        config.strategies[0]
+        if config.strategies
+        else StrategyConfig(name="ma-cross", symbol="BTC/USD")
+    )
+    # The example signal is built *for* an instrument, so resolve the instrument
+    # first (load_strategy with the built callable), then set the exposure scale
+    # (reference_qty, required for the EXPOSURE-mode example) and the warmup
+    # (lookback = slow window). Strategy is frozen, so use dataclasses.replace.
+    instrument = Instrument(parse_kraken_pair(strat_cfg.symbol))
+    signal_fn = ma_crossover_signal(instrument, fast=fast, slow=slow)
+    base = load_strategy(strat_cfg, signal_fn)
+    return dataclasses.replace(base, reference_qty=qty, lookback=slow)
+
+
+async def _run_engine(
+    engine: Engine, strategy: Strategy, feed: InMemoryFeed
+) -> int:
+    """Drive the strategy over the feed through the engine; return orders sent."""
+    runner = StrategyRunner(
+        strategy,
+        feed,
+        engine.router,
+        engine.tracker,
+        event_bus=engine.bus,
+        order_factory=_limit_at_close_factory(),
+    )
+    return await runner.run()
+
+
+@app.command()
+def run(
+    config_path: pathlib.Path | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="YAML AppConfig path. Defaults to a paper config (BTC/USD).",
+    ),
+    bars_path: pathlib.Path | None = typer.Option(
+        None,
+        "--bars",
+        "-b",
+        help="OHLC bars file (.csv/.parquet, schema time,o,h,l,c,v). "
+        "Omit for a built-in synthetic feed.",
+    ),
+    db_path: pathlib.Path | None = typer.Option(
+        None,
+        "--db",
+        help="Persist order/fill history to this SqliteStore path "
+        "(read it back later with status/kpi).",
+    ),
+    qty: float = typer.Option(
+        1.0,
+        "--qty",
+        help="Reference position size (base units) the exposure scales to.",
+    ),
+    fast: int = typer.Option(10, "--fast", help="Fast MA window (bars)."),
+    slow: int = typer.Option(30, "--slow", help="Slow MA window (bars)."),
+    live: bool = typer.Option(
+        False,
+        "--live",
+        help="Trade LIVE (real money). Requires --yes-i-understand AND "
+        "credentials; refuses otherwise.",
+    ),
+    yes_i_understand: bool = typer.Option(
+        False,
+        "--yes-i-understand",
+        help="Explicit acknowledgement required to go --live.",
+    ),
+) -> None:
+    """Run a strategy over a bars source and print a short summary.
+
+    Builds the engine (paper-by-default), loads the MA-crossover example strategy
+    for the config's symbol, replays the bars source (a ``--bars`` file or the
+    built-in synthetic feed) through the
+    :class:`~trading_bot.application.strategy_runner.StrategyRunner`, then prints
+    orders submitted, the final net position and the realised PnL.
+
+    **Going live is guarded.** ``--live`` demands both ``--yes-i-understand`` and
+    venue credentials; missing either, the command refuses with a non-zero exit
+    and **never places an order** (the broker is never even built down the live
+    path until both checks pass).
+    """
+    config = (
+        AppConfig.from_yaml(config_path)
+        if config_path is not None
+        else AppConfig()
+    )
+
+    mode = _resolve_mode(config, live=live, yes_i_understand=yes_i_understand)
+    config = config.model_copy(update={"mode": mode})
+
+    # Build the engine. In live mode build_engine refuses (BrokerError) if the
+    # configured venue lacks credentials — caught and surfaced as a clean exit,
+    # with no order ever placed.
+    try:
+        engine = build_engine(config, db_path=db_path)
+    except Exception as exc:  # noqa: BLE001 - surface any build failure cleanly
+        _console.print(f"[red]refusing to run:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    reference_qty = money(str(Decimal(str(qty))))
+    try:
+        strategy = _build_strategy(config, fast=fast, slow=slow, qty=reference_qty)
+    except Exception as exc:  # noqa: BLE001
+        _console.print(f"[red]bad strategy parameters:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    frame = (
+        _load_bars(bars_path) if bars_path is not None else _synthetic_bars()
+    )
+    feed = InMemoryFeed(frame.select(list(BARS_SCHEMA)))
+
+    submitted = asyncio.run(_run_engine(engine, strategy, feed))
+
+    position = engine.tracker.position(strategy.instrument)
+    net_qty = position.net_qty if position is not None else money("0")
+
+    _console.print(
+        f"[green]run complete[/green] "
+        f"(mode={config.mode}, strategy={strategy.name}, "
+        f"instrument={strategy.instrument})"
+    )
+    _console.print(f"orders submitted : {submitted}")
+    _console.print(f"final net qty    : {_render.fmt_money(net_qty)}")
+    _console.print(
+        f"realised PnL     : {_render.fmt_money(engine.perf.realised_pnl())}"
+    )
+    _console.print(
+        f"fees paid        : {_render.fmt_money(engine.perf.fees_paid())}"
+    )
+    _console.print(_render.positions_table(engine.tracker.all_positions()))
+
+
+def _resolve_mode(
+    config: AppConfig, *, live: bool, yes_i_understand: bool
+) -> str:
+    """Resolve the effective run mode, guarding the live path.
+
+    Paper unless ``--live`` is set. ``--live`` requires the explicit
+    ``--yes-i-understand`` acknowledgement (or an interactive confirmation);
+    without it the command refuses with a non-zero exit and never proceeds to
+    build a broker. (Credential presence is enforced one layer down by
+    :func:`~trading_bot.application.service_factory.build_engine`, which refuses a
+    credential-less live venue — so the two gates together mean a live order is
+    impossible without *both* an acknowledgement and a key.)
+    """
+    if not live:
+        return "paper"
+
+    acknowledged = yes_i_understand
+    if not acknowledged:
+        # No flag acknowledgement: ask interactively. A non-tty / declined
+        # answer leaves it False and we refuse below.
+        acknowledged = typer.confirm(
+            "LIVE trading uses real money. Are you sure you want to continue?",
+            default=False,
+        )
+    if not acknowledged:
+        _console.print(
+            "[red]refusing to trade live[/red] without explicit confirmation; "
+            "pass --yes-i-understand (no order was placed)."
+        )
+        raise typer.Exit(code=1)
+
+    return "live"
+
+
+# --- status ---------------------------------------------------------------- #
+
+
+@app.command()
+def status(
+    db_path: pathlib.Path = typer.Option(
+        ...,
+        "--db",
+        help="SqliteStore database path to read positions/orders from.",
+    ),
+) -> None:
+    """Show positions + open orders read from a persisted :class:`SqliteStore`.
+
+    The status command reads the **stored** order/fill history (written by a run
+    with a store attached) rather than spinning a fresh engine: it rebuilds each
+    instrument's net position from the stored fills (the PnL source of truth) and
+    lists the stored orders that are still live (not terminal). This is the
+    simplest genuinely-testable source — a file a previous run produced — and
+    avoids re-running a strategy just to observe state.
+    """
+    from trading_bot.application.position_tracker import PositionTracker
+    from trading_bot.domain.order import OrderStatus
+    from trading_bot.storage.sqlite_store import SqliteStore
+
+    if not db_path.exists():
+        raise typer.BadParameter(f"database not found: {db_path}")
+
+    store = SqliteStore(db_path)
+    tracker = PositionTracker()
+    for fill in store.fills():
+        tracker.apply(fill)
+
+    open_orders = [
+        order
+        for order in store.orders()
+        if order.status
+        not in (OrderStatus.FILLED, OrderStatus.CANCELLED, OrderStatus.REJECTED)
+    ]
+
+    _console.print(_render.positions_table(tracker.all_positions()))
+    _console.print(_render.open_orders_table(open_orders))
+
+
+# --- kpi ------------------------------------------------------------------- #
+
+
+@app.command()
+def kpi(
+    db_path: pathlib.Path = typer.Option(
+        ...,
+        "--db",
+        help="SqliteStore database path to compute KPIs from.",
+    ),
+    capital: float = typer.Option(
+        100_000.0,
+        "--capital",
+        help="Starting account capital (quote units) anchoring the equity "
+        "curve the KPI ratios are computed over.",
+    ),
+) -> None:
+    """Show realised PnL / fees / equity / KPI ratios from a stored fill history.
+
+    Rebuilds a :class:`~trading_bot.application.performance_service.
+    PerformanceService` from the fills persisted in a :class:`SqliteStore` (the
+    fills are the PnL source of truth) and renders the KPI table — realised PnL,
+    fees and the equity endpoint as exact :class:`~decimal.Decimal`, the Sharpe /
+    Sortino / max-drawdown / Calmar ratios as floats.
+
+    The KPI *ratios* are estimators over the equity curve ``capital + cumulative
+    realised PnL``; ``--capital`` anchors it to a realistic, strictly-positive
+    account value (the ratio math needs the curve not to cross zero). The
+    realised PnL / fees themselves are independent of ``--capital``.
+    """
+    from trading_bot.storage.sqlite_store import SqliteStore
+
+    if not db_path.exists():
+        raise typer.BadParameter(f"database not found: {db_path}")
+
+    store = SqliteStore(db_path)
+    perf = PerformanceService(v0=money(str(Decimal(str(capital)))))
+    for fill in store.fills():
+        perf.apply(fill)
+
+    _console.print(_render.kpi_table(perf))
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation only

--- a/trading_bot/tests/interfaces/test_cli_commands.py
+++ b/trading_bot/tests/interfaces/test_cli_commands.py
@@ -1,0 +1,312 @@
+"""Tests for the ``trading-bot`` CLI commands — ``run`` / ``status`` / ``kpi``.
+
+These exercise the user-facing commands through Typer's
+:class:`~typer.testing.CliRunner`, fully **offline** (an in-memory / fixture bars
+file replayed through the engine's :class:`~trading_bot.brokers.paper.PaperBroker`
+— the engine's real data path):
+
+* ``run`` over a realistic OHLC fixture (MA-crossover, paper) exits 0, prints a
+  summary, and moves the position — and the reported PnL matches an *independent*
+  recomputation from the broker's own fills (read back from the persisted store);
+* the ``--live`` path refuses (non-zero exit, clear message) and **never places
+  an order** when confirmation/credentials are missing;
+* ``status`` and ``kpi`` render their tables from a persisted store and surface
+  the expected position / PnL values.
+
+The ``_render`` helpers are also tested directly (no CLI) from a known state, so
+the table formatting is unit-checked without invoking a command.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import polars as pl
+import pytest
+from typer.testing import CliRunner
+
+from trading_bot.application.performance_service import PerformanceService
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.domain.position import Position
+from trading_bot.interfaces.cli import _render
+from trading_bot.interfaces.cli.main import app
+from trading_bot.storage.sqlite_store import SqliteStore
+
+runner = CliRunner()
+
+_BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+def _ohlc_fixture(path: pathlib.Path) -> pl.DataFrame:
+    """Write a deterministic OHLC CSV that crosses up then down, return the frame.
+
+    A short, explicit series: it rises from 100 to ~120 (the fast MA pulls above
+    the slow MA → a long), then falls back below (→ a short/close). Small windows
+    in the tests (fast=2, slow=4) make the crossover happen quickly and
+    deterministically. ``o/h/l`` track ``c`` (only ``c`` drives the signal).
+    """
+    closes = [
+        100.0, 101.0, 102.0, 104.0, 107.0, 111.0, 116.0, 120.0,
+        119.0, 116.0, 112.0, 107.0, 101.0, 95.0, 90.0, 86.0,
+    ]
+    times = list(range(len(closes)))
+    frame = pl.DataFrame(
+        {
+            "time": times,
+            "o": closes,
+            "h": [c + 0.5 for c in closes],
+            "l": [c - 0.5 for c in closes],
+            "c": closes,
+            "v": [1.0] * len(closes),
+        }
+    )
+    frame.write_csv(path)
+    return frame
+
+
+# --- run ------------------------------------------------------------------- #
+
+
+def test_run_over_fixture_paper_moves_position(tmp_path: pathlib.Path) -> None:
+    """`run` over an OHLC fixture (paper) exits 0, summarises, and trades.
+
+    Verification on real data: after the run, the PnL the engine reported is
+    recomputed *independently* from the broker's fills (read back from the
+    persisted store) and must agree exactly — fills are the source of truth.
+    """
+    bars = tmp_path / "bars.csv"
+    _ohlc_fixture(bars)
+    db = tmp_path / "run.db"
+
+    result = runner.invoke(
+        app,
+        [
+            "run",
+            "--bars", str(bars),
+            "--db", str(db),
+            "--fast", "2",
+            "--slow", "4",
+            "--qty", "1",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "run complete" in result.output
+    assert "mode=paper" in result.output
+    assert "orders submitted" in result.output
+
+    # Independent recomputation from the broker's persisted fills.
+    store = SqliteStore(db)
+    fills = store.fills()
+    assert fills, "the run should have produced at least one fill"
+
+    by_instrument: dict[Instrument, list[Fill]] = {}
+    for fill in fills:
+        by_instrument.setdefault(fill.instrument, []).append(fill)
+    expected_pnl = sum(
+        (Position.from_fills(fs).realised_pnl for fs in by_instrument.values()),
+        money("0"),
+    )
+
+    # The realised PnL printed in the summary must equal the fills-based figure.
+    assert _render.fmt_money(expected_pnl) in result.output
+
+
+def test_run_synthetic_feed_default(tmp_path: pathlib.Path) -> None:
+    """`run` with no --bars uses the built-in synthetic feed and exits 0."""
+    result = runner.invoke(app, ["run"])
+
+    assert result.exit_code == 0, result.output
+    assert "run complete" in result.output
+    # The default synthetic feed trends enough to submit at least one order.
+    assert "orders submitted" in result.output
+
+
+# --- --live guard ---------------------------------------------------------- #
+
+
+def test_run_live_without_confirmation_refuses_no_order() -> None:
+    """`run --live` with no confirmation refuses (non-zero) and places no order.
+
+    The interactive confirm gets EOF (no tty), so it aborts: a non-zero exit, a
+    clear refusal, and — crucially — the live broker is never even built, so no
+    order can have been placed.
+    """
+    result = runner.invoke(app, ["run", "--live"], input="")
+
+    assert result.exit_code != 0
+    # No "run complete" line — the run never proceeded to the engine.
+    assert "run complete" not in result.output
+
+
+def test_run_live_acknowledged_without_credentials_refuses(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`run --live --yes-i-understand` without creds refuses, places no order.
+
+    The acknowledgement passes the CLI gate, but ``build_engine`` refuses a
+    credential-less live Kraken venue (paper-by-default invariant): a non-zero
+    exit, a clear message, no order placed.
+    """
+    # Ensure no Kraken credentials are visible.
+    monkeypatch.delenv("KRAKEN_API_KEY", raising=False)
+    monkeypatch.delenv("KRAKEN_API_SECRET", raising=False)
+
+    cfg = tmp_path / "live.yaml"
+    cfg.write_text(
+        "mode: paper\nbrokers:\n  - name: k\n    exchange: kraken\n"
+    )
+
+    result = runner.invoke(
+        app,
+        ["run", "--live", "--yes-i-understand", "-c", str(cfg)],
+    )
+
+    assert result.exit_code != 0
+    assert "refusing to run" in result.output
+    assert "credentials" in result.output
+    assert "run complete" not in result.output
+
+
+def test_run_live_declined_confirmation_refuses() -> None:
+    """`run --live` answering 'n' to the confirmation refuses with non-zero exit."""
+    result = runner.invoke(app, ["run", "--live"], input="n\n")
+
+    assert result.exit_code != 0
+    assert "run complete" not in result.output
+
+
+# --- status ---------------------------------------------------------------- #
+
+
+def _seed_store(path: pathlib.Path) -> None:
+    """Persist a known order + a couple of fills into a store at ``path``."""
+    store = SqliteStore(path)
+
+    # A still-open order (status OPEN) so status lists it under "Open orders".
+    order = Order(
+        client_order_id="cid-1",
+        instrument=_BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("2"),
+        type=OrderType.LIMIT,
+        limit_price=money("30000"),
+    )
+    order.submit()
+    order.open("VID-1")
+    store.upsert_order(order)
+
+    # Fills that leave a net long position of 1 BTC with some realised PnL.
+    store.record_fill(
+        Fill("F1", "cid-0", _BTC_USD, OrderSide.BUY, money("2"),
+             money("30000"), money("0"), 1)
+    )
+    store.record_fill(
+        Fill("F2", "cid-1", _BTC_USD, OrderSide.SELL, money("1"),
+             money("31000"), money("0"), 2)
+    )
+
+
+def test_status_renders_positions_and_open_orders(
+    tmp_path: pathlib.Path,
+) -> None:
+    """`status --db` prints a positions table + an open-orders table."""
+    db = tmp_path / "state.db"
+    _seed_store(db)
+
+    result = runner.invoke(app, ["status", "--db", str(db)])
+
+    assert result.exit_code == 0, result.output
+    # Net position 1 BTC, the instrument, and the open order's id all present.
+    assert "BTC/USD" in result.output
+    assert "Positions" in result.output
+    assert "Open orders" in result.output
+    assert "cid-1" in result.output
+
+
+def test_status_missing_db_errors() -> None:
+    """`status --db <missing>` fails cleanly rather than crashing."""
+    result = runner.invoke(app, ["status", "--db", "/nonexistent/x.db"])
+
+    assert result.exit_code != 0
+
+
+# --- kpi ------------------------------------------------------------------- #
+
+
+def test_kpi_renders_realised_pnl(tmp_path: pathlib.Path) -> None:
+    """`kpi --db` renders the KPI table with the expected realised PnL.
+
+    A known two-fill sequence (buy 2 @ 30000, sell 1 @ 31000, no fees) realises
+    exactly 1000 on the closed unit; the table must show that figure.
+    """
+    db = tmp_path / "kpi.db"
+    _seed_store(db)
+
+    result = runner.invoke(app, ["kpi", "--db", str(db)])
+
+    assert result.exit_code == 0, result.output
+    assert "Realised PnL" in result.output
+    assert "1000" in result.output  # (31000 - 30000) * 1, no fees
+    assert "Sharpe" in result.output
+
+
+# --- _render helpers (no CLI) ---------------------------------------------- #
+
+
+def test_positions_table_contains_formatted_values() -> None:
+    """`positions_table` renders net qty / avg entry / realised PnL exactly."""
+    fills = [
+        Fill("F1", "c-0", _BTC_USD, OrderSide.BUY, money("2"),
+             money("30000"), money("0"), 1),
+        Fill("F2", "c-1", _BTC_USD, OrderSide.SELL, money("1"),
+             money("31000"), money("0"), 2),
+    ]
+    pos = Position.from_fills(fills)
+    table = _render.positions_table({_BTC_USD: pos})
+
+    rendered = _render_to_text(table)
+    assert "BTC/USD" in rendered
+    assert "1000" in rendered  # realised PnL
+    assert "30000" in rendered  # avg entry of the remaining 1 BTC
+
+
+def test_kpi_table_contains_realised_pnl_and_ratios() -> None:
+    """`kpi_table` shows realised PnL + the named ratios for a known fill set."""
+    perf = PerformanceService(v0=money("100000"))
+    perf.apply(
+        Fill("F1", "c-0", _BTC_USD, OrderSide.BUY, money("2"),
+             money("30000"), money("0"), 1)
+    )
+    perf.apply(
+        Fill("F2", "c-1", _BTC_USD, OrderSide.SELL, money("1"),
+             money("31000"), money("0"), 2)
+    )
+    table = _render.kpi_table(perf)
+
+    rendered = _render_to_text(table)
+    assert "Realised PnL" in rendered
+    assert "1000" in rendered
+    for metric in ("Sharpe", "Sortino", "Max drawdown", "Calmar"):
+        assert metric in rendered
+
+
+def test_fmt_money_never_uses_float() -> None:
+    """`fmt_money` renders exact decimals (no float) and ``None`` as a dash."""
+    assert _render.fmt_money(money("0.1")) == "0.1"
+    assert _render.fmt_money(money("1000")) == "1000"
+    assert _render.fmt_money(None) == "-"
+    # Fixed-places display quantises exactly, no binary error.
+    assert _render.fmt_money(money("1000.5"), places=2) == "1000.50"
+
+
+def _render_to_text(renderable: object) -> str:
+    """Render a rich renderable to plain text for substring assertions."""
+    from rich.console import Console
+
+    console = Console(width=200, record=True)
+    console.print(renderable)
+    return console.export_text()


### PR DESCRIPTION
## Summary
- Second leaf of **E7**: the user-facing `trading-bot` commands — `run` (run a strategy over a `--bars` file or a synthetic feed, **paper by default**), `status` and `kpi` (read a persisted `--db` history; rich tables, money as Decimal). The MVP is now runnable from the command line.

## Why
- `--live` requires **both** an explicit ack (`--yes-i-understand`/confirm) **and** credentials — "no live by accident" enforced at the interface, not just the factory. `status`/`kpi` rebuild from stored **fills** (PnL source of truth), genuinely testable. See `doc/dev/03-decisions.md`.

## Changes
- `interfaces/cli/main.py` (run/status/kpi) + `interfaces/cli/_render.py` (rich tables); `tests/interfaces/test_cli_commands.py` (11 tests, offline via CliRunner).

## Changelog
Added: `trading-bot` CLI commands — `run`/`status`/`kpi`.

## Test plan
- [x] `.venv/bin/python -m pytest` (450 passed, 0 unexpected skips)
- [x] end-to-end: `run` over an OHLC fixture → `kpi` → independent recompute all agree (realised PnL)
- [x] `--live` without ack/creds → refused, no order placed
- [x] ran `trading-bot run` myself: prints summary + positions table; paper fills
- [x] `ruff` + `mypy` clean