### PR TITLE
docs: plan web-ui (E9)

### DIFF
--- a/doc/dev/plans/web-ui/00-plan.md
+++ b/doc/dev/plans/web-ui/00-plan.md
@@ -1,0 +1,44 @@
+---
+plan: web-ui
+kind: global
+status: planning
+roadmap: "- [ ] **E9 — Web UI.** FastAPI + Jinja2 dashboard (positions/orders/PnL), mirroring dccd's UI."
+release_on_done: false
+---
+
+# E9 — Web UI
+
+## Goal
+
+A **read-only** web dashboard mirroring dccd's UI: a FastAPI app exposing the
+engine's state (positions, orders, PnL/KPI) as JSON + an SSE live stream, and a
+Jinja2 dashboard that is a **pure HTTP client** of that API. Launch it with
+`trading-bot serve`. Opens `trading_bot/interfaces/{api,ui}/`.
+
+**Invariants**: the UI is **read-only** — it never places orders (paper or live).
+Money is **Decimal strings** in JSON (never float). Everything offline-testable via
+FastAPI `TestClient` over a paper `Engine` (no real server, no network).
+
+## Decomposition
+
+1. **api** — `interfaces/api/app.py`: FastAPI `create_app(engine)` with read-only `/api/positions|orders|kpi|health` + SSE `/api/events`.
+2. **ui** — `interfaces/ui/`: Jinja2 dashboard (positions/orders/PnL+KPI), pure HTTP client of the api, live via SSE; served by the same app. Plus a `trading-bot serve` CLI command.
+
+## Leaf checklist
+
+- [ ] 01 api — feat/web-api — high
+- [ ] 02 ui — feat/web-ui — high (depends on 01)
+
+## Dependencies
+
+- 02 depends on 01. Serial in the main worktree.
+
+## Done criteria
+
+- `create_app(engine)` serves read-only positions/orders/KPI JSON (money as Decimal
+  strings) + an SSE event stream; the Jinja2 dashboard renders them and live-updates;
+  `trading-bot serve` launches it.
+- The UI never calls the application layer directly and never places an order.
+- `ruff`/`mypy`/`pytest` green via `.venv` (0 unexpected skips); the API + a UI smoke
+  are tested with FastAPI `TestClient` over a paper engine.
+- Last leaf (02) removes the E9 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/web-ui/01-api.md
+++ b/doc/dev/plans/web-ui/01-api.md
@@ -1,0 +1,83 @@
+---
+plan: web-ui/01-api
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: feat/web-api
+pr: ""
+---
+
+# Web API — read-only FastAPI over the engine
+
+## Goal
+
+A FastAPI `create_app(engine)` exposing the engine's live state **read-only**:
+positions, orders, PnL/KPI as JSON (money as **Decimal strings**), plus an SSE
+`/api/events` stream fed by the `EventBus`. The UI (leaf 02) is a pure HTTP client
+of this. No endpoint ever places or cancels an order.
+
+## Files to change
+
+- `trading_bot/interfaces/api/__init__.py`, `trading_bot/interfaces/api/app.py` — new; `create_app(engine)`.
+- `trading_bot/tests/interfaces/test_api.py` — new.
+- `pyproject.toml` — ensure `fastapi`/`uvicorn[standard]` in the `daemon` + `dev` extras.
+
+## Steps
+
+1. Read dccd's FastAPI app for the pattern
+   (`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/interfaces/api/app.py`):
+   `create_app()`, module-level pydantic response models, the SSE `/api/events`
+   endpoint using `EventBus.add_queue`/`remove_queue`. Read `service_factory.Engine`
+   (`tracker`, `perf`, `router`, `bus`), `application/position_tracker.py`
+   (`all_positions()`), `application/order_router.py` (`tracked_orders()`),
+   `application/performance_service.py` (`realised_pnl`/`fees_paid`/`equity_curve`/KPIs),
+   `application/events.py` (`EventBus`, `OrderEvent`/`FillEvent`/`LogEvent`).
+2. `create_app(engine) -> FastAPI`: store the engine on `app.state`. Endpoints
+   (all **GET**, read-only):
+   - `GET /api/health` → `{status, mode, strategies?}`.
+   - `GET /api/positions` → list of `{instrument, net_qty, avg_entry_price,
+     realised_pnl, fees_paid}` from `engine.tracker.all_positions()`. **All money
+     fields are `str(Decimal)`** (use a serializer/response model that renders
+     Decimal as string — never float).
+   - `GET /api/orders` → list of `{client_order_id, venue_order_id, instrument, side,
+     type, qty, limit_price, status, filled_qty, avg_fill_price}` from
+     `engine.router.tracked_orders()` (money as strings).
+   - `GET /api/kpi` → `{realised_pnl, fees_paid, equity_end, sharpe, sortino,
+     max_drawdown, calmar}` from `engine.perf` (money as strings; ratios as numbers).
+   - `GET /api/events` → **SSE**: register a queue via `engine.bus.add_queue()`,
+     stream events as `text/event-stream` (serialize each event to JSON with money as
+     strings), and `remove_queue` in a `finally` on disconnect (mirror dccd).
+3. **No mutation endpoints** — there is deliberately no POST to place/cancel orders;
+   the UI is read-only. Document this.
+4. Decimal-as-string: define response models (pydantic) or a JSON encoder so every
+   monetary field serializes as a string; assert it in tests.
+
+## Tests (via `.venv`, FastAPI `TestClient` — no real server)
+
+- Build a paper `engine`, run a short strategy so there are positions/orders/fills,
+  then `TestClient(create_app(engine))`:
+  - `GET /api/health` → 200, reports `mode == "paper"`.
+  - `GET /api/positions` → the expected instrument(s); **money fields are JSON strings**
+    (assert `isinstance(body[0]["net_qty"], str)` and the value is exact).
+  - `GET /api/orders` → the tracked orders with string money.
+  - `GET /api/kpi` → realised PnL (string) matches `engine.perf.realised_pnl()`; KPI
+    numbers present.
+- SSE: emit a `FillEvent` on `engine.bus` and assert a consumer reading `/api/events`
+  receives it (use `TestClient` streaming or a short read); the queue is removed on
+  disconnect.
+- **No-mutation**: assert there is no route that places an order (e.g. a POST to a
+  plausible order path returns 404/405).
+
+## Verification on real data
+
+In-process (paper engine via `TestClient` is the real data). Run a strategy through
+the engine, then hit `/api/positions` + `/api/kpi` and assert the JSON (Decimal
+strings) matches the engine's `tracker`/`perf` exactly. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`interfaces.api` — read-only FastAPI over the engine (positions/orders/KPI + SSE; money as Decimal strings)."
+- ADR: read-only API (no order placement from the web), Decimal-as-string JSON, SSE via EventBus queues.
+- Status/roadmap: deferred to leaf 02.

--- a/doc/dev/plans/web-ui/02-ui.md
+++ b/doc/dev/plans/web-ui/02-ui.md
@@ -1,0 +1,79 @@
+---
+plan: web-ui/02-ui
+kind: leaf
+status: planned
+complexity: high
+depends: [01]
+parallel: false
+branch: feat/web-ui
+pr: ""
+---
+
+# Web UI — Jinja2 dashboard + `trading-bot serve`
+
+## Goal
+
+A Jinja2 **dashboard** (positions / open orders / PnL+KPI) that is a **pure HTTP
+client** of the leaf-01 API — no direct application-layer calls — live-updating via
+the SSE stream, served by the same FastAPI app. Plus a `trading-bot serve` CLI
+command to launch it. Mirrors dccd's `interfaces/ui/`. The last E9 leaf — closes the
+E9 roadmap line.
+
+## Files to change
+
+- `trading_bot/interfaces/ui/__init__.py` — new.
+- `trading_bot/interfaces/ui/templates/dashboard.html` — new (Jinja2).
+- `trading_bot/interfaces/ui/static/app.js`, `.../static/style.css` — new.
+- `trading_bot/interfaces/api/app.py` — mount the UI (templates + `/static`) + a `GET /` dashboard route.
+- `trading_bot/interfaces/cli/main.py` — add a `serve` command (uvicorn).
+- `pyproject.toml` — `[tool.setuptools.package-data]` for the UI templates/static so they ship in the wheel; ensure `jinja2` in `daemon`+`dev`.
+- `trading_bot/tests/interfaces/test_ui.py` — new.
+
+## Steps
+
+1. Read dccd's UI pattern
+   (`/home/arthur/dev/Download_Crypto_Currencies_Data/dccd/interfaces/ui/` — its
+   `templates/`, `static/`, how the FastAPI app mounts Jinja2 + static, and how the
+   page fetches the API + consumes SSE). Read the leaf-01 `create_app` + endpoints.
+2. `GET /` (in `api/app.py` or a ui router) renders `dashboard.html` via
+   `Jinja2Templates`. The template is a shell (brand/header + empty tables); the
+   actual data is fetched **client-side** from `/api/positions|orders|kpi` and updated
+   live from `/api/events` (SSE) — the UI is a pure HTTP client, never touching the
+   application layer directly. Mount `/static`.
+3. `static/app.js`: on load, fetch the three JSON endpoints and fill the tables;
+   open an `EventSource('/api/events')` and refresh on `FillEvent`/`OrderEvent`.
+   Render money strings verbatim (they arrive as exact Decimal strings — no JS float
+   parsing of money). Minimal, dependency-free JS.
+4. `style.css`: a clean, minimal dashboard layout (a header + three cards/tables:
+   Positions, Open orders, PnL/KPI). Keep it simple and legible.
+5. `serve` CLI command: `trading-bot serve [--config <yaml>] [--host] [--port]` —
+   build an engine (from a config, or a paper default), `create_app(engine)`, and run
+   `uvicorn`. (For a live data run it would attach to a running system; for the MVP it
+   can serve a freshly-built/just-run engine — document the scope.)
+6. `package-data`: ship `interfaces/ui/templates/*` and `interfaces/ui/static/*` in
+   the wheel (mirror dccd's `[tool.setuptools.package-data]`).
+
+## Tests (via `.venv`, FastAPI `TestClient`)
+
+- `GET /` → 200, returns HTML containing the dashboard shell (brand + the three
+  table containers / expected element ids the JS targets).
+- `GET /static/app.js` and `/static/style.css` → 200 with the right content type.
+- The page references the API endpoints + `/api/events` (assert the JS/HTML wires to
+  `/api/positions`, `/api/orders`, `/api/kpi`, `/api/events`) — proving it's an HTTP
+  client of the API, not a server-rendered data dump.
+- `serve` command builds an app without launching a real server (test the wiring: the
+  command constructs `create_app(engine)` — patch/####stub `uvicorn.run` so no socket
+  is opened; assert it was called with the app).
+
+## Verification on real data
+
+In-process. Run a strategy through a paper engine, serve `create_app(engine)` via
+`TestClient`, load `GET /` and the three `/api/*` JSON endpoints, and confirm the
+dashboard shell + the JSON it will render reflect the engine's real positions/PnL
+(Decimal strings). Capture the rendered HTML head + a JSON sample. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "`interfaces.ui` — Jinja2 dashboard (positions/orders/PnL, live via SSE) + `trading-bot serve`."
+- ADR: the UI = pure HTTP client of the API (no app-layer calls); `serve` scope.
+- Status/roadmap: **remove the E9 line** from `07-roadmap.md`; mark E9 done in `06-status.md`.


### PR DESCRIPTION
Plan tree for **E9 — Web UI** (mirrors dccd's UI): a **read-only** web dashboard over the engine.

## Goal
A FastAPI app exposes positions/orders/PnL/KPI as JSON (money as Decimal strings) + an SSE live stream; a Jinja2 dashboard is a **pure HTTP client** of it, live-updating. `trading-bot serve` launches it.

## Invariants
- **Read-only**: the UI never places orders (paper or live).
- Money as **Decimal strings** in JSON (never float).
- Offline-testable via FastAPI `TestClient` over a paper engine (no real server).

## Leaves
- [ ] 01 api — feat/web-api — high
- [ ] 02 ui — feat/web-ui — high (depends on 01)

fastapi+uvicorn+jinja2 now in the venv. After merge: `/execute-leaf web-ui next`.