### PR TITLE
docs: plan triptych-orchestration (E8)

### DIFF
--- a/doc/dev/plans/triptych-orchestration/00-plan.md
+++ b/doc/dev/plans/triptych-orchestration/00-plan.md
@@ -1,0 +1,52 @@
+---
+plan: triptych-orchestration
+kind: global
+status: planning
+roadmap: "- [ ] **E8 — Orchestration of the triptych.** One `AppConfig` declaring data sources (dccd) + strategies (fynance) + brokers; a single entrypoint that wires the three. Decide library-import vs service-driving for dccd here."
+release_on_done: false
+---
+
+# E8 — Orchestration of the triptych
+
+## Goal
+
+Make Trading_Bot the **conductor** of the triptych: a single `AppConfig` declares
+its **data sources** (dccd), **strategies** (fynance signals) and **brokers** +
+risk, and one entrypoint wires all three and runs the whole declared system —
+`trading-bot run <config.yaml>` brings up every configured strategy at once. This
+is the epic that fulfils the "execution **and** orchestration" scope.
+
+**Resolves the deferred decision** (dccd integration depth): **library import**, not
+a separate service — `dccd.Client` exposes `read` (for feeds) **and**
+`backfill`/`stream` (to drive collection), all in-process. No daemon/IPC; trading_bot
+imports dccd and calls it.
+
+**Invariants**: paper-by-default; everything offline-testable (a fake dccd client +
+`InMemoryFeed` + `PaperBroker`).
+
+## Decomposition
+
+1. **app-config-full** — extend `AppConfig`: each strategy declares its data source + signal ref + sizing; a top-level data/storage section. Backward-compatible.
+2. **dccd-integration** — `application/data_provider.py`: `feed_for(strategy_config, *, client=None) -> DataFeed` via `dccd.Client` (library import).
+3. **entrypoint** — one entrypoint `AppConfig → engine + per-strategy runners → Orchestrator.run`, wired into `trading-bot run <config.yaml>`.
+
+## Leaf checklist
+
+- [ ] 01 app-config-full — feat/app-config-full — medium
+- [ ] 02 dccd-integration — feat/dccd-integration — high (depends on 01)
+- [ ] 03 entrypoint — feat/triptych-entrypoint — high (depends on 01, 02)
+
+## Dependencies
+
+- 02 depends on 01; 03 depends on 01 + 02. Serial in the main worktree.
+
+## Done criteria
+
+- `AppConfig` declares data + strategies (signal ref + sizing) + brokers + risk,
+  YAML-loadable, backward-compatible; `feed_for` builds a `DataFeed` from a strategy's
+  data source via dccd (library import, fake client offline); one entrypoint runs the
+  whole declared multi-strategy system through the `Orchestrator`.
+- `trading-bot run <config.yaml>` runs a declared (paper) system end-to-end.
+- `ruff`/`mypy`/`pytest` green via `.venv` (0 unexpected skips).
+- Last leaf (03) removes the E8 line from `07-roadmap.md` and updates `06-status.md`
+  (incl. recording the resolved dccd-integration decision).

--- a/doc/dev/plans/triptych-orchestration/01-app-config-full.md
+++ b/doc/dev/plans/triptych-orchestration/01-app-config-full.md
@@ -1,0 +1,65 @@
+---
+plan: triptych-orchestration/01-app-config-full
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/app-config-full
+pr: ""
+---
+
+# AppConfig — full declarative config (data + signal + sizing)
+
+## Goal
+
+Extend `AppConfig` so a single YAML fully declares a runnable system: each strategy
+names its **data source** (dccd: exchange + span + optional history start), its
+**signal** (a `module:function` reference or a builtin like `ma_crossover` with
+params), and its **sizing** (`reference_qty`, `lookback`); plus a top-level
+**data/storage** section. Backward-compatible with the current minimal `AppConfig`.
+
+## Files to change
+
+- `trading_bot/application/config.py` — extend `StrategyConfig` + add `DataSourceConfig`/`StorageConfig`.
+- `trading_bot/tests/application/test_config.py` — extend.
+- A small example config: `examples/config.example.yaml` — new (a runnable paper config).
+
+## Steps
+
+1. Read the current `config.py` (`AppConfig`, `BrokerConfig`, `StrategyConfig`,
+   `RiskConfig`, `from_yaml`).
+2. Extend `StrategyConfig` (keep `name`, `symbol`; all new fields **optional with
+   sensible defaults** so existing configs still validate):
+   - `data: DataSourceConfig` — `exchange: str` (e.g. "kraken"), `span: int`
+     (bar seconds), `start: str | int | None` (history start), `data_type: str = "ohlc"`.
+   - `signal: SignalRefConfig` — `ref: str` (a `"module:function"` **or** a builtin
+     name like `"ma_crossover"`), `params: dict[str, ...]` (e.g. `{fast: 10, slow: 30}`).
+   - `reference_qty: Decimal | None`, `lookback: int = 0`.
+   Use nested pydantic models; validators (non-empty exchange, positive span,
+   non-negative lookback, `reference_qty` positive when set).
+3. `StorageConfig` (top-level, optional): `db_path: str | None = None` (sqlite),
+   plus optional dccd defaults (`data_path: str | None`). Add `AppConfig.storage`.
+4. Keep `from_yaml` working; ensure a **minimal** `AppConfig()` and the existing test
+   configs still validate (backward-compatible — new fields optional/defaulted).
+
+## Tests (via `.venv`)
+
+- A full YAML (mode, storage.db_path, a strategy with data+signal+sizing) →
+  `AppConfig.from_yaml` parses the nested shape exactly (Decimal sizing intact).
+- A **minimal** legacy-shape config (just name+symbol) still validates (defaults applied).
+- Validators: empty exchange / non-positive span / negative lookback / non-positive
+  reference_qty all raise `ValidationError`.
+- The `examples/config.example.yaml` loads and validates.
+
+## Verification on real data
+
+In-process. Load `examples/config.example.yaml` and assert the parsed `AppConfig`
+exposes a strategy with its dccd data source, signal ref + params, and Decimal
+sizing — the shape leaf 02/03 consume. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`AppConfig` — full declarative config (per-strategy data source + signal ref + sizing, storage section)."
+- ADR: the declarative-config shape (signal-by-reference, data-source-per-strategy).
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/triptych-orchestration/02-dccd-integration.md
+++ b/doc/dev/plans/triptych-orchestration/02-dccd-integration.md
@@ -1,0 +1,63 @@
+---
+plan: triptych-orchestration/02-dccd-integration
+kind: leaf
+status: planned
+complexity: high
+depends: [01]
+parallel: false
+branch: feat/dccd-integration
+pr: ""
+---
+
+# dccd integration — feed_for (library import)
+
+## Goal
+
+Build a `DataFeed` for a strategy from its declared dccd data source, via **library
+import** (the resolved integration-depth decision): `dccd.Client.read` produces the
+bars and (optionally) `dccd.Client.backfill` ensures stored data exists first — all
+in-process, no separate service. Injectable client so offline tests use a fake.
+
+## Files to change
+
+- `trading_bot/application/data_provider.py` — new; `feed_for(...)` + a small dccd-client Protocol.
+- `trading_bot/application/__init__.py` — export `feed_for`.
+- `trading_bot/tests/application/test_data_provider.py` — new.
+
+## Steps
+
+1. Read `application/data_feed.py` (`DccdFeed(client, exchange, symbol, span, *, start_ns=None, ...)`,
+   `InMemoryFeed`, the `time,o,h,l,c,v` schema + the dccd column mapping), the new
+   `StrategyConfig.data` (leaf 01), and `dccd.Client` (`read`, `backfill`, `inventory`).
+2. `feed_for(strategy: StrategyConfig, *, client=None, backfill=False) -> DataFeed`:
+   - resolve `exchange`/`symbol`/`span`/`start` from `strategy.data`/`strategy.symbol`;
+   - if `client is None`, construct a real `dccd.Client` (with the configured data path
+     if given) — but keep the dccd type behind a small `Protocol` so tests inject a fake;
+   - optionally (`backfill=True` or when no stored data) call `client.backfill(...)` to
+     **drive collection** before reading — this is the orchestrator role (document it);
+   - return a `DccdFeed(client, ...)` (historical replay of the causal windows). The
+     existing `DccdFeed` already normalises dccd's columns and guarantees causality.
+3. Keep it thin: `feed_for` is config→feed glue; the causal/replay logic stays in
+   `DccdFeed`. The dccd coupling is one import + the injectable client.
+
+## Tests (via `.venv`, offline — fake dccd client)
+
+- `feed_for(strategy_config, client=<fake returning a canned polars frame>)` →
+  a `DccdFeed` that replays the expected causal prefixes (no real dccd).
+- `backfill=True` → the fake client's `backfill` is called before `read` (assert order).
+- The data-source fields (exchange/span/start) are passed through to the read call
+  (assert the fake recorded them).
+- A strategy whose data source is missing/invalid → a clear error.
+
+## Verification on real data
+
+`-m network` (opt-in): if a real `dccd.Client().inventory()` reports stored OHLC for
+some exchange/pair, `feed_for` over it reads via `Client.read` and replays a few
+causal prefixes (monotonic ts, no lookahead). If inventory is empty, **skip** with a
+clear reason — the fake-client test covers the logic. **Run** the offline suite via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.feed_for` — build a DataFeed from a strategy's dccd data source (library import; optional backfill drives collection)."
+- ADR: **the resolved dccd integration decision** — library import (read for feeds, backfill/stream to drive collection), no separate service; why.
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/triptych-orchestration/03-entrypoint.md
+++ b/doc/dev/plans/triptych-orchestration/03-entrypoint.md
@@ -1,0 +1,72 @@
+---
+plan: triptych-orchestration/03-entrypoint
+kind: leaf
+status: planned
+complexity: high
+depends: [01, 02]
+parallel: false
+branch: feat/triptych-entrypoint
+pr: ""
+---
+
+# Triptych entrypoint — one config runs the whole system
+
+## Goal
+
+One entrypoint that turns a full `AppConfig` into a **running multi-strategy
+system**: build the engine, load every declared strategy (signal + feed), wrap each
+in a `StrategyRunner`, and run them all via the `Orchestrator`. Wire it into the CLI
+so `trading-bot run <config.yaml>` brings up the whole declared (paper) system. The
+last E8 leaf — closes the E8 roadmap line.
+
+## Files to change
+
+- `trading_bot/application/run_app.py` — new; `build_runners(config, engine) -> list[StrategyRunner]` + `async run_app(config) -> ...`.
+- `trading_bot/application/__init__.py` — export them.
+- `trading_bot/interfaces/cli/main.py` — `run` accepts a config path and runs the whole declared system (multi-strategy) via the entrypoint; keep the single-strategy/synthetic path for quick demos.
+- `trading_bot/tests/application/test_run_app.py` — new.
+- `trading_bot/tests/interfaces/test_cli_run_config.py` — new (CLI over a config).
+
+## Steps
+
+1. Read `service_factory.build_engine`, `application/strategy.py` (`load_strategy`),
+   `application/data_provider.py` (`feed_for`, leaf 02), `application/strategy_runner.py`,
+   `application/orchestrator.py` (`Orchestrator.add`/`run`), the extended `AppConfig`
+   (leaf 01), and the CLI `run` (leaf E7-02).
+2. `build_runners(config, engine, *, dccd_client=None) -> list[StrategyRunner]`:
+   for each `StrategyConfig`: `strategy = load_strategy(strategy_cfg, strategy_cfg.signal.ref + params)`
+   (resolve a builtin name like `ma_crossover` to the factory, or import a `module:function`);
+   `feed = feed_for(strategy_cfg, client=dccd_client)`; build a `StrategyRunner(strategy,
+   feed, engine.router, engine.tracker, event_bus=engine.bus)`. Return the list.
+3. `async run_app(config, *, db_path=None, dccd_client=None, max_steps=None)`:
+   `engine = build_engine(config, db_path=config.storage.db_path or db_path)`;
+   `runners = build_runners(config, engine, dccd_client=...)`; `orch = Orchestrator(event_bus=engine.bus)`;
+   `orch.add_all(runners)`; `await orch.run()`; return a summary (per-strategy orders,
+   final positions, realised PnL from `engine.perf`). Paper-by-default (engine enforces it).
+4. CLI `run`: when given a **config path**, load `AppConfig.from_yaml`, call `run_app`,
+   and print a per-strategy summary + the positions/KPI table. Keep the existing
+   synthetic/single-strategy quick path (no config) working. `--live` guard unchanged.
+5. Offline-testable: pass a **fake dccd client** (or strategies using `InMemoryFeed`
+   via a test seam) + `PaperBroker` so the whole entrypoint runs with no network.
+
+## Tests (via `.venv`)
+
+- `run_app` over a 2-strategy `AppConfig` (fake dccd client returning canned bars,
+   paper) → both strategies run via the `Orchestrator`, positions update independently,
+   the summary reports each strategy's orders/PnL.
+- CLI `trading-bot run <config.yaml>` (a real example config + an injected/fake feed
+   path) → exit 0, prints a multi-strategy summary.
+- Backward-compat: `trading-bot run` with no config (synthetic) still works.
+- `--live` config without ack/creds → refused, nothing placed.
+
+## Verification on real data
+
+In-process (fake dccd client + PaperBroker is the engine's real data). Run `run_app`
+over a realistic 2-strategy config end-to-end and assert each strategy's position/PnL
+match an independent computation from its fills; run the same via the CLI. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.run_app` + CLI — run a whole declared multi-strategy system from one config (the triptych entrypoint)."
+- ADR: the single-entrypoint orchestration (config → engine → per-strategy runners → Orchestrator); note E8 fulfils the execution+orchestration scope.
+- Status/roadmap: **remove the E8 line** from `07-roadmap.md`; mark E8 done in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E8 — Orchestration of the triptych** — Trading_Bot becomes the conductor: one config declares data (dccd) + strategies (fynance) + brokers, one entrypoint runs the whole declared system.

## Resolves the deferred decision (dccd integration depth)
**Library import**, not a separate service: `dccd.Client` exposes `read` (feeds) **and** `backfill`/`stream` (drive collection), all in-process. No daemon/IPC.

## Leaves
- [ ] 01 app-config-full — feat/app-config-full — medium
- [ ] 02 dccd-integration — feat/dccd-integration — high (depends on 01)
- [ ] 03 entrypoint — feat/triptych-entrypoint — high (depends on 01, 02)

Goal: `trading-bot run <config.yaml>` brings up every configured strategy at once (paper by default). Offline-testable (fake dccd client + InMemoryFeed + PaperBroker).
After merge: `/execute-leaf triptych-orchestration next`.