### PR TITLE
feat: full declarative AppConfig (data + signal + sizing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `AppConfig` — full declarative config: each strategy declares its dccd **data
+  source** (exchange/span/start), its **signal** by reference (`module:function` or a
+  builtin like `ma_crossover` + params) and its sizing (`reference_qty`, `lookback`),
+  plus a top-level `storage` section. Backward-compatible (new fields optional).
+
 - Modern packaging via `pyproject.toml`; dev tooling (ruff, mypy, pytest,
   interrogate, pre-commit) and GitHub Actions CI across Python 3.11–3.13.
 - Claude Code developer workflow: `CLAUDE.md`, `.claude/` (workflow.json, hooks,

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,24 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-25 Declarative config: signal-by-reference, data-source-per-strategy
+
+**Decision.** `AppConfig` grows so one YAML fully declares a runnable system: each
+`StrategyConfig` carries its **data source** (`DataSourceConfig`: dccd exchange/span/
+start/data_type), its **signal by reference** (`SignalRefConfig.ref` = a
+`module:function` dotted string **or** a builtin name like `ma_crossover`, plus a
+`params` dict — resolved by the safe `load_strategy` loader, no arbitrary-file exec),
+and its sizing (`reference_qty` exact `Decimal`, `lookback`). A top-level
+`StorageConfig` separates state (`db_path`) from market-data (`data_path`). Every new
+field is optional/defaulted — legacy minimal configs validate unchanged.
+
+**Why.** A self-contained per-strategy declaration is what makes one entrypoint run a
+whole multi-strategy system (E8-03). Signal-by-reference keeps the no-arbitrary-exec
+safety of the strategy loader. Additive optional fields keep older configs valid as
+the schema grows.
+
+---
+
 ### 2026-06-23 MVP "first light" reached; legacy tree retired
 
 **Decision.** With the Typer CLI + async orchestration in place, the rewrite is

--- a/doc/dev/plans/triptych-orchestration/00-plan.md
+++ b/doc/dev/plans/triptych-orchestration/00-plan.md
@@ -32,7 +32,7 @@ imports dccd and calls it.
 
 ## Leaf checklist
 
-- [ ] 01 app-config-full — feat/app-config-full — medium
+- [x] 01 app-config-full — feat/app-config-full — medium
 - [ ] 02 dccd-integration — feat/dccd-integration — high (depends on 01)
 - [ ] 03 entrypoint — feat/triptych-entrypoint — high (depends on 01, 02)
 

--- a/doc/dev/plans/triptych-orchestration/01-app-config-full.md
+++ b/doc/dev/plans/triptych-orchestration/01-app-config-full.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: []
 parallel: false
 branch: feat/app-config-full
-pr: ""
+pr: "#45"
 ---
 
 # AppConfig — full declarative config (data + signal + sizing)

--- a/doc/dev/plans/triptych-orchestration/01-app-config-full.md
+++ b/doc/dev/plans/triptych-orchestration/01-app-config-full.md
@@ -1,7 +1,7 @@
 ---
 plan: triptych-orchestration/01-app-config-full
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -1,0 +1,43 @@
+# Example trading_bot engine config — a runnable *paper* declaration.
+#
+# Load it with:
+#     from trading_bot.application import AppConfig
+#     cfg = AppConfig.from_yaml("examples/config.example.yaml")
+#
+# Paper by default: this never trades real money. Switching `mode: live`
+# is a deliberate, explicit edit (and needs credentials + confirmation).
+
+mode: paper
+
+# Where the engine persists state and finds market data on disk.
+storage:
+  db_path: ./var/trading_bot.sqlite   # append-only order/fill history + state
+  data_path: ./var/dccd               # dccd on-disk OHLC data directory
+
+# One paper broker (the simulator sits behind the same Broker port as live).
+brokers:
+  - name: paper-main
+    exchange: kraken
+
+# One fully-declared strategy: pair + data source + signal + sizing.
+strategies:
+  - name: btc-ma-cross
+    symbol: BTC/USD
+    data:
+      exchange: kraken
+      span: 3600          # 1h bars (seconds)
+      start: "2024-01-01" # optional history start
+      data_type: ohlc
+    signal:
+      ref: ma_crossover   # builtin name (or a "module:function" import ref)
+      params:
+        fast: 10
+        slow: 30
+    reference_qty: "0.5"  # base units a fractional-exposure signal scales to
+    lookback: 30          # warmup bars before the signal is meaningful
+
+# Engine-wide risk limits (exact Decimals; null = unconstrained).
+risk:
+  max_position: "1.0"
+  max_order: "0.25"
+  max_daily_loss: "500"

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -88,7 +88,10 @@ from __future__ import annotations
 from trading_bot.application.config import (
     AppConfig,
     BrokerConfig,
+    DataSourceConfig,
     RiskConfig,
+    SignalRefConfig,
+    StorageConfig,
     StrategyConfig,
 )
 from trading_bot.application.data_feed import (
@@ -123,6 +126,9 @@ __all__ = [
     # config
     "AppConfig",
     "BrokerConfig",
+    "DataSourceConfig",
+    "SignalRefConfig",
+    "StorageConfig",
     "StrategyConfig",
     "RiskConfig",
     # events

--- a/trading_bot/application/config.py
+++ b/trading_bot/application/config.py
@@ -30,13 +30,16 @@ from __future__ import annotations
 
 import pathlib
 from decimal import Decimal
-from typing import Literal
+from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field, field_validator
 
 __all__ = [
     "BrokerConfig",
+    "DataSourceConfig",
+    "SignalRefConfig",
+    "StorageConfig",
     "StrategyConfig",
     "RiskConfig",
     "AppConfig",
@@ -69,8 +72,92 @@ class BrokerConfig(BaseModel):
         return v
 
 
+class DataSourceConfig(BaseModel):
+    """Where a strategy's bars come from — a dccd OHLC dataset.
+
+    Declares the dccd read a :class:`~trading_bot.application.data_feed.DccdFeed`
+    performs (leaf 02 consumes ``exchange`` / ``span`` / ``start``): the venue,
+    the bar width, an optional history start, and the data kind.
+
+    Parameters
+    ----------
+    exchange : str
+        Exchange/venue key the bars are stored under (e.g. ``"kraken"``). Passed
+        straight to ``dccd.Client.read``. Must be non-empty.
+    span : int
+        Bar width in **seconds** (dccd's ``span``; also the live close cadence).
+        Must be ``> 0``.
+    start : str or int or None, optional
+        Optional history start — a timestamp/ISO marker the feed maps to a
+        ``start_ns`` bound. ``None`` (default) reads from the dataset's start.
+    data_type : str, optional
+        The dccd data kind to read. Defaults to ``"ohlc"`` (the only kind the
+        bars feed normalises).
+
+    """
+
+    exchange: str
+    span: int
+    start: str | int | None = None
+    data_type: str = "ohlc"
+
+    @field_validator("exchange")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        """Reject a blank ``exchange`` (whitespace-only too)."""
+        if not v or not v.strip():
+            raise ValueError("must be a non-empty string")
+        return v
+
+    @field_validator("span")
+    @classmethod
+    def _positive_span(cls, v: int) -> int:
+        """Reject a non-positive bar ``span`` (seconds)."""
+        if v <= 0:
+            raise ValueError(f"span must be positive seconds, got {v}")
+        return v
+
+
+class SignalRefConfig(BaseModel):
+    """The signal a strategy evaluates — a reference plus its parameters.
+
+    A declarative pointer to a :data:`~trading_bot.application.strategy.SignalFn`
+    (leaf 03 resolves it): either a safe ``"module:function"`` dotted import
+    reference *or* a builtin name like ``"ma_crossover"``, plus the keyword
+    ``params`` the signal is built with (e.g. ``{"fast": 10, "slow": 30}``).
+
+    Parameters
+    ----------
+    ref : str
+        Either a ``"module:function"`` dotted reference or a builtin signal name
+        (e.g. ``"ma_crossover"``). Resolution happens in leaf 03; this leaf only
+        declares the shape. Must be non-empty.
+    params : dict, optional
+        Keyword arguments the signal is built with (e.g.
+        ``{"fast": 10, "slow": 30}``). Empty by default.
+
+    """
+
+    ref: str
+    params: dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("ref")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        """Reject a blank signal ``ref`` (whitespace-only too)."""
+        if not v or not v.strip():
+            raise ValueError("must be a non-empty string")
+        return v
+
+
 class StrategyConfig(BaseModel):
-    """One strategy the engine should drive (skeleton — grows in E5/E8).
+    """One strategy the engine should drive — data, signal and sizing.
+
+    The full declarative shape of a strategy: the pair it trades, where its bars
+    come from (:class:`DataSourceConfig`), the signal it evaluates
+    (:class:`SignalRefConfig`) and its sizing (``reference_qty`` / ``lookback``).
+    Every field beyond ``name`` / ``symbol`` is **optional with a default**, so a
+    legacy ``{name, symbol}``-only config still validates unchanged.
 
     Parameters
     ----------
@@ -80,11 +167,30 @@ class StrategyConfig(BaseModel):
         The canonical pair the strategy trades, ``BASE/QUOTE`` (e.g.
         ``"BTC/USD"``). Kept as a plain string here; later leaves resolve it to
         a :class:`~trading_bot.domain.instrument.Symbol`. Must be non-empty.
+    data : DataSourceConfig or None, optional
+        The strategy's bar source (dccd dataset). ``None`` (default) when the
+        runner supplies a feed by other means.
+    signal : SignalRefConfig or None, optional
+        The signal the strategy evaluates. ``None`` (default) when the signal is
+        injected programmatically rather than declared.
+    reference_qty : Decimal, optional
+        The max position size (base units) a fractional-exposure signal is a
+        fraction of (see :class:`~trading_bot.application.strategy.Strategy`).
+        Parsed exactly from a YAML scalar (``str``/``int``) without touching
+        ``float``. Must be positive when set. ``None`` (default) when the signal
+        emits explicit-quantity signals.
+    lookback : int, optional
+        Warmup: minimum number of bars before the signal is meaningful. Must be
+        ``>= 0``. Default ``0`` (no warmup).
 
     """
 
     name: str
     symbol: str
+    data: DataSourceConfig | None = None
+    signal: SignalRefConfig | None = None
+    reference_qty: Decimal | None = None
+    lookback: int = 0
 
     @field_validator("name", "symbol")
     @classmethod
@@ -93,6 +199,45 @@ class StrategyConfig(BaseModel):
         if not v or not v.strip():
             raise ValueError("must be a non-empty string")
         return v
+
+    @field_validator("reference_qty")
+    @classmethod
+    def _positive_qty(cls, v: Decimal | None) -> Decimal | None:
+        """Reject a non-positive ``reference_qty`` (``None`` is allowed)."""
+        if v is not None and v <= 0:
+            raise ValueError(f"reference_qty must be positive, got {v}")
+        return v
+
+    @field_validator("lookback")
+    @classmethod
+    def _non_negative_lookback(cls, v: int) -> int:
+        """Reject a negative ``lookback``."""
+        if v < 0:
+            raise ValueError(f"lookback must be non-negative, got {v}")
+        return v
+
+
+class StorageConfig(BaseModel):
+    """Where the engine persists state and finds market data on disk.
+
+    Both paths are optional (``None`` = use the layer's default): ``db_path`` is
+    the append-only SQLite store of order/fill history + engine state (the
+    reconciliation source), and ``data_path`` is the dccd data directory the
+    bars feed reads from.
+
+    Parameters
+    ----------
+    db_path : str or None, optional
+        Path to the engine's SQLite database. ``None`` (default) defers to the
+        storage layer's default location.
+    data_path : str or None, optional
+        Path to the dccd on-disk data directory. ``None`` (default) defers to
+        dccd's own default.
+
+    """
+
+    db_path: str | None = None
+    data_path: str | None = None
 
 
 class RiskConfig(BaseModel):
@@ -145,6 +290,9 @@ class AppConfig(BaseModel):
         The strategies to drive. Empty by default.
     risk : RiskConfig, optional
         Engine-wide risk limits. Defaults to all-unconstrained.
+    storage : StorageConfig, optional
+        Where state is persisted (SQLite) and where the bars feed reads data
+        from (dccd dir). Defaults to all-unset (each layer's own default).
 
     Examples
     --------
@@ -165,6 +313,7 @@ class AppConfig(BaseModel):
     brokers: list[BrokerConfig] = Field(default_factory=list)
     strategies: list[StrategyConfig] = Field(default_factory=list)
     risk: RiskConfig = Field(default_factory=RiskConfig)
+    storage: StorageConfig = Field(default_factory=StorageConfig)
 
     @classmethod
     def from_yaml(cls, path: str | pathlib.Path) -> AppConfig:

--- a/trading_bot/tests/application/test_config.py
+++ b/trading_bot/tests/application/test_config.py
@@ -10,6 +10,7 @@ round-trips a small YAML file (via ``tmp_path``).
 
 from __future__ import annotations
 
+import pathlib
 import textwrap
 from decimal import Decimal
 
@@ -19,8 +20,16 @@ from pydantic import ValidationError
 from trading_bot.application import (
     AppConfig,
     BrokerConfig,
+    DataSourceConfig,
     RiskConfig,
+    SignalRefConfig,
+    StorageConfig,
     StrategyConfig,
+)
+
+#: The shipped runnable paper config (resolved from the repo root).
+EXAMPLE_CONFIG = (
+    pathlib.Path(__file__).resolve().parents[3] / "examples" / "config.example.yaml"
 )
 
 # A realistic config dict reused across the round-trip assertions.
@@ -161,3 +170,214 @@ def test_from_yaml_empty_file_is_all_defaults(tmp_path) -> None:
     cfg = AppConfig.from_yaml(path)
     assert cfg.mode == "paper"
     assert cfg.brokers == []
+
+
+# --- full declarative config: data + signal + sizing + storage --------------
+
+# A fully-declared strategy (data + signal + sizing) + storage, as a YAML doc.
+FULL_YAML = textwrap.dedent(
+    """\
+    mode: paper
+    storage:
+      db_path: /tmp/tb.sqlite
+      data_path: /tmp/dccd
+    brokers:
+      - name: paper-main
+        exchange: kraken
+    strategies:
+      - name: btc-ma-cross
+        symbol: BTC/USD
+        data:
+          exchange: kraken
+          span: 3600
+          start: "2024-01-01"
+          data_type: ohlc
+        signal:
+          ref: ma_crossover
+          params:
+            fast: 10
+            slow: 30
+        reference_qty: "0.5"
+        lookback: 30
+    risk:
+      max_order: "0.25"
+    """
+)
+
+
+def test_full_yaml_parses_nested_shape(tmp_path) -> None:
+    """A full YAML round-trips into the exact data+signal+sizing+storage shape."""
+    path = tmp_path / "full.yml"
+    path.write_text(FULL_YAML)
+    cfg = AppConfig.from_yaml(path)
+
+    # storage section
+    assert isinstance(cfg.storage, StorageConfig)
+    assert cfg.storage.db_path == "/tmp/tb.sqlite"
+    assert cfg.storage.data_path == "/tmp/dccd"
+
+    strat = cfg.strategies[0]
+    assert strat.name == "btc-ma-cross"
+    assert strat.symbol == "BTC/USD"
+
+    # data source — exactly what DccdFeed consumes (leaf 02)
+    assert isinstance(strat.data, DataSourceConfig)
+    assert strat.data.exchange == "kraken"
+    assert strat.data.span == 3600
+    assert strat.data.start == "2024-01-01"
+    assert strat.data.data_type == "ohlc"
+
+    # signal ref + params — leaf 03 resolves these; ints survive intact
+    assert isinstance(strat.signal, SignalRefConfig)
+    assert strat.signal.ref == "ma_crossover"
+    assert strat.signal.params == {"fast": 10, "slow": 30}
+    assert all(isinstance(v, int) for v in strat.signal.params.values())
+
+    # sizing — reference_qty is an exact Decimal, never float
+    assert strat.reference_qty == Decimal("0.5")
+    assert isinstance(strat.reference_qty, Decimal)
+    assert strat.lookback == 30
+
+
+def test_minimal_legacy_strategy_still_validates() -> None:
+    """A {name, symbol}-only strategy validates — all new fields defaulted."""
+    cfg = AppConfig.model_validate(
+        {"strategies": [{"name": "legacy", "symbol": "BTC/USD"}]}
+    )
+    strat = cfg.strategies[0]
+    assert strat.data is None
+    assert strat.signal is None
+    assert strat.reference_qty is None
+    assert strat.lookback == 0
+    # storage defaults to an all-unset StorageConfig
+    assert isinstance(cfg.storage, StorageConfig)
+    assert cfg.storage.db_path is None
+    assert cfg.storage.data_path is None
+
+
+def test_reference_qty_parses_decimal_without_float_error() -> None:
+    """A numeric reference_qty keeps its exact decimal meaning."""
+    cfg = AppConfig.model_validate(
+        {"strategies": [{"name": "s", "symbol": "BTC/USD", "reference_qty": 0.1}]}
+    )
+    assert cfg.strategies[0].reference_qty == Decimal("0.1")
+
+
+def test_empty_data_exchange_raises() -> None:
+    """A blank data-source exchange is rejected."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(
+            {
+                "strategies": [
+                    {
+                        "name": "s",
+                        "symbol": "BTC/USD",
+                        "data": {"exchange": "  ", "span": 60},
+                    }
+                ]
+            }
+        )
+
+
+def test_non_positive_span_raises() -> None:
+    """A non-positive bar span is rejected."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(
+            {
+                "strategies": [
+                    {
+                        "name": "s",
+                        "symbol": "BTC/USD",
+                        "data": {"exchange": "kraken", "span": 0},
+                    }
+                ]
+            }
+        )
+
+
+def test_empty_signal_ref_raises() -> None:
+    """A blank signal ref is rejected."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(
+            {
+                "strategies": [
+                    {"name": "s", "symbol": "BTC/USD", "signal": {"ref": ""}}
+                ]
+            }
+        )
+
+
+def test_negative_lookback_raises() -> None:
+    """A negative lookback is rejected."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(
+            {"strategies": [{"name": "s", "symbol": "BTC/USD", "lookback": -1}]}
+        )
+
+
+def test_non_positive_reference_qty_raises() -> None:
+    """A non-positive reference_qty is rejected (zero too)."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate(
+            {
+                "strategies": [
+                    {"name": "s", "symbol": "BTC/USD", "reference_qty": "0"}
+                ]
+            }
+        )
+
+
+def test_signal_params_default_empty() -> None:
+    """A signal with only a ref gets an empty params dict."""
+    cfg = AppConfig.model_validate(
+        {
+            "strategies": [
+                {"name": "s", "symbol": "BTC/USD", "signal": {"ref": "m:f"}}
+            ]
+        }
+    )
+    assert cfg.strategies[0].signal is not None
+    assert cfg.strategies[0].signal.params == {}
+
+
+def test_data_source_data_type_defaults_to_ohlc() -> None:
+    """A data source without data_type defaults to ``ohlc``."""
+    cfg = AppConfig.model_validate(
+        {
+            "strategies": [
+                {
+                    "name": "s",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                }
+            ]
+        }
+    )
+    assert cfg.strategies[0].data is not None
+    assert cfg.strategies[0].data.data_type == "ohlc"
+    assert cfg.strategies[0].data.start is None
+
+
+def test_example_config_loads_and_validates() -> None:
+    """The shipped ``examples/config.example.yaml`` loads + validates.
+
+    Verification on real data: the parsed config exposes the exact shape that
+    leaves 02/03 consume — a dccd data source (exchange/span), a signal ref +
+    params, and Decimal sizing.
+    """
+    assert EXAMPLE_CONFIG.is_file()
+    cfg = AppConfig.from_yaml(EXAMPLE_CONFIG)
+
+    assert cfg.mode == "paper"
+    assert cfg.storage.db_path is not None
+
+    strat = cfg.strategies[0]
+    assert strat.data is not None
+    assert strat.data.exchange == "kraken"
+    assert strat.data.span == 3600
+    assert strat.signal is not None
+    assert strat.signal.ref == "ma_crossover"
+    assert strat.signal.params == {"fast": 10, "slow": 30}
+    assert isinstance(strat.reference_qty, Decimal)
+    assert strat.reference_qty == Decimal("0.5")
+    assert strat.lookback == 30


### PR DESCRIPTION
## Summary
- First leaf of **E8**: `AppConfig` now fully declares a runnable system — each `StrategyConfig` carries its dccd **data source** (exchange/span/start), its **signal by reference** (`module:function` or a builtin like `ma_crossover` + params), and sizing (`reference_qty`, `lookback`); a top-level `storage` section (db_path/data_path). Backward-compatible (all new fields optional/defaulted). New `examples/config.example.yaml`.

## Why
- A self-contained per-strategy declaration is what lets one entrypoint (E8-03) run a whole multi-strategy system. Signal-by-reference keeps the no-arbitrary-exec safety of `load_strategy`. See `doc/dev/03-decisions.md`.

## Changes
- `application/config.py` (+ `DataSourceConfig`/`SignalRefConfig`/`StorageConfig`) + exports; `tests/application/test_config.py` (+13 cases); `examples/config.example.yaml`.

## Changelog
Added: `AppConfig` — full declarative config.

## Test plan
- [x] `.venv/bin/python -m pytest` (472 passed, 0 unexpected skips; existing config tests pass)
- [x] minimal `AppConfig()` still valid (back-compat); `examples/config.example.yaml` loads
- [x] `ruff` + `mypy` clean