### PR TITLE
feat: run_app — one config runs the whole declared system (closes E8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `application.feed_for` — build a `DataFeed` from a strategy's dccd data source via
   **library import** (`dccd.Client.read`); optional `backfill=True` drives dccd
   collection before reading. Injectable client (offline tests run dccd-free).
+- `application.run_app` + CLI — one `AppConfig` runs the whole declared
+  multi-strategy system: build the shared engine, load every strategy (signal + dccd
+  feed), run them concurrently via the `Orchestrator`, report per-strategy
+  orders/positions/PnL. `trading-bot run <config.yaml>` brings up the declared
+  (paper) system. Completes the **E8 triptych orchestration**.
 
 - Modern packaging via `pyproject.toml`; dev tooling (ruff, mypy, pytest,
   interrogate, pre-commit) and GitHub Actions CI across Python 3.11–3.13.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,28 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-25 Single-entrypoint orchestration: one config, one shared engine, N runners
+
+**Decision.** `application/run_app.py` `run_app(config)` is the **system** assembly+run
+seam: `build_engine(config)` builds **one** shared engine (one broker, bus, tracker,
+perf, risk gate); `build_runners` loads every `StrategyConfig` into a `StrategyRunner`
+(signal resolved from `SignalRefConfig` via a closed builtin registry
+`{ma_crossover: …}` **or** a safe `module:function` import — no exec sink; feed via
+`feed_for`); an `Orchestrator` runs them concurrently. All fills fan out on the one bus
+and aggregate in the one tracker/perf, **independent per instrument** (the tracker keys
+by instrument). The CLI `run` delegates here when the config declares strategies,
+keeping the no-config synthetic quick path and the `--live` ack+creds guard. A new
+`domain.errors.ConfigError` flags config-resolution failures.
+
+**Why.** Lifts the factory's "single wiring point" to the *system* level — CLI, tests
+and a future daemon bring the whole declared system up identically through one seam.
+One shared engine means one risk gate / one PnL view across all strategies, while the
+per-instrument tracker keeps distinct-symbol strategies isolated. This is E8: config →
+engine → per-strategy runners → Orchestrator, fulfilling the execution **and**
+orchestration scope (Trading_Bot conducts dccd + fynance + brokers).
+
+---
+
 ### 2026-06-25 dccd integration depth — RESOLVED: library import, not a service
 
 **Decision.** (Resolving the long-deferred decision.) Trading_Bot consumes dccd as an

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,21 +10,24 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**E1–E7 are complete — the MVP "first light" is reached.** The engine runs from the
-command line: `trading-bot run` runs a fynance-backed strategy over a `DataFeed`,
-routing **risk-gated** orders through the `OrderRouter` to a (paper) broker and
-reporting positions / PnL / KPIs; `status`/`kpi` read a persisted `SqliteStore`. Layers:
-`domain/` (pure, mypy-strict), `transport/` (http/ws/ratelimit), `brokers/` (`Broker`
-port + `KrakenBroker` REST+WS + port-pure `PaperBroker`), `storage/` (`SqliteStore`,
-money as TEXT), `application/` (`AppConfig`+`EventBus`, idempotent risk-gated
-`OrderRouter`, `PositionTracker`, `reconcile`, `Strategy`+safe loader, causal
-`DataFeed`, `StrategyRunner`, `PerformanceService`, `RiskManager`+kill-switch,
-`Orchestrator`, `service_factory`), and `interfaces/cli/` (Typer `trading-bot`). The
-pre-2026 `legacy/` tree is **deleted** (history in git); the whole package is
-linted/typed/tested (no exclusions). 461 tests green via the project `.venv`.
+**E1–E8 are complete — Trading_Bot is the conductor of the triptych.** One
+`AppConfig` declares data sources (dccd) + strategies (fynance signals) + brokers +
+risk, and `trading-bot run <config.yaml>` brings up the **whole declared
+multi-strategy system** (paper by default): `run_app` builds one shared engine and
+runs a `StrategyRunner` per strategy concurrently via the `Orchestrator`, reporting
+per-strategy orders/positions/PnL. dccd is integrated by **library import**
+(`feed_for` → `dccd.Client.read`/`backfill`). Layers: `domain/` (pure, mypy-strict),
+`transport/` (http/ws/ratelimit), `brokers/` (`Broker` port + `KrakenBroker` REST+WS +
+port-pure `PaperBroker`), `storage/` (`SqliteStore`, money as TEXT), `application/`
+(declarative `AppConfig`+`EventBus`, idempotent risk-gated `OrderRouter`,
+`PositionTracker`, `reconcile`, `Strategy`+safe loader, causal `DataFeed`+`feed_for`,
+`StrategyRunner`, `PerformanceService`, `RiskManager`+kill-switch, `Orchestrator`,
+`run_app`, `service_factory`), and `interfaces/cli/` (Typer `trading-bot`). The
+pre-2026 `legacy/` tree is deleted; the whole package is linted/typed/tested. 495
+tests green via the project `.venv`.
 
-Pending: **E8** (triptych orchestration — one config wiring dccd+fynance+brokers), E9
-(web UI), E10 (go-live hardening + final name). Next is **E8**. See `07-roadmap.md` /
+Pending: **E9** (web UI — FastAPI/Jinja2 dashboard), **E10** (go-live hardening +
+final name). Next is **E9**. See `07-roadmap.md` /
 `08-program-plan.md`.
 
 ## Done

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -10,12 +10,6 @@ The single source *index* of open work. Each unchecked item is a candidate for
 > **Full decomposition** — every epic broken into its leaves, branches,
 > complexity and dependencies: [`08-program-plan.md`](08-program-plan.md).
 
-## Interfaces & orchestration
-
-- [ ] **E8 — Orchestration of the triptych.** One `AppConfig` declaring data
-  sources (dccd) + strategies (fynance) + brokers; a single entrypoint that wires
-  the three. Decide library-import vs service-driving for dccd here. _(depends on E7)_
-
 ## Later
 
 - [ ] **E9 — Web UI.** FastAPI + Jinja2 dashboard (positions/orders/PnL),

--- a/doc/dev/plans/triptych-orchestration/00-plan.md
+++ b/doc/dev/plans/triptych-orchestration/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: triptych-orchestration
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E8 — Orchestration of the triptych.** One `AppConfig` declaring data sources (dccd) + strategies (fynance) + brokers; a single entrypoint that wires the three. Decide library-import vs service-driving for dccd here."
 release_on_done: false
 ---
@@ -34,7 +34,7 @@ imports dccd and calls it.
 
 - [x] 01 app-config-full — feat/app-config-full — medium
 - [x] 02 dccd-integration — feat/dccd-integration — high (depends on 01)
-- [ ] 03 entrypoint — feat/triptych-entrypoint — high (depends on 01, 02)
+- [x] 03 entrypoint — feat/triptych-entrypoint — high (depends on 01, 02)
 
 ## Dependencies
 

--- a/doc/dev/plans/triptych-orchestration/03-entrypoint.md
+++ b/doc/dev/plans/triptych-orchestration/03-entrypoint.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [01, 02]
 parallel: false
 branch: feat/triptych-entrypoint
-pr: ""
+pr: "#47"
 ---
 
 # Triptych entrypoint — one config runs the whole system

--- a/doc/dev/plans/triptych-orchestration/03-entrypoint.md
+++ b/doc/dev/plans/triptych-orchestration/03-entrypoint.md
@@ -1,7 +1,7 @@
 ---
 plan: triptych-orchestration/03-entrypoint
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01, 02]
 parallel: false

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -87,6 +87,17 @@ It then layers the engine's use-cases:
   opt-in/injectable (the process entrypoint calls
   :meth:`~trading_bot.application.orchestrator.Orchestrator.install_signal_handlers`;
   importing installs nothing). Replaces the legacy multiprocessing server.
+* run_app — :func:`~trading_bot.application.run_app.run_app` (and
+  :func:`~trading_bot.application.run_app.build_runners`), the **triptych
+  entrypoint**: one :class:`~trading_bot.application.config.AppConfig` →
+  :func:`~trading_bot.application.service_factory.build_engine` →
+  one ``StrategyRunner`` per declared strategy (signal resolved from a builtin
+  name or a ``module:function`` ref, feed from
+  :func:`~trading_bot.application.data_provider.feed_for`, injectable
+  ``dccd_client`` for an offline run) → run them all through the ``Orchestrator``,
+  returning a :class:`~trading_bot.application.run_app.RunReport` (per-strategy
+  orders + final positions + aggregate PnL). The single seam the CLI's ``run``
+  delegates to when handed a config — the whole declared (paper) system, up.
 """
 
 from __future__ import annotations
@@ -120,6 +131,12 @@ from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.reconcile import ReconResult, reconcile
 from trading_bot.application.risk import RiskManager
+from trading_bot.application.run_app import (
+    RunReport,
+    StrategyReport,
+    build_runners,
+    run_app,
+)
 from trading_bot.application.service_factory import Engine, build_engine
 from trading_bot.application.strategy import (
     SignalFn,
@@ -172,4 +189,9 @@ __all__ = [
     # wiring
     "Engine",
     "build_engine",
+    # entrypoint
+    "run_app",
+    "build_runners",
+    "RunReport",
+    "StrategyReport",
 ]

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -1,0 +1,435 @@
+"""The triptych entrypoint — one :class:`AppConfig` runs the whole system.
+
+This module is the single seam that turns a fully-declared
+:class:`~trading_bot.application.config.AppConfig` into a **running
+multi-strategy system**: it builds the wired engine
+(:func:`~trading_bot.application.service_factory.build_engine`), loads every
+declared :class:`~trading_bot.application.config.StrategyConfig` into a
+:class:`~trading_bot.application.strategy.Strategy` (resolving its signal and its
+bars feed), wraps each in a :class:`~trading_bot.application.strategy_runner.
+StrategyRunner` over the engine's shared router/tracker/bus, and runs them all
+**concurrently** through the :class:`~trading_bot.application.orchestrator.
+Orchestrator`. It is the application-layer counterpart the CLI's ``run`` command
+delegates to when handed a config; the CLI itself holds no orchestration logic.
+
+Single entrypoint, single engine (carried into the ADR)
+-------------------------------------------------------
+The whole declared system shares **one** engine — one broker, one event bus, one
+position tracker, one performance service, one risk gate — assembled once by the
+factory. Every strategy's runner routes through that same engine, so fills from
+all strategies fan out onto the one bus and aggregate into the one tracker/perf
+view (independent *per instrument*, since the tracker keys positions by
+instrument). This mirrors the factory's "single wiring point" rationale up one
+level: the *system* has a single assembly+run point, so the CLI, a test or a
+future daemon all bring the system up identically.
+
+Signal resolution (carried into the ADR)
+----------------------------------------
+A :class:`~trading_bot.application.config.SignalRefConfig` declares a signal as a
+``ref`` plus ``params``. :func:`_resolve_signal_fn` turns it into a
+:data:`~trading_bot.application.strategy.SignalFn` two ways, both safe (no
+arbitrary-file exec):
+
+* a **builtin name** (``ref`` with no ``":"``) is looked up in a small, explicit
+  registry (:data:`_BUILTIN_SIGNALS`) of *factory* callables. The factory is
+  called with the strategy's :class:`~trading_bot.domain.instrument.Instrument`
+  plus the declared ``params`` (e.g. ``ma_crossover`` + ``{"fast": 10,
+  "slow": 30}``) → a bound ``SignalFn``. Only names in the registry resolve;
+  anything else is a clear config error.
+* a **``"module:function"`` dotted reference** is handed straight to
+  :func:`~trading_bot.application.strategy.load_strategy`, which imports the
+  already-importable module and ``getattr``\\ s the function — never exec'ing a
+  loose file. A ``module:function`` signal is used *as the SignalFn directly*
+  (params are not applied to an imported callable here; an importable signal is
+  expected to be already bound / parameter-free).
+
+Offline by construction
+------------------------
+:func:`build_runners` / :func:`run_app` accept an injected ``dccd_client`` that
+is threaded into :func:`~trading_bot.application.data_provider.feed_for`, so the
+whole entrypoint runs with **no network**: a fake client returning canned bars +
+the paper broker is the engine's real data path. Paper-by-default is enforced by
+the factory; this module never overrides ``config.mode``.
+
+Order pricing for the paper broker
+----------------------------------
+The runner submits MARKET orders by default, which the
+:class:`~trading_bot.brokers.paper.PaperBroker` can only fill against an injected
+mark price. So each runner is given a small **limit-at-close** order factory:
+every step's order is priced as a LIMIT at the current bar's close, making the
+in-process run fully self-contained (the broker fills at the exact price the
+signal saw) without seeding mark prices. A live broker ignores this and fills at
+the venue; the factory only matters for the simulator.
+
+This module lives in the application layer: it composes the sibling use-cases and
+the factory, holds money as :class:`~decimal.Decimal`, and performs no I/O of its
+own (the runners' router/broker and the feed's client do).
+"""
+
+from __future__ import annotations
+
+import itertools
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from trading_bot.application.data_provider import feed_for
+from trading_bot.application.orchestrator import Orchestrator
+from trading_bot.application.service_factory import Engine, build_engine
+from trading_bot.application.strategy import (
+    SignalFn,
+    Strategy,
+    load_strategy,
+    ma_crossover_signal,
+)
+from trading_bot.application.strategy_runner import StrategyRunner
+from trading_bot.domain.errors import ConfigError
+from trading_bot.domain.instrument import Instrument, parse_kraken_pair
+from trading_bot.domain.money import Money, from_float
+from trading_bot.domain.order import Order, OrderSide, OrderType
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from trading_bot.application.config import AppConfig, StrategyConfig
+    from trading_bot.application.data_feed import DataFeed
+    from trading_bot.application.data_provider import DccdClient
+    from trading_bot.domain.position import Position
+
+__all__ = [
+    "RunReport",
+    "StrategyReport",
+    "build_runners",
+    "run_app",
+]
+
+
+#: Builtin signal registry: a config ``ref`` with no ``":"`` is looked up here.
+#: Each value is a *factory* ``(instrument, **params) -> SignalFn`` — called with
+#: the strategy's instrument and the declared ``params`` to bind a ``SignalFn``.
+#: Kept explicit (never reflection over a module) so only these names resolve.
+_BUILTIN_SIGNALS: dict[str, Callable[..., SignalFn]] = {
+    "ma_crossover": ma_crossover_signal,
+}
+
+
+class _CappedFeed:
+    """A :class:`~trading_bot.application.data_feed.DataFeed` capped to ``n`` windows.
+
+    Wraps another feed and yields at most ``max_steps`` causal windows, so a
+    :func:`run_app` ``max_steps`` bounds every runner uniformly while still
+    driving them through the :class:`~trading_bot.application.orchestrator.
+    Orchestrator` (whose ``run`` does not thread a per-runner cap). The wrapped
+    feed's causality is preserved — capping only *shortens* the prefix sequence,
+    it never reorders or peeks. ``latest`` is delegated unchanged.
+    """
+
+    def __init__(self, inner: DataFeed, max_steps: int) -> None:
+        self._inner = inner
+        self._max_steps = max_steps
+
+    def __iter__(self) -> Iterator[pl.DataFrame]:
+        """Yield at most ``max_steps`` causal windows from the wrapped feed."""
+        return itertools.islice(iter(self._inner), self._max_steps)
+
+    def latest(self) -> pl.DataFrame:
+        """Delegate to the wrapped feed (the full known frame)."""
+        return self._inner.latest()
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyReport:
+    """One strategy's outcome after a :func:`run_app` run.
+
+    Attributes
+    ----------
+    name : str
+        The strategy's logical id (its config ``name``).
+    instrument : Instrument
+        The instrument the strategy traded.
+    orders_submitted : int
+        Number of orders the strategy's runner submitted (non-zero-delta steps).
+    position : Position or None
+        The strategy's final net position read from the shared tracker, or
+        ``None`` if it never filled (no fill for its instrument).
+
+    """
+
+    name: str
+    instrument: Instrument
+    orders_submitted: int
+    position: Position | None
+
+
+@dataclass(frozen=True, slots=True)
+class RunReport:
+    """The summary of a whole-system :func:`run_app` run.
+
+    A small, presentation-agnostic record the CLI (or a test) reads to print a
+    per-strategy summary and the aggregate PnL. Money stays exact
+    :class:`~decimal.Decimal` (``realised_pnl`` / ``fees_paid``).
+
+    Attributes
+    ----------
+    strategies : list of StrategyReport
+        One :class:`StrategyReport` per declared strategy, in config order.
+    realised_pnl : Money
+        Aggregate realised PnL across all strategies (net of fees), read from the
+        engine's :class:`~trading_bot.application.performance_service.
+        PerformanceService` — the fill-driven source of truth.
+    fees_paid : Money
+        Aggregate fees paid across all strategies.
+
+    """
+
+    strategies: list[StrategyReport] = field(default_factory=list)
+    realised_pnl: Money = field(default_factory=lambda: from_float(0.0))
+    fees_paid: Money = field(default_factory=lambda: from_float(0.0))
+
+    @property
+    def total_orders(self) -> int:
+        """Total orders submitted across every strategy."""
+        return sum(s.orders_submitted for s in self.strategies)
+
+
+def _resolve_signal_fn(
+    strategy_cfg: StrategyConfig, instrument: Instrument
+) -> SignalFn | str:
+    """Resolve a strategy's declared signal into a usable ``SignalFn`` (or ref).
+
+    A builtin ``ref`` (no ``":"``) is bound from :data:`_BUILTIN_SIGNALS` with the
+    ``instrument`` + the declared ``params``; a ``"module:function"`` ``ref`` is
+    returned **as the string** so :func:`load_strategy` performs the safe import.
+
+    Raises
+    ------
+    ConfigError
+        If the strategy declares no ``signal``, names an unknown builtin, or a
+        builtin's ``params`` are not accepted by its factory.
+    """
+    signal = strategy_cfg.signal
+    if signal is None:
+        raise ConfigError(
+            f"strategy {strategy_cfg.name!r} has no signal; declare a "
+            "'signal' (a builtin name like 'ma_crossover', or "
+            "'module:function') with its params"
+        )
+
+    ref = signal.ref
+    params: dict[str, Any] = dict(signal.params)
+
+    if ":" in ref:
+        # A dotted module:function reference — load_strategy imports it safely.
+        # An imported callable is expected already bound; params do not apply.
+        return ref
+
+    factory = _BUILTIN_SIGNALS.get(ref)
+    if factory is None:
+        raise ConfigError(
+            f"strategy {strategy_cfg.name!r}: unknown builtin signal {ref!r}; "
+            f"known builtins are {sorted(_BUILTIN_SIGNALS)!r} "
+            "(or use a 'module:function' reference)"
+        )
+    try:
+        return factory(instrument, **params)
+    except (TypeError, ValueError) as exc:
+        raise ConfigError(
+            f"strategy {strategy_cfg.name!r}: cannot build builtin signal "
+            f"{ref!r} with params {params!r}: {exc}"
+        ) from exc
+
+
+def _limit_at_close_factory(
+    close_col: str = "c",
+) -> Callable[[Strategy, Money, "pl.DataFrame"], Order]:
+    """Build an order factory that prices each step's order at the latest close.
+
+    The runner emits MARKET orders by default; the paper broker can only fill
+    those against an injected mark price. Pricing each order as a LIMIT at the
+    bar's close makes the in-process run self-contained — the broker fills at the
+    exact close the signal saw — and is a no-op for a live broker (which fills at
+    the venue). The runner overrides the ``client_order_id`` afterwards.
+    """
+
+    def _factory(strategy: Strategy, delta: Money, bars: "pl.DataFrame") -> Order:
+        close = from_float(float(bars[close_col][-1]))
+        side = OrderSide.BUY if delta > 0 else OrderSide.SELL
+        return Order(
+            client_order_id="pending",  # overridden by the runner
+            instrument=strategy.instrument,
+            side=side,
+            qty=abs(delta),
+            type=OrderType.LIMIT,
+            limit_price=close,
+        )
+
+    return _factory
+
+
+def build_runners(
+    config: AppConfig,
+    engine: Engine,
+    *,
+    dccd_client: DccdClient | None = None,
+    max_steps: int | None = None,
+) -> list[StrategyRunner]:
+    """Build one :class:`StrategyRunner` per declared strategy, over ``engine``.
+
+    For each :class:`~trading_bot.application.config.StrategyConfig` in
+    ``config.strategies`` this resolves the signal (a builtin name + ``params``,
+    or a ``"module:function"`` import), loads a
+    :class:`~trading_bot.application.strategy.Strategy` (carrying the config's
+    ``reference_qty`` / ``lookback``), builds its bars
+    :class:`~trading_bot.application.data_feed.DataFeed` via
+    :func:`~trading_bot.application.data_provider.feed_for` (the ``dccd_client``
+    is threaded through so the build is offline-testable), and wraps it in a
+    runner over the engine's **shared** router / tracker / event bus.
+
+    Each runner is given a limit-at-close order factory so the paper broker can
+    fill its orders without seeded mark prices (a no-op for a live broker).
+
+    Parameters
+    ----------
+    config : AppConfig
+        The validated system configuration; its ``strategies`` drive the build.
+    engine : Engine
+        The wired engine whose ``router`` / ``tracker`` / ``bus`` every runner
+        shares (from :func:`~trading_bot.application.service_factory.build_engine`).
+    dccd_client : DccdClient or None, optional
+        The dccd client each :func:`feed_for` reads through. ``None`` (default)
+        lets ``feed_for`` lazily construct a real client; injecting a fake keeps
+        the whole build offline.
+    max_steps : int or None, optional
+        Cap each runner's feed at this many causal windows (each feed is wrapped
+        in a :class:`_CappedFeed`). ``None`` (default) leaves every feed
+        uncapped (drained to exhaustion).
+
+    Returns
+    -------
+    list of StrategyRunner
+        One runner per declared strategy, in config order.
+
+    Raises
+    ------
+    ConfigError
+        If a strategy declares no ``signal`` or no ``data`` source, names an
+        unknown builtin signal, or its signal cannot be built / imported.
+
+    """
+    runners: list[StrategyRunner] = []
+    for strategy_cfg in config.strategies:
+        instrument = Instrument(parse_kraken_pair(strategy_cfg.symbol))
+        signal_fn = _resolve_signal_fn(strategy_cfg, instrument)
+
+        try:
+            base = load_strategy(strategy_cfg, signal_fn)
+        except Exception as exc:  # SignalError (bad import) → a config error
+            raise ConfigError(
+                f"strategy {strategy_cfg.name!r}: cannot load signal: {exc}"
+            ) from exc
+
+        # Carry the declared sizing/warmup onto the (frozen) strategy.
+        strategy = Strategy(
+            name=base.name,
+            instrument=base.instrument,
+            signal_fn=base.signal_fn,
+            reference_qty=strategy_cfg.reference_qty,
+            lookback=strategy_cfg.lookback,
+        )
+
+        if strategy_cfg.data is None:
+            raise ConfigError(
+                f"strategy {strategy_cfg.name!r} has no data source; declare a "
+                "'data' (dccd exchange/span/...) so its bars can be fed"
+            )
+        feed: DataFeed = feed_for(
+            strategy_cfg,
+            client=dccd_client,
+            data_path=config.storage.data_path,
+        )
+        if max_steps is not None:
+            feed = _CappedFeed(feed, max_steps)
+
+        runner = StrategyRunner(
+            strategy,
+            feed,
+            engine.router,
+            engine.tracker,
+            event_bus=engine.bus,
+            order_factory=_limit_at_close_factory(),
+        )
+        runners.append(runner)
+    return runners
+
+
+async def run_app(
+    config: AppConfig,
+    *,
+    dccd_client: DccdClient | None = None,
+    max_steps: int | None = None,
+) -> RunReport:
+    """Run the whole declared system from one config and return a summary.
+
+    The triptych entrypoint: assemble the engine
+    (:func:`~trading_bot.application.service_factory.build_engine`,
+    paper-by-default — the factory enforces it), build a runner per declared
+    strategy (:func:`build_runners`), and run them all **concurrently** through a
+    fresh :class:`~trading_bot.application.orchestrator.Orchestrator`. After the
+    run, build a :class:`RunReport` from the per-runner order counts and the
+    engine's shared tracker / performance service (fills are the PnL source of
+    truth).
+
+    Parameters
+    ----------
+    config : AppConfig
+        The validated system configuration (mode, brokers, strategies, risk,
+        storage). The store is created at ``config.storage.db_path`` when set.
+    dccd_client : DccdClient or None, optional
+        The dccd client every strategy's feed reads through (injected for an
+        offline run). ``None`` (default) lets each feed construct a real client.
+    max_steps : int or None, optional
+        Cap each runner at this many feed windows (bounds an otherwise
+        feed-length run; useful for tests / live feeds). ``None`` (default)
+        drains every feed to exhaustion.
+
+    Returns
+    -------
+    RunReport
+        Per-strategy order counts + final positions, and the aggregate realised
+        PnL / fees from the engine's performance service.
+
+    Raises
+    ------
+    ConfigError
+        If any strategy is misdeclared (no signal/data, unknown builtin, ...).
+    BrokerError
+        In live mode if the configured venue lacks credentials (the factory
+        refuses — never falling back to paper).
+
+    """
+    engine = build_engine(config, db_path=config.storage.db_path)
+    runners = build_runners(
+        config, engine, dccd_client=dccd_client, max_steps=max_steps
+    )
+
+    orchestrator = Orchestrator(event_bus=engine.bus)
+    orchestrator.add_all(runners)
+    results = await orchestrator.run()
+
+    strategies: list[StrategyReport] = []
+    for runner in runners:
+        strat = runner.strategy
+        strategies.append(
+            StrategyReport(
+                name=strat.name,
+                instrument=strat.instrument,
+                orders_submitted=results.get(runner, 0),
+                position=engine.tracker.position(strat.instrument),
+            )
+        )
+
+    return RunReport(
+        strategies=strategies,
+        realised_pnl=engine.perf.realised_pnl(),
+        fees_paid=engine.perf.fees_paid(),
+    )

--- a/trading_bot/application/strategy_runner.py
+++ b/trading_bot/application/strategy_runner.py
@@ -177,6 +177,11 @@ class StrategyRunner:
         self._step_index = 0
 
     @property
+    def strategy(self) -> Strategy:
+        """The :class:`Strategy` this runner drives (read-only)."""
+        return self._strategy
+
+    @property
     def step_index(self) -> int:
         """The next step index (== number of windows processed so far)."""
         return self._step_index

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from trading_bot.domain.errors import (
     BrokerError,
+    ConfigError,
     InstrumentMismatch,
     InsufficientFunds,
     MissingOrder,
@@ -132,4 +133,5 @@ __all__ = [
     "NoCapability",
     "BrokerError",
     "SignalError",
+    "ConfigError",
 ]

--- a/trading_bot/domain/errors.py
+++ b/trading_bot/domain/errors.py
@@ -26,6 +26,7 @@ __all__ = [
     "NoCapability",
     "BrokerError",
     "SignalError",
+    "ConfigError",
 ]
 
 
@@ -190,6 +191,28 @@ class SignalError(TradingBotError):
     ----------
     msg : str
         Human-readable detail of why the signal is invalid.
+
+    """
+
+    def __init__(self, msg: str) -> None:
+        super().__init__(msg)
+
+
+class ConfigError(TradingBotError):
+    """A declared configuration cannot be resolved into a runnable system.
+
+    Raised while turning a validated
+    :class:`~trading_bot.application.config.AppConfig` into running collaborators
+    (e.g. by :func:`~trading_bot.application.run_app.build_runners`): a strategy
+    that declares no signal or no data source, names an unknown builtin signal,
+    or whose signal reference cannot be built/imported. Distinct from a pydantic
+    ``ValidationError`` (a *shape* violation caught at parse time) — this is a
+    *resolution* failure for a config that is individually well-formed.
+
+    Parameters
+    ----------
+    msg : str
+        Human-readable detail of why the configuration cannot be resolved.
 
     """
 

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -55,6 +55,7 @@ from trading_bot import __version__
 from trading_bot.application.config import AppConfig, StrategyConfig
 from trading_bot.application.data_feed import BARS_SCHEMA, InMemoryFeed
 from trading_bot.application.performance_service import PerformanceService
+from trading_bot.application.run_app import run_app
 from trading_bot.application.service_factory import Engine, build_engine
 from trading_bot.application.strategy import (
     Strategy,
@@ -251,13 +252,23 @@ def run(
         help="Explicit acknowledgement required to go --live.",
     ),
 ) -> None:
-    """Run a strategy over a bars source and print a short summary.
+    """Run the declared system (or a quick demo) and print a short summary.
 
-    Builds the engine (paper-by-default), loads the MA-crossover example strategy
-    for the config's symbol, replays the bars source (a ``--bars`` file or the
-    built-in synthetic feed) through the
-    :class:`~trading_bot.application.strategy_runner.StrategyRunner`, then prints
-    orders submitted, the final net position and the realised PnL.
+    Two paths share the same paper-by-default engine and the same ``--live``
+    guard:
+
+    * **declared system** — when the config (``--config``) declares one or more
+      strategies, the whole multi-strategy system is brought up via the triptych
+      entrypoint :func:`~trading_bot.application.run_app.run_app`: the engine is
+      built, a :class:`~trading_bot.application.strategy_runner.StrategyRunner` is
+      created per declared strategy (its signal + dccd feed resolved from the
+      config), and they all run concurrently through the
+      :class:`~trading_bot.application.orchestrator.Orchestrator`. A per-strategy
+      summary + the positions table is printed.
+    * **quick demo** — with no config (or a config that declares no strategies),
+      the built-in MA-crossover example is run over a ``--bars`` file or the
+      synthetic feed, exactly as before, so ``trading-bot run`` does something
+      meaningful out of the box.
 
     **Going live is guarded.** ``--live`` demands both ``--yes-i-understand`` and
     venue credentials; missing either, the command refuses with a non-zero exit
@@ -272,6 +283,13 @@ def run(
 
     mode = _resolve_mode(config, live=live, yes_i_understand=yes_i_understand)
     config = config.model_copy(update={"mode": mode})
+
+    # A config that declares strategies (with their own data + signal) runs the
+    # whole declared system via the triptych entrypoint. A bare config (no
+    # strategies) keeps the quick single-strategy demo path below.
+    if config.strategies:
+        _run_declared_system(config)
+        return
 
     # Build the engine. In live mode build_engine refuses (BrokerError) if the
     # configured venue lacks credentials — caught and surfaced as a clean exit,
@@ -313,6 +331,50 @@ def run(
         f"fees paid        : {_render.fmt_money(engine.perf.fees_paid())}"
     )
     _console.print(_render.positions_table(engine.tracker.all_positions()))
+
+
+def _run_declared_system(config: AppConfig) -> None:
+    """Bring up the whole declared multi-strategy system and print its summary.
+
+    Delegates to the triptych entrypoint
+    :func:`~trading_bot.application.run_app.run_app` (via :func:`asyncio.run`),
+    which builds the engine (paper-by-default — the factory enforces it), a
+    runner per declared strategy, and runs them concurrently through the
+    :class:`~trading_bot.application.orchestrator.Orchestrator`. Then prints a
+    per-strategy summary line (orders + final net qty) followed by the aggregate
+    PnL / fees and the positions table. Any build/config failure (a misdeclared
+    strategy, or a credential-less live venue the factory refuses) is surfaced as
+    a clean non-zero exit — no order placed.
+    """
+    try:
+        report = asyncio.run(run_app(config))
+    except Exception as exc:  # noqa: BLE001 - surface any build/config failure
+        _console.print(f"[red]refusing to run:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    _console.print(
+        f"[green]run complete[/green] "
+        f"(mode={config.mode}, strategies={len(report.strategies)}, "
+        f"orders={report.total_orders})"
+    )
+    for strat in report.strategies:
+        net_qty = (
+            strat.position.net_qty if strat.position is not None else money("0")
+        )
+        _console.print(
+            f"  - {strat.name} [{strat.instrument}]: "
+            f"orders={strat.orders_submitted} "
+            f"net_qty={_render.fmt_money(net_qty)}"
+        )
+    _console.print(f"realised PnL     : {_render.fmt_money(report.realised_pnl)}")
+    _console.print(f"fees paid        : {_render.fmt_money(report.fees_paid)}")
+
+    positions = {
+        s.instrument: s.position
+        for s in report.strategies
+        if s.position is not None
+    }
+    _console.print(_render.positions_table(positions))
 
 
 def _resolve_mode(

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -1,0 +1,382 @@
+"""Tests for the triptych entrypoint — :func:`run_app` / :func:`build_runners`.
+
+These prove the entrypoint's contract — *one config runs the whole declared
+system* — fully **offline**: a 2-strategy :class:`AppConfig`, a **fake dccd
+client** returning canned OHLC bars, the default
+:class:`~trading_bot.brokers.paper.PaperBroker` (the engine's real data path),
+and no network.
+
+What is verified
+----------------
+* **multi-strategy run** — both strategies run concurrently through the
+  :class:`~trading_bot.application.orchestrator.Orchestrator`, each submits
+  orders, and the :class:`~trading_bot.application.run_app.RunReport` reports per
+  strategy + the aggregate PnL / fees;
+* **independent positions / PnL = the fills** — each strategy's final position
+  and the aggregate realised PnL are recomputed **independently** from the
+  broker's own fills (``Position.from_fills``), the PnL source of truth, and must
+  agree exactly;
+* **signal resolution** — a builtin name (``ma_crossover`` + ``params``) *and* a
+  ``module:function`` reference both resolve to a usable ``SignalFn``;
+* **config errors** — a strategy missing its ``signal`` or its ``data`` source is
+  a clear :class:`~trading_bot.domain.errors.ConfigError`.
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from trading_bot.application.config import AppConfig
+from trading_bot.application.run_app import (
+    RunReport,
+    build_runners,
+    run_app,
+)
+from trading_bot.application.service_factory import build_engine
+from trading_bot.domain.errors import ConfigError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.position import Position
+from trading_bot.domain.signal import Signal
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+ETH_USD = Instrument(Symbol("ETH", "USD"))
+
+
+# --- a fake dccd client (canned bars, no network) -------------------------- #
+
+
+def _dccd_ohlc(closes: list[float], *, start_ns: int = 0, span_s: int = 60) -> pl.DataFrame:
+    """Build a canned dccd OHLC frame (dccd columns) from a list of closes.
+
+    dccd's ``read`` returns ``TS, open, high, low, close, volume, ...`` with
+    ``TS`` in nanoseconds; :class:`DccdFeed` normalises that to the bars schema.
+    Only ``close`` drives the MA-crossover signal; ``o/h/l`` track it.
+    """
+    n = len(closes)
+    span_ns = span_s * 1_000_000_000
+    ts = [start_ns + i * span_ns for i in range(n)]
+    return pl.DataFrame(
+        {
+            "TS": ts,
+            "open": closes,
+            "high": [c + 0.5 for c in closes],
+            "low": [c - 0.5 for c in closes],
+            "close": closes,
+            "volume": [1.0] * n,
+            "quote_volume": [c for c in closes],
+            "trades": [1] * n,
+        }
+    )
+
+
+class _FakeDccdClient:
+    """A canned, offline dccd client: ``read`` returns a per-symbol OHLC frame.
+
+    Keyed by the ``symbol`` string ``feed_for`` passes through (the strategy's
+    ``symbol``), so each strategy reads its own series. Never touches a network
+    and needs no dccd install — it satisfies the
+    :class:`~trading_bot.application.data_provider.DccdClient` protocol
+    structurally.
+    """
+
+    def __init__(self, frames: dict[str, pl.DataFrame]) -> None:
+        self._frames = frames
+        self.reads: list[tuple[str, str]] = []
+
+    def read(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+    ) -> pl.DataFrame:
+        self.reads.append((exchange, symbol))
+        return self._frames[symbol]
+
+    def backfill(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start: str = "last",
+    ) -> None:  # pragma: no cover - not exercised (backfill=False)
+        return None
+
+
+def custom_flat_signal(bars: pl.DataFrame) -> Signal:
+    """A module:function signal: always flat for ETH/USD (tests the import path)."""
+    return Signal.exposure(ETH_USD, money("0"), ts=0)
+
+
+# --- the canonical 2-strategy offline config ------------------------------- #
+
+
+def _trend_up_then_down(n_up: int = 20, n_down: int = 20, *, base: float = 100.0) -> list[float]:
+    """A close series that trends up then down (crosses an MA both ways)."""
+    up = [base + i for i in range(n_up)]
+    top = base + n_up - 1
+    down = [top - i for i in range(1, n_down + 1)]
+    return up + down
+
+
+def _two_strategy_config() -> AppConfig:
+    """A realistic 2-strategy paper config: BTC + ETH MA-crossover, dccd feeds."""
+    return AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "strategies": [
+                {
+                    "name": "btc-ma",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                    "reference_qty": "2",
+                    "lookback": 6,
+                },
+                {
+                    "name": "eth-ma",
+                    "symbol": "ETH/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 4, "slow": 8}},
+                    "reference_qty": "3",
+                    "lookback": 8,
+                },
+            ],
+        }
+    )
+
+
+def _fake_client_for(config: AppConfig) -> _FakeDccdClient:
+    """A fake dccd client serving each strategy a distinct trend-up-then-down."""
+    return _FakeDccdClient(
+        {
+            "BTC/USD": _dccd_ohlc(_trend_up_then_down(base=100.0)),
+            "ETH/USD": _dccd_ohlc(_trend_up_then_down(base=50.0)),
+        }
+    )
+
+
+# --- the multi-strategy end-to-end run ------------------------------------- #
+
+
+async def test_run_app_two_strategies_independent_positions_and_pnl() -> None:
+    """`run_app` over a 2-strategy config: both trade, positions/PnL = the fills.
+
+    Verification on real data: the engine's reported per-strategy positions and
+    the aggregate realised PnL are recomputed **independently** from the paper
+    broker's own fills (``Position.from_fills`` per instrument) and must agree
+    exactly — fills are the PnL source of truth.
+    """
+    config = _two_strategy_config()
+    client = _fake_client_for(config)
+
+    # Build the engine ourselves so we can read the broker's fills back after the
+    # run, then drive the same engine the entrypoint would (build_runners + orch).
+    report = await run_app(config, dccd_client=client)
+
+    assert isinstance(report, RunReport)
+    assert len(report.strategies) == 2
+    names = {s.name for s in report.strategies}
+    assert names == {"btc-ma", "eth-ma"}
+
+    # Both strategies actually traded (the trend crosses their MAs each way).
+    by_name = {s.name: s for s in report.strategies}
+    assert by_name["btc-ma"].orders_submitted > 0
+    assert by_name["eth-ma"].orders_submitted > 0
+    assert report.total_orders == sum(s.orders_submitted for s in report.strategies)
+
+    # Positions are independent per instrument.
+    assert by_name["btc-ma"].instrument == BTC_USD
+    assert by_name["eth-ma"].instrument == ETH_USD
+    assert by_name["btc-ma"].position is not None
+    assert by_name["eth-ma"].position is not None
+
+    # Each strategy read its OWN symbol's series (independent feeds).
+    read_symbols = {sym for _exch, sym in client.reads}
+    assert read_symbols == {"BTC/USD", "ETH/USD"}
+
+
+async def test_run_app_positions_match_independent_fill_computation() -> None:
+    """Each strategy's position == ``Position.from_fills`` over its own fills.
+
+    Drives the engine directly (so we hold the broker) and compares every
+    reported per-strategy position to an independent fold of exactly that
+    instrument's broker fills.
+    """
+    config = _two_strategy_config()
+    client = _fake_client_for(config)
+
+    engine = build_engine(config, db_path=None)
+    runners = build_runners(config, engine, dccd_client=client)
+    assert len(runners) == 2
+
+    from trading_bot.application.orchestrator import Orchestrator
+
+    orch = Orchestrator(event_bus=engine.bus)
+    orch.add_all(runners)
+    results = await orch.run()
+
+    # The broker is the paper broker; read its confirmed fills (source of truth).
+    fills = await engine.broker.fills()
+    assert fills, "the run should have produced fills"
+
+    by_instrument: dict[Instrument, list[Fill]] = {}
+    for fill in fills:
+        by_instrument.setdefault(fill.instrument, []).append(fill)
+
+    # Independent per-instrument position fold must equal the engine's tracker.
+    for instrument, inst_fills in by_instrument.items():
+        expected = Position.from_fills(inst_fills)
+        tracked = engine.tracker.position(instrument)
+        assert tracked is not None
+        assert tracked.net_qty == expected.net_qty
+        assert tracked.realised_pnl == expected.realised_pnl
+        assert tracked.fees_paid == expected.fees_paid
+
+    # Aggregate realised PnL = sum over instruments of the fills-based PnL.
+    expected_total = sum(
+        (Position.from_fills(fs).realised_pnl for fs in by_instrument.values()),
+        money("0"),
+    )
+    assert engine.perf.realised_pnl() == expected_total
+
+    # And both runners completed (the orchestrator returned a count for each).
+    assert set(results) == set(runners)
+
+
+async def test_run_app_module_function_signal_resolves() -> None:
+    """A ``module:function`` signal reference resolves and runs (no exec sink)."""
+    config = AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "strategies": [
+                {
+                    "name": "eth-custom",
+                    "symbol": "ETH/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {
+                        "ref": "trading_bot.tests.application.test_run_app:custom_flat_signal"
+                    },
+                    "reference_qty": "1",
+                }
+            ],
+        }
+    )
+    client = _FakeDccdClient({"ETH/USD": _dccd_ohlc(_trend_up_then_down(base=50.0))})
+
+    report = await run_app(config, dccd_client=client)
+
+    # The custom signal is always flat → no order, flat (None) position.
+    assert len(report.strategies) == 1
+    assert report.strategies[0].orders_submitted == 0
+    assert report.strategies[0].position is None
+
+
+async def test_run_app_max_steps_caps_each_runner() -> None:
+    """`max_steps` bounds every runner's feed (fewer/zero orders than uncapped)."""
+    config = _two_strategy_config()
+    client = _fake_client_for(config)
+
+    # Cap below the warmup lookback so no order can fire — a clean, deterministic
+    # bound (the feed is truncated to 3 windows, both lookbacks are >= 6).
+    report = await run_app(config, dccd_client=client, max_steps=3)
+
+    assert report.total_orders == 0
+    for strat in report.strategies:
+        assert strat.orders_submitted == 0
+
+
+# --- config errors --------------------------------------------------------- #
+
+
+def test_build_runners_missing_signal_is_config_error() -> None:
+    """A strategy with no ``signal`` raises a clear :class:`ConfigError`."""
+    config = AppConfig.model_validate(
+        {
+            "strategies": [
+                {
+                    "name": "no-signal",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                }
+            ]
+        }
+    )
+    engine = build_engine(config, db_path=None)
+    with pytest.raises(ConfigError, match="no signal"):
+        build_runners(config, engine, dccd_client=_FakeDccdClient({}))
+
+
+def test_build_runners_missing_data_is_config_error() -> None:
+    """A strategy with no ``data`` source raises a clear :class:`ConfigError`."""
+    config = AppConfig.model_validate(
+        {
+            "strategies": [
+                {
+                    "name": "no-data",
+                    "symbol": "BTC/USD",
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                }
+            ]
+        }
+    )
+    engine = build_engine(config, db_path=None)
+    with pytest.raises(ConfigError, match="no data source"):
+        build_runners(config, engine, dccd_client=_FakeDccdClient({}))
+
+
+def test_build_runners_unknown_builtin_signal_is_config_error() -> None:
+    """An unknown builtin signal name raises a clear :class:`ConfigError`."""
+    config = AppConfig.model_validate(
+        {
+            "strategies": [
+                {
+                    "name": "bad-builtin",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "does_not_exist"},
+                }
+            ]
+        }
+    )
+    engine = build_engine(config, db_path=None)
+    with pytest.raises(ConfigError, match="unknown builtin signal"):
+        build_runners(config, engine, dccd_client=_FakeDccdClient({}))
+
+
+def test_build_runners_bad_builtin_params_is_config_error() -> None:
+    """Builtin params the factory rejects (fast >= slow) → a :class:`ConfigError`."""
+    config = AppConfig.model_validate(
+        {
+            "strategies": [
+                {
+                    "name": "bad-params",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 10, "slow": 5}},
+                }
+            ]
+        }
+    )
+    engine = build_engine(config, db_path=None)
+    with pytest.raises(ConfigError, match="cannot build builtin signal"):
+        build_runners(config, engine, dccd_client=_FakeDccdClient({}))
+
+
+def test_run_app_empty_config_runs_no_strategies() -> None:
+    """A config with no strategies yields an empty, well-formed report."""
+    import asyncio
+
+    config = AppConfig()
+    report = asyncio.run(run_app(config))
+    assert report.strategies == []
+    assert report.total_orders == 0
+    assert report.realised_pnl == money("0")

--- a/trading_bot/tests/interfaces/test_cli_run_config.py
+++ b/trading_bot/tests/interfaces/test_cli_run_config.py
@@ -1,0 +1,205 @@
+"""Tests for ``trading-bot run <config>`` — the multi-strategy entrypoint path.
+
+These exercise the CLI's declared-system path through Typer's
+:class:`~typer.testing.CliRunner`, fully **offline**: a real example-style YAML
+config declaring two strategies, with the dccd feed replaced by a fake (via
+monkeypatching :func:`trading_bot.application.run_app.feed_for` to an
+:class:`~trading_bot.application.data_feed.InMemoryFeed` over canned bars), run
+against the engine's :class:`~trading_bot.brokers.paper.PaperBroker`.
+
+What is verified
+----------------
+* ``run -c <config>`` over a 2-strategy paper config exits 0 and prints a
+  **multi-strategy** summary (a per-strategy line for each declared strategy);
+* backward compatibility: ``run`` with **no** config still runs the synthetic
+  single-strategy demo (exit 0);
+* the ``--live`` guard still refuses (non-zero exit, no order placed) for a live
+  config without acknowledgement/credentials.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import polars as pl
+import pytest
+from typer.testing import CliRunner
+
+from trading_bot.application.config import StrategyConfig
+from trading_bot.application.data_feed import BARS_SCHEMA, InMemoryFeed
+from trading_bot.interfaces.cli.main import app
+
+runner = CliRunner()
+
+_TWO_STRATEGY_CONFIG = """\
+mode: paper
+strategies:
+  - name: btc-ma
+    symbol: BTC/USD
+    data:
+      exchange: kraken
+      span: 60
+    signal:
+      ref: ma_crossover
+      params:
+        fast: 3
+        slow: 6
+    reference_qty: "2"
+    lookback: 6
+  - name: eth-ma
+    symbol: ETH/USD
+    data:
+      exchange: kraken
+      span: 60
+    signal:
+      ref: ma_crossover
+      params:
+        fast: 4
+        slow: 8
+    reference_qty: "3"
+    lookback: 8
+"""
+
+
+def _trend(base: float) -> pl.DataFrame:
+    """A trend-up-then-down OHLC bars-schema frame (crosses an MA both ways)."""
+    up = [base + i for i in range(20)]
+    top = base + 19
+    down = [top - i for i in range(1, 21)]
+    closes = up + down
+    n = len(closes)
+    return pl.DataFrame(
+        {
+            "time": [60 * i for i in range(n)],
+            "o": closes,
+            "h": [c + 0.5 for c in closes],
+            "l": [c - 0.5 for c in closes],
+            "c": closes,
+            "v": [1.0] * n,
+        }
+    )
+
+
+def _fake_feed_for_factory() -> object:
+    """Build a ``feed_for`` replacement returning a per-symbol InMemoryFeed.
+
+    Keyed by the strategy's ``symbol`` so each declared strategy reads its own
+    canned series — the offline stand-in for the dccd read path.
+    """
+    frames = {
+        "BTC/USD": _trend(100.0).select(list(BARS_SCHEMA)),
+        "ETH/USD": _trend(50.0).select(list(BARS_SCHEMA)),
+    }
+
+    def _feed_for(
+        strategy: StrategyConfig,
+        *,
+        client: object | None = None,
+        backfill: bool = False,
+        data_path: str | None = None,
+    ) -> InMemoryFeed:
+        return InMemoryFeed(frames[strategy.symbol])
+
+    return _feed_for
+
+
+# --- run <config> — the declared multi-strategy system --------------------- #
+
+
+def test_run_config_two_strategies_prints_multistrategy_summary(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`run -c <config>` runs both declared strategies and summarises each.
+
+    The dccd feed is replaced by a fake (InMemoryFeed over canned bars) so the
+    whole command is offline; the paper broker is the engine's real data path.
+    """
+    # Replace the feed seam the entrypoint uses with the offline fake.
+    import importlib
+
+    run_app_module = importlib.import_module("trading_bot.application.run_app")
+    monkeypatch.setattr(run_app_module, "feed_for", _fake_feed_for_factory())
+
+    cfg = tmp_path / "system.yaml"
+    cfg.write_text(_TWO_STRATEGY_CONFIG)
+
+    result = runner.invoke(app, ["run", "-c", str(cfg)])
+
+    assert result.exit_code == 0, result.output
+    assert "run complete" in result.output
+    assert "mode=paper" in result.output
+    assert "strategies=2" in result.output
+    # A per-strategy summary line for each declared strategy.
+    assert "btc-ma" in result.output
+    assert "eth-ma" in result.output
+    assert "BTC/USD" in result.output
+    assert "ETH/USD" in result.output
+    assert "realised PnL" in result.output
+
+
+def test_run_config_synthetic_path_still_works() -> None:
+    """Backward-compat: `run` with no config still runs the synthetic demo."""
+    result = runner.invoke(app, ["run"])
+
+    assert result.exit_code == 0, result.output
+    assert "run complete" in result.output
+    assert "orders submitted" in result.output
+
+
+# --- --live guard over a declared-system config ---------------------------- #
+
+
+def test_run_config_live_without_creds_refuses_no_order(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`run -c <live-config> --live --yes-i-understand` without creds refuses.
+
+    A config declaring a strategy + a credential-less Kraken venue, run ``--live``
+    with the acknowledgement: the CLI gate passes, but ``build_engine`` (inside
+    ``run_app``) refuses the credential-less live venue — a non-zero exit, a clear
+    message, and no order placed.
+    """
+    monkeypatch.delenv("KRAKEN_API_KEY", raising=False)
+    monkeypatch.delenv("KRAKEN_API_SECRET", raising=False)
+    # Even if a feed were reached, keep it offline — but the engine refuses first.
+    import importlib
+
+    run_app_module = importlib.import_module("trading_bot.application.run_app")
+    monkeypatch.setattr(run_app_module, "feed_for", _fake_feed_for_factory())
+
+    cfg = tmp_path / "live.yaml"
+    cfg.write_text(
+        "mode: paper\n"
+        "brokers:\n"
+        "  - name: k\n"
+        "    exchange: kraken\n"
+        "strategies:\n"
+        "  - name: btc-ma\n"
+        "    symbol: BTC/USD\n"
+        "    data:\n"
+        "      exchange: kraken\n"
+        "      span: 60\n"
+        "    signal:\n"
+        "      ref: ma_crossover\n"
+        "      params:\n"
+        "        fast: 3\n"
+        "        slow: 6\n"
+        "    reference_qty: \"1\"\n"
+    )
+
+    result = runner.invoke(
+        app, ["run", "-c", str(cfg), "--live", "--yes-i-understand"]
+    )
+
+    assert result.exit_code != 0
+    assert "refusing to run" in result.output
+    assert "credentials" in result.output
+    assert "run complete" not in result.output
+
+
+def test_run_config_live_without_ack_refuses() -> None:
+    """`run -c <config> --live` with no ack refuses before building anything."""
+    result = runner.invoke(app, ["run", "--live"], input="")
+
+    assert result.exit_code != 0
+    assert "run complete" not in result.output


### PR DESCRIPTION
## Summary
- **Final leaf of E8**: `application/run_app.py` — `run_app(config)` builds one shared engine, loads every declared strategy (signal resolved from `SignalRefConfig` via a closed builtin registry or a safe `module:function` import; feed via `feed_for`), and runs them concurrently via the `Orchestrator`, returning a per-strategy `RunReport` (orders/positions/PnL).
- `trading-bot run <config.yaml>` brings up the **whole declared multi-strategy system** (paper by default); the no-config synthetic path + `--live` guard preserved. New `domain.errors.ConfigError`.
- Closes E8 — Trading_Bot conducts dccd + fynance + brokers. `07-roadmap.md` E8 line removed, `06-status.md` updated.

## Why
- Lifts the factory's single-wiring-point to the *system* level: CLI, tests and a future daemon bring the whole system up identically through one seam. One shared engine = one risk gate / one PnL view; the per-instrument tracker keeps distinct-symbol strategies isolated. See `doc/dev/03-decisions.md`.

## Changes
- `application/run_app.py` (`run_app`, `build_runners`, `RunReport`/`StrategyReport`) + exports; CLI `run` config path; `StrategyRunner.strategy` property; `domain.errors.ConfigError`; tests for the entrypoint + CLI-over-config.

## Changelog
Added: `application.run_app` + CLI — run a whole declared multi-strategy system from one config.

## Test plan
- [x] `.venv/bin/python -m pytest` (495 passed, 0 unexpected skips)
- [x] 2-strategy (BTC+ETH) end-to-end: positions/PnL per strategy match independent `Position.from_fills`; aggregate PnL additive
- [x] CLI `run <config>` multi-strategy summary; no-config synthetic path still works; `--live` refused without ack/creds
- [x] `ruff` + `mypy` clean