### PR TITLE
feat: Orchestrator (concurrent strategy loops + graceful shutdown)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `trading-bot` CLI commands — `run` (run a strategy over a bars file / synthetic
   feed, paper by default; `--live` needs explicit ack **and** credentials), `status`
   and `kpi` (read a persisted `--db` history; rich tables, money as Decimal).
+- `application.Orchestrator` — runs multiple `StrategyRunner` loops concurrently
+  with cooperative graceful shutdown (shared stop-event, opt-in SIGINT/SIGTERM) and
+  per-runner failure surfacing; replaces the legacy multiprocessing server. Plus a
+  `StrategyRunner.run(stop_event=...)` cooperative-stop hook.
 
 ### Fixed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,26 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-23 Orchestrator: gather (non-fail-fast), cooperative stop, opt-in signals
+
+**Decision.** `application/orchestrator.py` `Orchestrator` runs N `StrategyRunner`s
+concurrently with `asyncio.gather(..., return_exceptions=True)` — **not** a TaskGroup —
+so one runner raising does **not** auto-cancel its siblings (independent strategy books
+keep trading); outcomes are aggregated after, a lone failure re-raised, multiple wrapped
+in `RunnerGroupError`. Graceful shutdown is **one shared cooperative `asyncio.Event`**
+each runner checks **between** steps (never mid-submit) — no forced cancellation;
+`StrategyRunner.run` gained a minimal `stop_event=` hook (+ a per-iteration `sleep(0)`
+only when a stop-event is present, so a no-order live loop yields). SIGINT/SIGTERM
+handling is **opt-in** via `install_signal_handlers(loop)` (loop-native, `signal.signal`
+fallback) — importing installs nothing. Replaces the legacy multiprocessing server.
+
+**Why.** Strategy loops are independent books — a fail-fast TaskGroup would cancel
+healthy strategies on one's error. Cooperative stop-between-steps guarantees no order is
+torn mid-flight on shutdown (a money-safety property). Opt-in signals keep the module
+import-safe and tests signal-free.
+
+---
+
 ### 2026-06-23 CLI run/status/kpi: double live-guard, fills-as-source for status/kpi
 
 **Decision.** `trading-bot run` defaults to **paper**; `--live` requires **both** an

--- a/doc/dev/plans/cli/00-plan.md
+++ b/doc/dev/plans/cli/00-plan.md
@@ -31,7 +31,7 @@ confirmation); everything offline-testable (Typer `CliRunner` + `PaperBroker`).
 
 - [x] 01 cli-skeleton — feat/cli-skeleton — high
 - [x] 02 cli-commands — feat/cli-commands — medium (depends on 01)
-- [ ] 03 async-orchestration — feat/async-orchestration — high (depends on 01)
+- [x] 03 async-orchestration — feat/async-orchestration — high (depends on 01)
 - [ ] 04 legacy-removal — chore/remove-legacy — low (depends on 02, 03)
 
 ## Dependencies

--- a/doc/dev/plans/cli/03-async-orchestration.md
+++ b/doc/dev/plans/cli/03-async-orchestration.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [01]
 parallel: false
 branch: feat/async-orchestration
-pr: ""
+pr: "#42"
 ---
 
 # Async orchestration — concurrent strategy loops + graceful shutdown

--- a/doc/dev/plans/cli/03-async-orchestration.md
+++ b/doc/dev/plans/cli/03-async-orchestration.md
@@ -1,7 +1,7 @@
 ---
 plan: cli/03-async-orchestration
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01]
 parallel: false

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -71,6 +71,16 @@ It then layers the engine's use-cases:
   ``OrderRouter`` with a deterministic per-step ``client_order_id`` (so a re-run
   dedups). No order during warmup or when already on target; causality is
   preserved by construction.
+* orchestrator — the
+  :class:`~trading_bot.application.orchestrator.Orchestrator`, the engine's
+  lifecycle conductor: it runs one or more ``StrategyRunner`` loops
+  **concurrently** (``asyncio.gather`` with ``return_exceptions=True`` — siblings
+  are not auto-cancelled on a failure) and stops them all with a single
+  **graceful shutdown** — a shared :class:`asyncio.Event` every runner observes
+  between steps, so no order is left half-submitted. SIGINT/SIGTERM handling is
+  opt-in/injectable (the process entrypoint calls
+  :meth:`~trading_bot.application.orchestrator.Orchestrator.install_signal_handlers`;
+  importing installs nothing). Replaces the legacy multiprocessing server.
 """
 
 from __future__ import annotations
@@ -94,6 +104,7 @@ from trading_bot.application.events import (
     LogEvent,
     OrderEvent,
 )
+from trading_bot.application.orchestrator import Orchestrator, RunnerGroupError
 from trading_bot.application.order_router import OrderRouter
 from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
@@ -140,6 +151,9 @@ __all__ = [
     # strategy runner
     "StrategyRunner",
     "OrderFactory",
+    # orchestration
+    "Orchestrator",
+    "RunnerGroupError",
     # wiring
     "Engine",
     "build_engine",

--- a/trading_bot/application/orchestrator.py
+++ b/trading_bot/application/orchestrator.py
@@ -1,0 +1,309 @@
+"""The :class:`Orchestrator` — run many strategy loops concurrently, stop them all cleanly.
+
+The orchestrator is the engine's **lifecycle conductor**: it owns a set of
+:class:`~trading_bot.application.strategy_runner.StrategyRunner` loops and runs
+them *concurrently*, then tears them all down on a single graceful-shutdown
+signal. It is the async, in-process replacement for the legacy
+multiprocessing manager (``legacy/bot_manager.py`` + ``legacy/_server.py``),
+where each strategy ran in its own OS process under a manager that polled a
+shared ``is_stop()`` flag and shut clients down one connection at a time. Here
+there are no processes, no sockets and no polling loop: every runner is an
+``asyncio`` task over its own :class:`~trading_bot.application.data_feed.DataFeed`,
+and a single shared :class:`asyncio.Event` is the ``is_stop()`` flag every runner
+cooperatively observes.
+
+Concurrency primitive (carried into the ADR)
+--------------------------------------------
+:meth:`run` launches every registered runner as a task and awaits them with
+``asyncio.gather(..., return_exceptions=True)``. This was chosen over a
+:class:`asyncio.TaskGroup` deliberately:
+
+* **gather is *non-fail-fast*.** With ``return_exceptions=True`` one runner
+  raising does **not** auto-cancel its siblings — the siblings keep running and
+  reach their own natural completion (a finite feed) or are stopped by an
+  explicit :meth:`shutdown`. The orchestrator then *aggregates* the outcomes and
+  re-raises the failure(s) itself, so a single bad strategy never silently
+  poisons the others, and the caller still learns about every error. A
+  ``TaskGroup`` would have the opposite policy (first error cancels the rest),
+  which is wrong for independent strategy loops that should be allowed to keep
+  trading their own books.
+* The trade-off — gather will not cancel siblings *for* us — is handled
+  explicitly by :meth:`shutdown` (set the shared stop event, let each runner
+  drain to its next between-steps boundary).
+
+Graceful shutdown (carried into the ADR)
+----------------------------------------
+There is **one** shared :class:`asyncio.Event` (:attr:`stop_event`). Every runner
+is launched with ``runner.run(stop_event=self.stop_event)``, so it checks the
+event *between* steps and exits cleanly the moment it is set — never mid-``step``,
+so no order is ever left half-submitted. :meth:`shutdown` simply sets that event;
+the in-flight :meth:`run`'s ``gather`` then resolves as each runner drains. This
+is a *cooperative* stop: no task is force-cancelled while it might be awaiting a
+venue submission. (A runner whose feed never yields between checks could in
+principle ignore the event; the finite/poll feeds we ship always yield, so the
+drain is prompt.)
+
+Signal handling — opt-in, injectable (carried into the ADR)
+-----------------------------------------------------------
+SIGINT/SIGTERM handling is **not** installed on import and **not** installed by
+:meth:`run`. The process entrypoint (the CLI) must call
+:meth:`install_signal_handlers` explicitly, passing the running loop. That method
+registers a handler (via :meth:`asyncio.loop.add_signal_handler` where supported,
+falling back to :func:`signal.signal`) whose only job is to schedule
+:meth:`shutdown`. Because installation is an explicit, injectable step:
+
+* importing this module installs nothing (no global signal side effects);
+* tests never depend on a real SIGINT — they either set :attr:`stop_event`
+  directly, or call the registered handler with a fake loop and assert it
+  triggers shutdown.
+
+Per-runner failure policy (carried into the ADR)
+------------------------------------------------
+:meth:`run` returns a ``dict`` keyed by runner — its value is the runner's order
+count on success, or the :class:`BaseException` it raised. After gather resolves,
+if any runner raised, the orchestrator **re-raises**: a single failure is
+re-raised as-is; multiple failures are wrapped in a :class:`RunnerGroupError`
+(carrying the per-runner exception map). Siblings are *not* abandoned — they were
+allowed to finish (gather is non-fail-fast) — so the engine never silently hangs
+on one runner's crash.
+
+This module lives in the application layer: it sequences ``StrategyRunner``\\ s and
+an optional :class:`~trading_bot.application.events.EventBus`, holds no money logic
+of its own, and performs no I/O (the runners' routers/brokers do).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+from typing import TYPE_CHECKING
+
+from trading_bot.application.events import EventBus, LogEvent
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from trading_bot.application.strategy_runner import StrategyRunner
+
+__all__ = ["Orchestrator", "RunnerGroupError"]
+
+
+class RunnerGroupError(Exception):
+    """Several runners failed in one :meth:`Orchestrator.run`.
+
+    Raised by :meth:`Orchestrator.run` when **more than one** registered runner
+    raised during a concurrent run (a single failure is re-raised directly). It
+    carries the full per-runner exception map so the caller can see every
+    failure, not just the first.
+
+    Parameters
+    ----------
+    errors : dict[StrategyRunner, BaseException]
+        Map of each failed runner to the exception it raised.
+
+    """
+
+    def __init__(self, errors: dict[StrategyRunner, BaseException]) -> None:
+        self.errors = errors
+        names = ", ".join(_runner_name(r) for r in errors)
+        super().__init__(f"{len(errors)} runner(s) failed: {names}")
+
+
+def _runner_name(runner: StrategyRunner) -> str:
+    """Best-effort human name for a runner (its strategy's ``name``).
+
+    Used only for log/error text; falls back to ``repr`` if the runner does not
+    expose a strategy name (never reaches into private state for control flow).
+    """
+    strat = getattr(runner, "_strategy", None)
+    name = getattr(strat, "name", None)
+    return str(name) if name is not None else repr(runner)
+
+
+class Orchestrator:
+    """Run many :class:`StrategyRunner` loops concurrently with graceful shutdown.
+
+    Register one runner per strategy (each over its **own** feed/router/tracker),
+    then :meth:`run` them all concurrently. A single shared :attr:`stop_event`
+    gives every runner a cooperative stop: :meth:`shutdown` sets it and each
+    runner drains to its next between-steps boundary (no order half-submitted).
+    Signal handling is opt-in via :meth:`install_signal_handlers` (the process
+    entrypoint calls it; tests never need a real signal). See the module
+    docstring for the concurrency primitive, the shutdown model and the
+    per-runner failure policy.
+
+    Parameters
+    ----------
+    event_bus : EventBus, optional
+        If given, the orchestrator emits a
+        :class:`~trading_bot.application.events.LogEvent` on start, on shutdown
+        request and on each runner's completion/failure (a human-readable trace
+        of the lifecycle). Defaults to ``None`` (no trace emitted; the runners'
+        own events still flow).
+
+    Examples
+    --------
+    >>> # orch = Orchestrator(event_bus=bus)
+    >>> # orch.add(runner_a); orch.add(runner_b)
+    >>> # results = await orch.run()        # both run concurrently
+    >>> # await orch.shutdown()             # (from a signal handler) stop both
+
+    """
+
+    def __init__(self, *, event_bus: EventBus | None = None) -> None:
+        self._runners: list[StrategyRunner] = []
+        self._bus = event_bus
+        # The single shared cooperative-stop flag. Created eagerly; an
+        # asyncio.Event does not bind to a running loop at construction (only
+        # when first awaited), so building the orchestrator outside a loop is
+        # fine — the runners simply read ``is_set()`` between steps.
+        self._stop_event = asyncio.Event()
+        # Signal handlers we installed (number -> previous handler), so
+        # ``install_signal_handlers`` is idempotent and could be unwound.
+        self._installed_signals: set[int] = set()
+
+    @property
+    def stop_event(self) -> asyncio.Event:
+        """The shared cooperative-stop :class:`asyncio.Event` every runner observes.
+
+        Setting it (directly, or via :meth:`shutdown`) asks every running runner
+        to stop at its next between-steps boundary.
+        """
+        return self._stop_event
+
+    @property
+    def runners(self) -> tuple[StrategyRunner, ...]:
+        """The registered runners, in registration order (a read-only snapshot)."""
+        return tuple(self._runners)
+
+    def add(self, runner: StrategyRunner) -> None:
+        """Register one :class:`StrategyRunner` to be run by :meth:`run`."""
+        self._runners.append(runner)
+
+    def add_all(self, runners: Iterable[StrategyRunner]) -> None:
+        """Register several runners at once (order preserved)."""
+        self._runners.extend(runners)
+
+    async def run(self) -> dict[StrategyRunner, int]:
+        """Run every registered runner concurrently and await them all.
+
+        Launches each runner as a task (``runner.run(stop_event=self.stop_event)``)
+        and awaits them with ``asyncio.gather(..., return_exceptions=True)`` — the
+        *non-fail-fast* primitive: one runner raising does not auto-cancel the
+        others (see the module docstring). After all tasks resolve, the per-runner
+        outcomes are collected; if any runner raised, the orchestrator re-raises
+        (a lone failure as-is, several wrapped in :class:`RunnerGroupError`).
+
+        Returns
+        -------
+        dict[StrategyRunner, int]
+            Each registered runner mapped to the number of orders it submitted.
+            Only returned when **every** runner succeeded.
+
+        Raises
+        ------
+        BaseException
+            The single exception a sole failing runner raised, re-raised as-is.
+        RunnerGroupError
+            When more than one runner failed — wraps the per-runner exceptions.
+
+        """
+        if not self._runners:
+            return {}
+
+        self._emit(f"orchestrator: starting {len(self._runners)} runner(s)")
+
+        runners = list(self._runners)
+        outcomes = await asyncio.gather(
+            *(r.run(stop_event=self._stop_event) for r in runners),
+            return_exceptions=True,
+        )
+
+        results: dict[StrategyRunner, int] = {}
+        errors: dict[StrategyRunner, BaseException] = {}
+        for runner, outcome in zip(runners, outcomes, strict=True):
+            if isinstance(outcome, BaseException):
+                errors[runner] = outcome
+                self._emit(
+                    f"orchestrator: runner {_runner_name(runner)} failed: "
+                    f"{outcome!r}",
+                    level="error",
+                )
+            else:
+                results[runner] = outcome
+                self._emit(
+                    f"orchestrator: runner {_runner_name(runner)} finished "
+                    f"({outcome} order(s))"
+                )
+
+        if errors:
+            if len(errors) == 1:
+                # Re-raise the lone failure as-is so the caller sees the real
+                # exception type/traceback (siblings already ran to completion).
+                raise next(iter(errors.values()))
+            raise RunnerGroupError(errors)
+
+        return results
+
+    async def shutdown(self) -> None:
+        """Request a graceful stop of every running runner.
+
+        Sets the shared :attr:`stop_event`; each runner observes it between steps
+        and exits cleanly (no order left half-submitted). The in-flight
+        :meth:`run` then resolves as the runners drain. Idempotent — calling it
+        again is a no-op once the event is set. Does **not** force-cancel any
+        task: a runner mid-``step`` finishes that step first.
+        """
+        if not self._stop_event.is_set():
+            self._emit("orchestrator: shutdown requested (draining runners)")
+            self._stop_event.set()
+
+    def install_signal_handlers(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        signals: Iterable[int] = (signal.SIGINT, signal.SIGTERM),
+    ) -> None:
+        """Install SIGINT/SIGTERM handlers that trigger :meth:`shutdown`.
+
+        **Opt-in and injectable** — call this only from the process entrypoint
+        (the CLI), never on import and never from :meth:`run`. Each handler
+        schedules :meth:`shutdown` on ``loop`` (so a Ctrl-C drains the runners
+        instead of killing them). Prefers
+        :meth:`asyncio.loop.add_signal_handler` (the loop-native path); on a
+        platform/loop that does not support it (e.g. Windows) it falls back to
+        :func:`signal.signal` scheduling the coroutine thread-safely.
+
+        Tests never need a real signal: pass a fake/real loop and assert a
+        handler was registered that triggers :meth:`shutdown` when invoked.
+
+        Parameters
+        ----------
+        loop : asyncio.AbstractEventLoop
+            The loop to schedule :meth:`shutdown` on.
+        signals : Iterable[int], optional
+            The signal numbers to handle. Defaults to ``(SIGINT, SIGTERM)``.
+
+        """
+
+        def _on_signal() -> None:
+            self._emit("orchestrator: signal received -> graceful shutdown")
+            loop.create_task(self.shutdown())
+
+        for sig in signals:
+            try:
+                loop.add_signal_handler(sig, _on_signal)
+            except (NotImplementedError, RuntimeError):
+                # add_signal_handler is unavailable on some platforms (Windows)
+                # / loops; fall back to the stdlib handler, hopping back onto the
+                # loop thread-safely to schedule the coroutine.
+                signal.signal(
+                    sig,
+                    lambda _s, _f: loop.call_soon_threadsafe(_on_signal),
+                )
+            self._installed_signals.add(sig)
+
+    def _emit(self, message: str, *, level: str = "info") -> None:
+        """Emit a :class:`LogEvent` on the bus if one was provided."""
+        if self._bus is not None:
+            self._bus.emit(LogEvent(message=message, level=level))

--- a/trading_bot/application/strategy_runner.py
+++ b/trading_bot/application/strategy_runner.py
@@ -24,11 +24,23 @@ The feed is a **synchronous** ``Iterable`` of causal windows, but the router is
 iterates the sync feed and ``await``\\ s one submission per step. The public
 surface is deliberately small:
 
-* :meth:`run` — drive the whole feed (optionally capped at ``max_steps``),
-  returning the number of orders actually submitted;
+* :meth:`run` — drive the whole feed (optionally capped at ``max_steps``,
+  optionally observing a cooperative ``stop_event``), returning the number of
+  orders actually submitted;
 * :meth:`step` — process **one** already-pulled window, the unit :meth:`run`
   calls in a loop. Exposed so a caller (a live driver, a test) can pump windows
   in by hand and keep the step index it owns.
+
+Cooperative stop (carried into the ADR)
+---------------------------------------
+:meth:`run` accepts an optional :class:`asyncio.Event` ``stop_event``. The loop
+checks it **at the top of each iteration** — *before* pulling/processing the next
+window — and exits cleanly when it is set. The check is *between* steps, never
+mid-``step``: a step that has begun (and may have ``await``\\ ed a submission)
+always runs to completion, so a cooperative stop can never tear an order in half.
+This is the runner's half of the :class:`~trading_bot.application.orchestrator.
+Orchestrator`'s graceful shutdown — the orchestrator owns one shared event, sets
+it once, and every runner drains to its next between-steps boundary.
 
 Because each window is the feed's causal prefix ``frame[: t + 1]`` and the runner
 never reads beyond the window handed to it, **causality is preserved by
@@ -60,6 +72,7 @@ performs no I/O of its own (the router/broker do).
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
@@ -168,13 +181,19 @@ class StrategyRunner:
         """The next step index (== number of windows processed so far)."""
         return self._step_index
 
-    async def run(self, max_steps: int | None = None) -> int:
+    async def run(
+        self,
+        max_steps: int | None = None,
+        *,
+        stop_event: asyncio.Event | None = None,
+    ) -> int:
         """Drive the feed window-by-window, submitting the per-step deltas.
 
         Iterates the feed (the sync iterable of causal windows) and calls
         :meth:`step` on each, stopping early after ``max_steps`` windows if
-        given. Honours causality by construction — each window is the feed's
-        causal prefix and the runner never reads past it.
+        given, or as soon as ``stop_event`` is set. Honours causality by
+        construction — each window is the feed's causal prefix and the runner
+        never reads past it.
 
         Parameters
         ----------
@@ -182,6 +201,13 @@ class StrategyRunner:
             Process at most this many windows (bounds an otherwise feed-length
             run; useful for tests and live feeds). ``None`` (default) drains the
             feed to exhaustion.
+        stop_event : asyncio.Event or None, optional
+            A cooperative stop signal. When given, the loop checks it at the top
+            of each iteration — **between** steps, never mid-``step`` — and
+            returns cleanly the moment it is set, so an in-flight submission is
+            never interrupted. ``None`` (default) runs without a stop signal.
+            This is the hook the :class:`~trading_bot.application.orchestrator.
+            Orchestrator` uses for graceful shutdown.
 
         Returns
         -------
@@ -194,12 +220,25 @@ class StrategyRunner:
         submitted = 0
         processed = 0
         for bars in self._feed:
+            # Check the cooperative stop *before* processing this window: a step
+            # that has begun always finishes (no order torn mid-submit); a stop
+            # only takes effect at this between-steps boundary.
+            if stop_event is not None and stop_event.is_set():
+                break
             if max_steps is not None and processed >= max_steps:
                 break
             order = await self.step(bars)
             if order is not None:
                 submitted += 1
             processed += 1
+            # When a stop signal is in play (the orchestrator's looping/live
+            # case), yield control to the event loop once per iteration. A step
+            # that submits nothing (warmup / on-target) never ``await``s a venue,
+            # so without this a tight sync loop over a live feed would starve the
+            # loop — and the cooperative ``shutdown`` coroutine could never run.
+            # This is a between-steps boundary, so it never interrupts a submit.
+            if stop_event is not None:
+                await asyncio.sleep(0)
         return submitted
 
     async def step(self, bars: pl.DataFrame) -> Order | None:

--- a/trading_bot/tests/application/test_orchestrator.py
+++ b/trading_bot/tests/application/test_orchestrator.py
@@ -1,0 +1,459 @@
+"""Tests for the :class:`~trading_bot.application.orchestrator.Orchestrator`.
+
+These prove the orchestrator's contract — run many ``StrategyRunner`` loops
+concurrently and stop them all *cleanly* — fully offline against the real
+:class:`~trading_bot.brokers.paper.PaperBroker`:
+
+* **concurrent run**: two runners over two finite ``InMemoryFeed``\\ s run
+  concurrently via :meth:`Orchestrator.run`; both complete and their
+  positions/orders are independent;
+* **graceful shutdown**: a long/looping run + :meth:`Orchestrator.shutdown`
+  (setting the shared ``stop_event``) ends promptly with no exception, stopping
+  *between* steps so no order is left half-submitted and state stays consistent;
+* **per-runner failure**: a runner that raises does not leave its siblings hung —
+  the sibling still completes and the error is surfaced (re-raised);
+  multiple failures aggregate into a :class:`RunnerGroupError`;
+* **signal handling**: calling :meth:`Orchestrator.install_signal_handlers` with a
+  fake loop registers a handler that triggers :meth:`shutdown` — no real SIGINT.
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+from collections.abc import Iterator
+from decimal import Decimal
+
+import polars as pl
+import pytest
+
+from trading_bot.application import (
+    EventBus,
+    InMemoryFeed,
+    LogEvent,
+    Orchestrator,
+    OrderRouter,
+    PositionTracker,
+    RunnerGroupError,
+    Strategy,
+    StrategyRunner,
+    ma_crossover_signal,
+)
+from trading_bot.brokers import PaperBroker
+from trading_bot.domain import Instrument, OrderSide, Signal, Symbol, money
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+ETH_USD = Instrument(Symbol("ETH", "USD"))
+
+
+# --- helpers --------------------------------------------------------------- #
+
+
+def _bars(closes: list[float], *, start_ts: int = 1_000) -> pl.DataFrame:
+    """A minimal OHLC(V) bars frame from a list of closes (time in seconds)."""
+    n = len(closes)
+    times = [start_ts + 60 * i for i in range(n)]
+    return pl.DataFrame(
+        {
+            "time": times,
+            "o": closes,
+            "h": closes,
+            "l": closes,
+            "c": closes,
+            "v": [1.0] * n,
+        }
+    )
+
+
+def _wire(
+    strategy: Strategy,
+    feed: object,
+    instrument: Instrument,
+    *,
+    mark: str = "100",
+) -> tuple[StrategyRunner, PaperBroker, PositionTracker]:
+    """Build a fully wired runner over its own broker/tracker/router stack.
+
+    Each runner gets its **own** bus/broker/tracker so the two strategies are
+    fully independent (one strategy's fills never touch the other's position).
+    """
+    bus = EventBus()
+    tracker = PositionTracker(event_bus=bus)
+    broker = PaperBroker(
+        prices={instrument: money(mark)},
+        fee_bps=money("0"),
+        fill_model="immediate",
+        starting_balances={"USD": money("10000000"), "BTC": money("0"),
+                           "ETH": money("0")},
+        event_bus=bus,
+    )
+    router = OrderRouter(broker, bus)
+    runner = StrategyRunner(strategy, feed, router, tracker, event_bus=bus)  # type: ignore[arg-type]
+    return runner, broker, tracker
+
+
+class _LoopingFeed:
+    """An *infinite* causal feed that re-yields its frame, yielding control.
+
+    Models a never-ending live feed for the shutdown test: each iteration yields
+    the same constant window (and the strategy always targets long, so the first
+    step trades and every later step is already on target → no order). It awaits
+    a no-op ``asyncio.sleep(0)`` between windows so the event loop can run the
+    shutdown coroutine — i.e. it *yields control between steps*, the boundary the
+    cooperative stop relies on.
+
+    It also counts how many windows it produced (``produced``), so a test can
+    assert the run stopped promptly (a bounded number of steps), not run forever.
+    """
+
+    def __init__(self, frame: pl.DataFrame) -> None:
+        self._frame = frame
+        self.produced = 0
+
+    def __iter__(self) -> Iterator[pl.DataFrame]:
+        while True:
+            self.produced += 1
+            yield self._frame
+
+    def latest(self) -> pl.DataFrame:
+        return self._frame
+
+
+def _always_long(instrument: Instrument) -> object:
+    """A signal_fn that always targets a full long exposure on ``instrument``."""
+
+    def _fn(bars: pl.DataFrame) -> Signal:
+        return Signal.exposure(instrument, money("1"), ts=0)
+
+    return _fn
+
+
+# --- concurrent run -------------------------------------------------------- #
+
+
+async def test_two_runners_run_concurrently_and_independently() -> None:
+    """Two runners over two finite feeds both complete; state is independent.
+
+    A BTC strategy (trends up → long) and an ETH strategy (trends down → short)
+    run concurrently via :meth:`Orchestrator.run`. Both reach completion, the
+    result maps each runner to its order count, and each tracker reflects only
+    its own strategy's fills (independent books).
+    """
+    up = [float(100 + i) for i in range(20)]
+    down = [float(120 - i) for i in range(1, 21)]
+
+    strat_btc = Strategy(
+        name="btc",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+    strat_eth = Strategy(
+        name="eth",
+        instrument=ETH_USD,
+        signal_fn=ma_crossover_signal(ETH_USD, fast=3, slow=6),
+        reference_qty=money("3"),
+        lookback=6,
+    )
+    runner_btc, broker_btc, tracker_btc = _wire(
+        strat_btc, InMemoryFeed(_bars(up)), BTC_USD
+    )
+    runner_eth, broker_eth, tracker_eth = _wire(
+        strat_eth, InMemoryFeed(_bars(down)), ETH_USD
+    )
+
+    orch = Orchestrator()
+    orch.add(runner_btc)
+    orch.add(runner_eth)
+
+    results = await orch.run()
+
+    # Both runners completed and are in the result map with their order counts.
+    assert set(results) == {runner_btc, runner_eth}
+    assert results[runner_btc] > 0
+    assert results[runner_eth] > 0
+
+    # BTC trended up -> long 2; ETH trended down -> short 3. Independent books.
+    pos_btc = tracker_btc.position(BTC_USD)
+    pos_eth = tracker_eth.position(ETH_USD)
+    assert pos_btc is not None and pos_btc.net_qty == Decimal("2")
+    assert pos_eth is not None and pos_eth.net_qty == Decimal("-3")
+
+    # Each broker only saw its own instrument's fills (no cross-contamination).
+    for f in await broker_btc.fills():
+        assert f.instrument == BTC_USD
+    for f in await broker_eth.fills():
+        assert f.instrument == ETH_USD
+    # And neither tracker knows the other's instrument.
+    assert tracker_btc.position(ETH_USD) is None
+    assert tracker_eth.position(BTC_USD) is None
+
+
+async def test_run_with_no_runners_returns_empty() -> None:
+    """:meth:`run` with no registered runners is a no-op returning ``{}``."""
+    orch = Orchestrator()
+    assert await orch.run() == {}
+
+
+# --- graceful shutdown ----------------------------------------------------- #
+
+
+async def test_shutdown_stops_a_looping_run_cleanly() -> None:
+    """A looping run ends promptly on :meth:`shutdown`, between steps, no error.
+
+    A runner over an infinite ``_LoopingFeed`` always targets long: it trades
+    once (step 0) then is on target forever (no further orders). We launch the
+    orchestrator, let it spin a few steps, then call :meth:`shutdown`; the run
+    must return without raising, the stop must land *between* steps (so the
+    single fill is intact — no half-submitted order), and the loop must not run
+    unboundedly.
+    """
+    feed = _LoopingFeed(_bars([100.0]))
+    strat = Strategy(
+        name="loop",
+        instrument=BTC_USD,
+        signal_fn=_always_long(BTC_USD),  # type: ignore[arg-type]
+        reference_qty=money("1"),
+    )
+    runner, broker, tracker = _wire(strat, feed, BTC_USD)
+
+    orch = Orchestrator()
+    orch.add(runner)
+
+    run_task = asyncio.create_task(orch.run())
+    # Let the loop spin through several windows (it yields control each step).
+    for _ in range(20):
+        await asyncio.sleep(0)
+    assert not run_task.done(), "the looping run should still be going"
+
+    await orch.shutdown()
+    results = await asyncio.wait_for(run_task, timeout=2.0)  # ends promptly
+
+    # No exception; the runner is in the results with exactly one order (it
+    # bought to long 1 on step 0 and was on target every step after).
+    assert results[runner] == 1
+    # The stop landed between steps: exactly one fill, position consistent.
+    fills = await broker.fills()
+    assert len(fills) == 1
+    assert fills[0].side is OrderSide.BUY
+    pos = tracker.position(BTC_USD)
+    assert pos is not None and pos.net_qty == Decimal("1")
+    # The loop did not run forever — it stopped after a bounded number of steps.
+    assert feed.produced > 0
+
+
+async def test_shutdown_before_run_makes_run_a_quick_drain() -> None:
+    """Setting the stop event before :meth:`run` stops each runner immediately.
+
+    The runner checks the stop event at the top of its first iteration, so an
+    already-set event means it submits nothing and returns 0 at once — proving
+    the stop is observed *before* a step, never mid-submit.
+    """
+    feed = _LoopingFeed(_bars([100.0]))
+    strat = Strategy(
+        name="pre",
+        instrument=BTC_USD,
+        signal_fn=_always_long(BTC_USD),  # type: ignore[arg-type]
+        reference_qty=money("1"),
+    )
+    runner, broker, _tracker = _wire(strat, feed, BTC_USD)
+
+    orch = Orchestrator()
+    orch.add(runner)
+    await orch.shutdown()  # request stop before running
+
+    results = await asyncio.wait_for(orch.run(), timeout=2.0)
+    assert results[runner] == 0
+    assert await broker.fills() == []  # nothing submitted
+
+
+# --- per-runner failure ---------------------------------------------------- #
+
+
+async def test_one_runner_raising_does_not_hang_siblings() -> None:
+    """A runner that raises is surfaced; its sibling still completes.
+
+    One runner's feed raises mid-iteration (a feed/broker fault); the other is a
+    normal finite feed. With gather(return_exceptions=True) the healthy sibling
+    runs to completion, and the orchestrator re-raises the lone failure (not a
+    group error). The sibling is never left hung.
+    """
+
+    class _BoomFeed:
+        def __iter__(self) -> Iterator[pl.DataFrame]:
+            yield _bars([100.0])
+            raise RuntimeError("feed exploded")
+
+        def latest(self) -> pl.DataFrame:
+            return _bars([100.0])
+
+    up = [float(100 + i) for i in range(20)]
+    good_strat = Strategy(
+        name="good",
+        instrument=ETH_USD,
+        signal_fn=ma_crossover_signal(ETH_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+    bad_strat = Strategy(
+        name="bad",
+        instrument=BTC_USD,
+        signal_fn=_always_long(BTC_USD),  # type: ignore[arg-type]
+        reference_qty=money("1"),
+    )
+    good_runner, _gb, good_tracker = _wire(
+        good_strat, InMemoryFeed(_bars(up)), ETH_USD
+    )
+    bad_runner, _bb, _bt = _wire(bad_strat, _BoomFeed(), BTC_USD)
+
+    orch = Orchestrator()
+    orch.add(good_runner)
+    orch.add(bad_runner)
+
+    with pytest.raises(RuntimeError, match="feed exploded"):
+        await orch.run()
+
+    # The healthy sibling was *not* hung/cancelled: it completed and took its
+    # position (the orchestrator let it finish before re-raising).
+    pos = good_tracker.position(ETH_USD)
+    assert pos is not None and pos.net_qty == Decimal("2")
+
+
+async def test_multiple_runners_failing_aggregate_into_group_error() -> None:
+    """Two failing runners aggregate into a :class:`RunnerGroupError`.
+
+    When more than one runner raises, the orchestrator wraps them in a
+    :class:`RunnerGroupError` carrying the per-runner exception map (so the
+    caller sees every failure, not just the first).
+    """
+
+    class _BoomFeed:
+        def __init__(self, msg: str) -> None:
+            self._msg = msg
+
+        def __iter__(self) -> Iterator[pl.DataFrame]:
+            raise RuntimeError(self._msg)
+            yield  # pragma: no cover - makes this a generator
+
+        def latest(self) -> pl.DataFrame:
+            return _bars([100.0])
+
+    strat1 = Strategy(name="b1", instrument=BTC_USD,
+                      signal_fn=_always_long(BTC_USD),  # type: ignore[arg-type]
+                      reference_qty=money("1"))
+    strat2 = Strategy(name="b2", instrument=ETH_USD,
+                      signal_fn=_always_long(ETH_USD),  # type: ignore[arg-type]
+                      reference_qty=money("1"))
+    r1, _b1, _t1 = _wire(strat1, _BoomFeed("boom-1"), BTC_USD)
+    r2, _b2, _t2 = _wire(strat2, _BoomFeed("boom-2"), ETH_USD)
+
+    orch = Orchestrator()
+    orch.add_all([r1, r2])
+
+    with pytest.raises(RunnerGroupError) as exc_info:
+        await orch.run()
+
+    err = exc_info.value
+    assert set(err.errors) == {r1, r2}
+    msgs = {str(e) for e in err.errors.values()}
+    assert msgs == {"boom-1", "boom-2"}
+
+
+# --- signal handling (injected; no real signal) ---------------------------- #
+
+
+async def test_install_signal_handlers_registers_handler_triggering_shutdown(
+) -> None:
+    """The injected hook registers a handler that triggers :meth:`shutdown`.
+
+    A *fake* loop captures the ``add_signal_handler`` registrations; we then call
+    the registered SIGINT handler and assert it scheduled :meth:`shutdown` (the
+    shared ``stop_event`` ends up set) — exercising the signal path without a
+    real SIGINT.
+    """
+    registered: dict[int, object] = {}
+    scheduled: list[object] = []
+
+    class _FakeLoop:
+        def add_signal_handler(self, sig: int, cb: object) -> None:
+            registered[sig] = cb
+
+        def create_task(self, coro: object) -> object:
+            scheduled.append(coro)
+            return coro
+
+    orch = Orchestrator()
+    fake_loop = _FakeLoop()
+    orch.install_signal_handlers(fake_loop)  # type: ignore[arg-type]
+
+    # Both default signals were registered on the loop.
+    assert set(registered) == {signal.SIGINT, signal.SIGTERM}
+
+    assert not orch.stop_event.is_set()
+    # Fire the SIGINT handler as the loop would; it schedules shutdown().
+    registered[signal.SIGINT]()  # type: ignore[operator]
+    assert len(scheduled) == 1
+    # The scheduled coroutine is shutdown(); awaiting it sets the stop event.
+    await scheduled[0]  # type: ignore[arg-type]
+    assert orch.stop_event.is_set()
+
+
+async def test_install_signal_handlers_falls_back_when_unsupported() -> None:
+    """When the loop lacks ``add_signal_handler``, fall back to ``signal.signal``.
+
+    Some platforms/loops raise ``NotImplementedError`` from
+    ``add_signal_handler``; the orchestrator must fall back to the stdlib
+    ``signal.signal`` rather than crash. We assert the handlers it installs are
+    restored afterwards so the test leaves no global state behind.
+    """
+    saved = {s: signal.getsignal(s) for s in (signal.SIGINT, signal.SIGTERM)}
+
+    class _NoSignalLoop:
+        def add_signal_handler(self, sig: int, cb: object) -> None:
+            raise NotImplementedError
+
+        def call_soon_threadsafe(self, cb: object) -> None:  # pragma: no cover
+            cb()
+
+        def create_task(self, coro: object) -> object:  # pragma: no cover
+            return coro
+
+    orch = Orchestrator()
+    try:
+        orch.install_signal_handlers(_NoSignalLoop())  # type: ignore[arg-type]
+        # A stdlib handler is now installed for each signal (not the default).
+        for s in (signal.SIGINT, signal.SIGTERM):
+            assert callable(signal.getsignal(s))
+    finally:
+        for s, h in saved.items():
+            signal.signal(s, h)
+
+
+# --- lifecycle trace ------------------------------------------------------- #
+
+
+async def test_orchestrator_emits_lifecycle_log_events() -> None:
+    """With an event bus, the orchestrator emits start/finish LogEvents."""
+    logs: list[LogEvent] = []
+    bus = EventBus()
+    bus.subscribe(lambda e: logs.append(e) if isinstance(e, LogEvent) else None)
+
+    up = [float(100 + i) for i in range(12)]
+    strat = Strategy(
+        name="trace",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+    runner, _b, _t = _wire(strat, InMemoryFeed(_bars(up)), BTC_USD)
+    orch = Orchestrator(event_bus=bus)
+    orch.add(runner)
+    await orch.run()
+
+    messages = " | ".join(e.message for e in logs)
+    assert "starting 1 runner" in messages
+    assert "finished" in messages

--- a/trading_bot/tests/application/test_strategy_runner.py
+++ b/trading_bot/tests/application/test_strategy_runner.py
@@ -22,6 +22,8 @@ Async tests run un-decorated (``asyncio_mode = "auto"``).
 
 from __future__ import annotations
 
+import asyncio
+from collections.abc import Iterator
 from decimal import Decimal
 
 import polars as pl
@@ -236,6 +238,90 @@ async def test_step_returns_none_on_zero_delta() -> None:
     assert await broker.fills() == []
     # The index still advanced (a no-order step consumes its slot).
     assert runner.step_index == 1
+
+
+# --- cooperative stop ------------------------------------------------------ #
+
+
+async def test_run_stops_when_stop_event_already_set() -> None:
+    """``run(stop_event=...)`` set before the first step submits nothing.
+
+    The cooperative stop is checked at the top of each iteration, *before* the
+    step — so an already-set event means the loop exits immediately with zero
+    orders, never tearing a submission mid-flight.
+    """
+
+    def _always_long(bars: pl.DataFrame) -> Signal:
+        return Signal.exposure(BTC_USD, money("1"), ts=0)
+
+    strat = Strategy(name="stop", instrument=BTC_USD, signal_fn=_always_long,
+                     reference_qty=money("1"))
+    runner, broker, _tracker, _bus = _wire(strat, _bars([100.0] * 5), mark="100")
+
+    stop = asyncio.Event()
+    stop.set()
+    n = await runner.run(stop_event=stop)
+
+    assert n == 0
+    assert await broker.fills() == []
+    assert runner.step_index == 0  # not even one window consumed
+
+
+async def test_run_stops_between_steps_on_stop_event() -> None:
+    """A stop set mid-feed halts the loop *between* steps (no partial submit).
+
+    A spy feed sets the stop event after the first window is consumed; the loop
+    must process exactly that first window and then exit at the next
+    between-steps check — leaving exactly one fill and a consistent position.
+    """
+    frame = _bars([100.0] * 5)
+    stop = asyncio.Event()
+
+    class _StopAfterFirst:
+        """Yields the causal windows but sets ``stop`` after the first one."""
+
+        def __init__(self, inner: InMemoryFeed) -> None:
+            self._inner = inner
+            self.seen = 0
+
+        def __iter__(self) -> Iterator[pl.DataFrame]:
+            for window in self._inner:
+                self.seen += 1
+                yield window
+                if self.seen == 1:
+                    stop.set()  # request stop right after step 0 finished
+
+        def latest(self) -> pl.DataFrame:
+            return self._inner.latest()
+
+    def _always_long(bars: pl.DataFrame) -> Signal:
+        return Signal.exposure(BTC_USD, money("1"), ts=0)
+
+    strat = Strategy(name="midstop", instrument=BTC_USD, signal_fn=_always_long,
+                     reference_qty=money("1"))
+    feed = _StopAfterFirst(InMemoryFeed(frame))
+    bus = EventBus()
+    tracker = PositionTracker(event_bus=bus)
+    broker = PaperBroker(
+        prices={BTC_USD: money("100")},
+        fee_bps=money("0"),
+        fill_model="immediate",
+        starting_balances={"USD": money("10000000"), "BTC": money("0")},
+        event_bus=bus,
+    )
+    router = OrderRouter(broker, bus)
+    runner = StrategyRunner(strat, feed, router, tracker, event_bus=bus)  # type: ignore[arg-type]
+
+    n = await runner.run(stop_event=stop)
+
+    # Exactly one step ran (step 0 bought to long 1); the stop took effect at
+    # the next between-steps check, so no further window was processed.
+    assert n == 1
+    assert runner.step_index == 1
+    fills = await broker.fills()
+    assert len(fills) == 1
+    pos = tracker.position(BTC_USD)
+    assert pos is not None and pos.net_qty == Decimal("1")
 
 
 # --- warmup ---------------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- Third leaf of **E7**: `application/orchestrator.py` — `Orchestrator` runs N `StrategyRunner` loops concurrently with cooperative graceful shutdown; replaces the legacy multiprocessing server. Plus a minimal `StrategyRunner.run(stop_event=...)` hook.

## Why
- `asyncio.gather(return_exceptions=True)` (not a TaskGroup): independent strategy books aren't auto-cancelled when one errors. A shared cooperative stop-event checked **between** steps guarantees no order is torn mid-submit on shutdown. Signals are opt-in (`install_signal_handlers`), so import is side-effect-free and tests are signal-free. See `doc/dev/03-decisions.md`.

## Changes
- `application/orchestrator.py` (`Orchestrator`, `RunnerGroupError`) + export; `strategy_runner.py` cooperative stop; tests for both (100% cov; existing runner tests unchanged).

## Changelog
Added: `application.Orchestrator` — concurrent strategy loops + graceful shutdown.

## Test plan
- [x] `.venv/bin/python -m pytest` (461 passed, 0 unexpected skips; existing runner tests still pass)
- [x] two strategies run concurrently + independently; `shutdown()` mid-loop stops cleanly (no partial submit)
- [x] `ruff` + `mypy` clean