### PR TITLE
feat: read-only FastAPI over the engine (positions/orders/KPI + SSE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `interfaces.api` — read-only FastAPI over the engine: `GET /api/{health,positions,
+  orders,kpi}` (money as **Decimal strings**, never float) + an SSE `/api/events`
+  stream fed by the `EventBus`. The web surface only observes — no order placement.
 - `AppConfig` — full declarative config: each strategy declares its dccd **data
   source** (exchange/span/start), its **signal** by reference (`module:function` or a
   builtin like `ma_crossover` + params) and its sizing (`reference_qty`, `lookback`),

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,23 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-25 Web API: read-only, money as Decimal strings, SSE via EventBus
+
+**Decision.** `interfaces/api/app.py` `create_app(engine)` is a **read-only** HTTP
+surface over the engine: `GET /api/{health,positions,orders,kpi}` and an SSE
+`GET /api/events`. There is **no** route to place/cancel an order — the only
+money-moving surface stays off the HTTP boundary entirely (a POST to an order path
+returns 405). All money serializes as **`str(Decimal)`** via a `_DecimalJSONResponse`
+encoder (exact, never float); KPI ratios go out as JSON numbers, and a ratio fynance
+can't define on a given curve degrades to `0.0` rather than 500-ing. SSE registers an
+`EventBus.add_queue()` and `remove_queue()`s in a `finally` (mirrors dccd).
+
+**Why.** A dashboard must never become a trading surface — keeping the API observe-only
+means the web can't move money even if exposed. Decimal-string JSON preserves exactness
+to the browser (the UI renders the strings verbatim, no JS float parsing of money).
+
+---
+
 ### 2026-06-25 Single-entrypoint orchestration: one config, one shared engine, N runners
 
 **Decision.** `application/run_app.py` `run_app(config)` is the **system** assembly+run

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -49,6 +49,11 @@ risk, the CLI, the orchestration layer, and (later) the UI and go-live hardening
 
 - **Final project name** — kept as `trading_bot` for now (deferred decision).
 - **Default paper-vs-live beyond MVP** — paper-first for now; revisit at go-live.
+- **KPI ratios need a positive starting capital** — `service_factory.build_engine`
+  wires `PerformanceService(v0=0)`, and fynance refuses an equity curve that crosses
+  zero, so the Sharpe/Sortino/Calmar shown by the API (and the CLI `kpi` absent
+  `--capital`) degrade to `0.0`. Robust (never errors), but the ratios are meaningless
+  until a config-driven starting capital is wired into `build_engine` (small follow-up).
 - **Same-instrument strategies commingle in `run_app`** — the orchestrated system
   shares one engine, and the `PositionTracker`/`PerformanceService` key state **by
   instrument**, so two strategies declared on the *same* symbol fold their fills into

--- a/doc/dev/plans/web-ui/00-plan.md
+++ b/doc/dev/plans/web-ui/00-plan.md
@@ -26,7 +26,7 @@ FastAPI `TestClient` over a paper `Engine` (no real server, no network).
 
 ## Leaf checklist
 
-- [ ] 01 api — feat/web-api — high
+- [x] 01 api — feat/web-api — high
 - [ ] 02 ui — feat/web-ui — high (depends on 01)
 
 ## Dependencies

--- a/doc/dev/plans/web-ui/01-api.md
+++ b/doc/dev/plans/web-ui/01-api.md
@@ -1,7 +1,7 @@
 ---
 plan: web-ui/01-api
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: []
 parallel: false

--- a/doc/dev/plans/web-ui/01-api.md
+++ b/doc/dev/plans/web-ui/01-api.md
@@ -6,7 +6,7 @@ complexity: high
 depends: []
 parallel: false
 branch: feat/web-api
-pr: ""
+pr: "#50"
 ---
 
 # Web API — read-only FastAPI over the engine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,10 @@ dev = [
     # The CLI (Typer + Rich) so the unit suite / CI can import and exercise it.
     "typer>=0.12",
     "rich>=13.0",
+    # The HTTP API (FastAPI + uvicorn) so the unit suite / CI can import and
+    # exercise interfaces.api via fastapi.testclient.TestClient.
+    "fastapi>=0.110",
+    "uvicorn[standard]>=0.29",
 ]
 doc = [
     "sphinx>=7.0",

--- a/trading_bot/interfaces/__init__.py
+++ b/trading_bot/interfaces/__init__.py
@@ -10,8 +10,12 @@ action is delegated to a use-case the
 * cli — the Typer command-line app (:mod:`trading_bot.interfaces.cli`), the
   console-script entrypoint (``trading-bot``). Starts minimal (a ``version``
   command) and grows the real start/stop/status/KPI commands in later leaves.
+* api — a **read-only** FastAPI over the engine
+  (:mod:`trading_bot.interfaces.api`): positions / orders / PnL+KPI as JSON
+  (money as Decimal strings) plus an SSE event stream. No endpoint ever places
+  or cancels an order.
 
-The FastAPI + Jinja2 dashboard (``api`` / ``ui``) lands later.
+The Jinja2 dashboard (``ui``) lands later.
 """
 
 from __future__ import annotations

--- a/trading_bot/interfaces/api/__init__.py
+++ b/trading_bot/interfaces/api/__init__.py
@@ -1,0 +1,18 @@
+"""trading_bot HTTP API — a **read-only** FastAPI over the live engine.
+
+The :mod:`trading_bot.interfaces.api` package exposes the engine's live state
+(positions, orders, PnL/KPI) plus a Server-Sent-Events stream over HTTP, for the
+UI (leaf 02) and any other HTTP client to consume. It is the outermost ring of
+the hexagon: it reads the :class:`~trading_bot.application.service_factory.Engine`
+the factory wired and renders its state out — it holds **no** business logic and,
+deliberately, **never mutates** the engine (no order is ever placed or cancelled
+through this API; see :func:`~trading_bot.interfaces.api.app.create_app`).
+
+The single entrypoint is :func:`~trading_bot.interfaces.api.app.create_app`.
+"""
+
+from __future__ import annotations
+
+from trading_bot.interfaces.api.app import create_app
+
+__all__ = ["create_app"]

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -1,0 +1,345 @@
+"""FastAPI application — a **read-only** HTTP view of the live engine.
+
+``create_app(engine)`` builds a :class:`fastapi.FastAPI` that renders the
+:class:`~trading_bot.application.service_factory.Engine`'s live state out over
+HTTP: positions, tracked orders and PnL/KPI as JSON, plus a Server-Sent-Events
+stream of order/fill/log events fed by the engine's
+:class:`~trading_bot.application.events.EventBus`. The UI (leaf 02) is a pure
+HTTP client of this API.
+
+Read-only — a hard invariant (carried into the ADR)
+---------------------------------------------------
+**Every endpoint is a GET and no endpoint mutates the engine.** There is
+deliberately *no* route that places, amends or cancels an order: the write path
+(:class:`~trading_bot.application.order_router.OrderRouter`) is reachable only
+in-process by the strategy runner, never from the network. A web client can
+*observe* the engine — it can never *trade* through it. This keeps the only
+money-moving surface (order submission) off the HTTP boundary entirely, so a
+compromised or misused web client cannot place an order. The absence of a POST
+order route is the invariant; a POST to a plausible order path returns ``405``
+(method not allowed) because only GET is registered for it.
+
+Money is serialized as Decimal **strings**, never floats (carried into the ADR)
+-------------------------------------------------------------------------------
+A price of ``0.1`` must appear in the JSON as the string ``"0.1"`` — exact, with
+no binary-float rounding. JSON has no decimal type and Python's ``json`` renders
+a :class:`~decimal.Decimal` via ``float()`` by default (lossy). To guarantee
+exactness, this module **never lets a Decimal reach the float path**: the route
+handlers build plain dicts whose money fields are already ``str(Decimal)`` (and
+``None`` for an absent optional, rendered as JSON ``null``), and responses go out
+through :class:`_DecimalJSONResponse`, whose encoder stringifies any stray
+:class:`~decimal.Decimal` as a defence in depth. The KPI *ratios* (Sharpe,
+Sortino, max-drawdown, Calmar) are statistical estimators, not money, so they go
+out as JSON numbers (floats are fine there).
+
+SSE — mirrors dccd (carried into the ADR)
+-----------------------------------------
+``GET /api/events`` registers its own :class:`asyncio.Queue` on the bus via
+:meth:`~trading_bot.application.events.EventBus.add_queue`, an async generator
+``await``\\ s the queue and yields ``data: <json>\\n\\n`` frames (each event
+serialized with money as strings and tagged with a ``type`` discriminator), and
+:meth:`~trading_bot.application.events.EventBus.remove_queue` runs in a
+``finally`` so the queue is always unregistered on disconnect — exactly dccd's
+``/api/events`` shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Callable
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from trading_bot.application.events import (
+    Event,
+    FillEvent,
+    LogEvent,
+    OrderEvent,
+)
+
+if TYPE_CHECKING:
+    from trading_bot.application.service_factory import Engine
+    from trading_bot.domain.fill import Fill
+    from trading_bot.domain.order import Order
+    from trading_bot.domain.position import Position
+
+__all__ = ["create_app"]
+
+
+# ---------------------------------------------------------------------------
+# Decimal-as-string JSON — the money-exactness crux
+# ---------------------------------------------------------------------------
+
+def _money_str(value: Decimal | None) -> str | None:
+    """Render a money :class:`~decimal.Decimal` as an exact string (``None`` passes).
+
+    ``str(Decimal("0.1"))`` is ``"0.1"`` — exact, with no float round-trip. A
+    ``None`` (an absent optional money field) passes through so it serializes as
+    JSON ``null``.
+    """
+    return None if value is None else str(value)
+
+
+def _default(obj: Any) -> str:
+    """``json`` encoder hook: stringify a :class:`~decimal.Decimal` (defence in depth).
+
+    The route handlers already stringify money before it reaches the encoder, so
+    in practice no bare ``Decimal`` arrives here. This hook is the safety net: if
+    one ever slips through, it is rendered as ``str(Decimal)`` (exact) rather than
+    via ``float()`` (lossy) or raising.
+    """
+    if isinstance(obj, Decimal):
+        return str(obj)
+    raise TypeError(f"object of type {type(obj).__name__!r} is not JSON serializable")
+
+
+class _DecimalJSONResponse(JSONResponse):
+    """A :class:`~fastapi.responses.JSONResponse` that renders Decimals as strings.
+
+    Replaces FastAPI's default encoder so *any* :class:`~decimal.Decimal` in a
+    response body is serialized as an exact string (``str(Decimal)``), never as a
+    lossy ``float``. Used as the app-wide ``default_response_class`` so every
+    endpoint inherits the guarantee.
+    """
+
+    def render(self, content: Any) -> bytes:
+        """Serialize *content* to UTF-8 JSON bytes with the Decimal-as-string hook."""
+        return json.dumps(
+            content,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+            default=_default,
+        ).encode("utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Serialization — engine objects -> JSON-ready dicts (money already stringified)
+# ---------------------------------------------------------------------------
+
+def _position_dict(position: Position) -> dict[str, Any]:
+    """Render a :class:`~trading_bot.domain.position.Position` as a JSON-ready dict.
+
+    Money fields (``net_qty``, ``avg_entry_price``, ``realised_pnl``,
+    ``fees_paid``) are exact :class:`~decimal.Decimal` strings; ``avg_entry_price``
+    is ``None`` (JSON ``null``) when the position is flat.
+    """
+    return {
+        "instrument": str(position.instrument),
+        "net_qty": _money_str(position.net_qty),
+        "avg_entry_price": _money_str(position.avg_entry_price),
+        "realised_pnl": _money_str(position.realised_pnl),
+        "fees_paid": _money_str(position.fees_paid),
+    }
+
+
+def _order_dict(order: Order) -> dict[str, Any]:
+    """Render an :class:`~trading_bot.domain.order.Order` as a JSON-ready dict.
+
+    Enums (``side``, ``type``, ``status``) serialize by their ``.value``; money
+    fields (``qty``, ``limit_price``, ``stop_price``, ``filled_qty``,
+    ``avg_fill_price``) as exact Decimal strings, with ``null`` for an absent
+    optional price / a not-yet-filled average.
+    """
+    return {
+        "client_order_id": order.client_order_id,
+        "venue_order_id": order.venue_order_id,
+        "instrument": str(order.instrument),
+        "side": order.side.value,
+        "type": order.type.value,
+        "qty": _money_str(order.qty),
+        "limit_price": _money_str(order.limit_price),
+        "stop_price": _money_str(order.stop_price),
+        "status": order.status.value,
+        "filled_qty": _money_str(order.filled_qty),
+        "avg_fill_price": _money_str(order.avg_fill_price),
+    }
+
+
+def _fill_dict(fill: Fill) -> dict[str, Any]:
+    """Render a :class:`~trading_bot.domain.fill.Fill` as a JSON-ready dict.
+
+    Money fields (``qty``, ``price``, ``fee``) as exact Decimal strings; ``side``
+    by its ``.value``; ``ts`` as the integer milliseconds it already is.
+    """
+    return {
+        "fill_id": fill.fill_id,
+        "client_order_id": fill.client_order_id,
+        "instrument": str(fill.instrument),
+        "side": fill.side.value,
+        "qty": _money_str(fill.qty),
+        "price": _money_str(fill.price),
+        "fee": _money_str(fill.fee),
+        "ts": fill.ts,
+    }
+
+
+def _safe_ratio(compute: Callable[[], float]) -> float:
+    """Evaluate a KPI ratio, returning ``0.0`` when it is undefined on this curve.
+
+    The fynance-backed ratio estimators reject some real equity curves the
+    fill-driven :class:`~trading_bot.application.performance_service.
+    PerformanceService` produces: with the factory's default ``v0 = 0`` the
+    equity series starts at (or crosses) zero the moment a fee is charged, and
+    fynance raises a :class:`ValueError` ("initial value cannot be null" / "must
+    be of the same sign"). A read-only KPI view must not turn that into a 500;
+    instead it reports ``0.0`` — the same "undefined estimator → 0.0" convention
+    the service already uses for a too-short series.
+    """
+    try:
+        return compute()
+    except (ValueError, ZeroDivisionError, ArithmeticError):
+        return 0.0
+
+
+def _event_dict(event: Event) -> dict[str, Any]:
+    """Serialize a bus :class:`~trading_bot.application.events.Event` for SSE.
+
+    Tags the payload with a ``type`` discriminator and embeds the event's domain
+    object rendered with money as Decimal strings: an
+    :class:`~trading_bot.application.events.OrderEvent` -> the order dict, a
+    :class:`~trading_bot.application.events.FillEvent` -> the fill dict, a
+    :class:`~trading_bot.application.events.LogEvent` -> ``{message, level}``.
+    """
+    if isinstance(event, OrderEvent):
+        return {"type": "order", "order": _order_dict(event.order)}
+    if isinstance(event, FillEvent):
+        return {"type": "fill", "fill": _fill_dict(event.fill)}
+    if isinstance(event, LogEvent):
+        return {"type": "log", "message": event.message, "level": event.level}
+    # Defensive: an unknown event type still streams a typed, JSON-safe frame.
+    return {"type": "unknown", "repr": repr(event)}
+
+
+# ---------------------------------------------------------------------------
+# Application factory
+# ---------------------------------------------------------------------------
+
+def create_app(engine: Engine) -> FastAPI:
+    """Build the read-only FastAPI over a wired :class:`Engine`.
+
+    Stores ``engine`` on ``app.state`` and registers the read-only GET endpoints
+    (``/api/health``, ``/api/positions``, ``/api/orders``, ``/api/kpi``) plus the
+    SSE stream (``/api/events``). Every response renders money as an exact
+    :class:`~decimal.Decimal` string (see the module docstring). **No** endpoint
+    mutates the engine — there is deliberately no route to place or cancel an
+    order.
+
+    Parameters
+    ----------
+    engine : Engine
+        The fully-wired engine to expose. Read through ``app.state.engine`` by the
+        handlers, so the wiring is explicit and the app is testable with a paper
+        engine.
+
+    Returns
+    -------
+    FastAPI
+        The configured application — pass it to a server (uvicorn) or to
+        :class:`fastapi.testclient.TestClient`.
+
+    """
+    app = FastAPI(
+        title="trading_bot API",
+        summary="Read-only HTTP view of the live trading engine.",
+        default_response_class=_DecimalJSONResponse,
+    )
+    app.state.engine = engine
+
+    def _engine(request: Request) -> Engine:
+        """Read the wired engine off ``app.state`` (explicit, testable access)."""
+        return request.app.state.engine  # type: ignore[no-any-return]
+
+    # -- Health -------------------------------------------------------------- #
+
+    @app.get("/api/health")
+    async def health(request: Request) -> dict[str, Any]:
+        """Liveness + a snapshot of what the engine is configured to run."""
+        eng = _engine(request)
+        return {
+            "status": "ok",
+            "mode": eng.config.mode,
+            "strategies": len(eng.config.strategies),
+        }
+
+    # -- Positions ----------------------------------------------------------- #
+
+    @app.get("/api/positions")
+    async def positions(request: Request) -> list[dict[str, Any]]:
+        """Live net positions per instrument (money as Decimal strings)."""
+        eng = _engine(request)
+        return [
+            _position_dict(position)
+            for position in eng.tracker.all_positions().values()
+        ]
+
+    # -- Orders -------------------------------------------------------------- #
+
+    @app.get("/api/orders")
+    async def orders(request: Request) -> list[dict[str, Any]]:
+        """Every order the router has tracked (enums by value; money as strings)."""
+        eng = _engine(request)
+        return [_order_dict(order) for order in eng.router.tracked_orders().values()]
+
+    # -- KPI ----------------------------------------------------------------- #
+
+    @app.get("/api/kpi")
+    async def kpi(request: Request) -> dict[str, Any]:
+        """Aggregate PnL/KPI: money as Decimal strings, ratios as JSON numbers."""
+        perf = _engine(request).perf
+        equity = perf.equity_curve()
+        equity_end = equity[-1] if equity else None
+        return {
+            "realised_pnl": _money_str(perf.realised_pnl()),
+            "fees_paid": _money_str(perf.fees_paid()),
+            "equity_end": _money_str(equity_end),
+            "sharpe": _safe_ratio(perf.sharpe),
+            "sortino": _safe_ratio(perf.sortino),
+            "max_drawdown": _safe_ratio(perf.max_drawdown),
+            "calmar": _safe_ratio(perf.calmar),
+        }
+
+    # -- SSE events ---------------------------------------------------------- #
+
+    @app.get("/api/events")
+    async def events(request: Request) -> StreamingResponse:
+        """Server-Sent-Events stream of order/fill/log events from the bus.
+
+        Registers a fresh queue on the engine's
+        :class:`~trading_bot.application.events.EventBus`, yields each event as a
+        ``data: <json>\\n\\n`` frame (money as Decimal strings, tagged with a
+        ``type``), and unregisters the queue in a ``finally`` on disconnect.
+        """
+        bus = _engine(request).bus
+        queue = bus.add_queue()
+
+        async def _generator() -> Any:
+            try:
+                # Flush an immediate comment so the client's EventSource leaves
+                # "connecting" without waiting for the first real event (mirrors
+                # dccd, where a buffering middleware otherwise stalls the start).
+                yield ": connected\n\n"
+                while True:
+                    if await request.is_disconnected():
+                        break
+                    try:
+                        # Bounded wait so the loop periodically wakes to re-check
+                        # disconnection (and so a hung consumer cannot pin the
+                        # queue forever); on timeout, send an SSE heartbeat
+                        # comment. Mirrors dccd's /api/events.
+                        event = await asyncio.wait_for(queue.get(), timeout=15.0)
+                        yield (
+                            f"data: {json.dumps(_event_dict(event), default=_default)}\n\n"
+                        )
+                    except asyncio.TimeoutError:
+                        yield ": heartbeat\n\n"
+            finally:
+                bus.remove_queue(queue)
+
+        return StreamingResponse(_generator(), media_type="text/event-stream")
+
+    return app

--- a/trading_bot/tests/interfaces/test_api.py
+++ b/trading_bot/tests/interfaces/test_api.py
@@ -1,0 +1,445 @@
+"""Tests for ``trading_bot.interfaces.api`` — the read-only FastAPI over the engine.
+
+The whole API is exercised in-process against a **paper engine** (the real data
+path: a :class:`~trading_bot.brokers.paper.PaperBroker` produces real fills,
+which fold into real positions and PnL) through
+:class:`fastapi.testclient.TestClient` — no real server, no network.
+
+What is verified
+----------------
+* ``GET /api/health`` reports ``mode == "paper"`` and the strategy count;
+* ``GET /api/positions`` returns the held instrument(s) with **money as exact
+  Decimal strings** (a ``0.1`` qty serializes as ``"0.1"``, not ``0.1`` the
+  float) matching ``engine.tracker``;
+* ``GET /api/orders`` returns the router's tracked orders with enums by ``.value``
+  and money as strings;
+* ``GET /api/kpi`` returns realised PnL as a string equal to
+  ``engine.perf.realised_pnl()`` and the four KPI ratio keys;
+* ``GET /api/events`` (SSE) streams a :class:`FillEvent` emitted on the bus and
+  the queue is removed on disconnect;
+* there is **no** mutation route — a POST to a plausible order path is rejected.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from decimal import Decimal
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from trading_bot.application.config import AppConfig
+from trading_bot.application.events import FillEvent
+from trading_bot.application.service_factory import Engine, build_engine
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.interfaces.api import create_app
+
+# --- fixtures: a paper engine seeded with real orders / fills -------------- #
+
+_BTC = Instrument(Symbol("BTC", "USD"))
+_ETH = Instrument(Symbol("ETH", "USD"))
+
+
+def _build_seeded_engine() -> Engine:
+    """A paper engine with two strategies declared and real orders/fills booked.
+
+    Submits a BUY then a partial-close SELL on BTC and a single BUY on ETH
+    through the engine's real :class:`~trading_bot.application.order_router.
+    OrderRouter`; the wired :class:`~trading_bot.brokers.paper.PaperBroker` fills
+    each immediately at the limit price and emits ``FillEvent``\\ s onto the
+    shared bus, so the tracker and performance service hold real state.
+    """
+    config = AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "strategies": [
+                {"name": "btc-ma", "symbol": "BTC/USD"},
+                {"name": "eth-ma", "symbol": "ETH/USD"},
+            ],
+        }
+    )
+    engine = build_engine(config)
+
+    async def _book() -> None:
+        # BTC: buy 0.1 @ 30000, then sell 0.04 @ 31000 (realises PnL on the close).
+        await engine.router.submit(
+            Order(
+                client_order_id="btc-buy-1",
+                instrument=_BTC,
+                side=OrderSide.BUY,
+                qty=money("0.1"),
+                type=OrderType.LIMIT,
+                limit_price=money("30000"),
+            )
+        )
+        await engine.router.submit(
+            Order(
+                client_order_id="btc-sell-1",
+                instrument=_BTC,
+                side=OrderSide.SELL,
+                qty=money("0.04"),
+                type=OrderType.LIMIT,
+                limit_price=money("31000"),
+            )
+        )
+        # ETH: a single buy that stays fully open as a long position.
+        await engine.router.submit(
+            Order(
+                client_order_id="eth-buy-1",
+                instrument=_ETH,
+                side=OrderSide.BUY,
+                qty=money("2"),
+                type=OrderType.LIMIT,
+                limit_price=money("2000"),
+            )
+        )
+
+    asyncio.run(_book())
+    return engine
+
+
+@pytest.fixture
+def engine() -> Engine:
+    """A paper engine seeded with real BTC/ETH orders + fills."""
+    return _build_seeded_engine()
+
+
+@pytest.fixture
+def client(engine: Engine) -> TestClient:
+    """A ``TestClient`` over ``create_app(engine)`` (no real server)."""
+    return TestClient(create_app(engine))
+
+
+# --- health ---------------------------------------------------------------- #
+
+
+def test_health_reports_paper_mode_and_strategy_count(client: TestClient) -> None:
+    """``/api/health`` is 200 and reports the paper mode + declared strategies."""
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["mode"] == "paper"
+    assert body["strategies"] == 2
+
+
+# --- positions: money is an exact Decimal string --------------------------- #
+
+
+def test_positions_money_fields_are_exact_decimal_strings(
+    client: TestClient, engine: Engine
+) -> None:
+    """``/api/positions`` renders every money field as the **exact** Decimal string."""
+    resp = client.get("/api/positions")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    by_instrument = {row["instrument"]: row for row in body}
+    assert set(by_instrument) == {"BTC/USD", "ETH/USD"}
+
+    # The crux: money is a JSON *string*, not a float, and exact.
+    btc = by_instrument["BTC/USD"]
+    assert isinstance(btc["net_qty"], str)
+    # bought 0.1, sold 0.04 -> net 0.06 long; serialized exactly, no float noise.
+    assert btc["net_qty"] == "0.06"
+    assert btc["avg_entry_price"] == "30000"
+
+    eth = by_instrument["ETH/USD"]
+    assert isinstance(eth["net_qty"], str)
+    # The ETH 2.0 buy is the canonical "a price/qty of 2 stays exact" case.
+    assert eth["net_qty"] == "2"
+
+    # Every position dict must match the engine's tracker exactly.
+    for instrument, position in engine.tracker.all_positions().items():
+        row = by_instrument[str(instrument)]
+        assert row["net_qty"] == str(position.net_qty)
+        assert row["realised_pnl"] == str(position.realised_pnl)
+        assert row["fees_paid"] == str(position.fees_paid)
+        expected_entry = (
+            None
+            if position.avg_entry_price is None
+            else str(position.avg_entry_price)
+        )
+        assert row["avg_entry_price"] == expected_entry
+
+
+def test_positions_money_never_serialized_as_float() -> None:
+    """A ``0.1`` quantity must appear in the raw JSON as ``"0.1"``, not ``0.1``.
+
+    Guards the Decimal-as-string invariant at the byte level: a flat-from-fresh
+    position of exactly 0.1 (no closing trade) must render the string ``"0.1"``,
+    proving money never crosses the lossy float path.
+    """
+    config = AppConfig.model_validate({"mode": "paper"})
+    engine = build_engine(config)
+    engine.tracker.apply(
+        Fill(
+            fill_id="T1",
+            client_order_id="cid-1",
+            instrument=_BTC,
+            side=OrderSide.BUY,
+            qty=money("0.1"),
+            price=money("30000.1"),
+            fee=money("0"),
+            ts=1,
+        )
+    )
+    client = TestClient(create_app(engine))
+    raw = client.get("/api/positions").text
+    # The exact strings must be present in the wire bytes...
+    assert '"net_qty":"0.1"' in raw
+    assert '"avg_entry_price":"30000.1"' in raw
+    # ...and the lossy float forms must NOT appear.
+    assert '"net_qty":0.1' not in raw
+    assert "0.1000000000000000055511151231257827021181583404541015625" not in raw
+
+
+# --- orders: enums by value, money as strings ------------------------------ #
+
+
+def test_orders_lists_tracked_orders_with_value_enums_and_string_money(
+    client: TestClient, engine: Engine
+) -> None:
+    """``/api/orders`` returns the router's tracked orders, enums by value, money str."""
+    resp = client.get("/api/orders")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    by_cid = {row["client_order_id"]: row for row in body}
+    assert set(by_cid) == set(engine.router.tracked_orders())
+
+    btc_buy = by_cid["btc-buy-1"]
+    # Enums serialize by their .value (not "OrderSide.BUY").
+    assert btc_buy["side"] == "buy"
+    assert btc_buy["type"] == "limit"
+    assert btc_buy["status"] in {"filled", "open", "partially_filled"}
+    # Money fields are exact strings.
+    assert isinstance(btc_buy["qty"], str)
+    assert btc_buy["qty"] == "0.1"
+    assert btc_buy["limit_price"] == "30000"
+    assert isinstance(btc_buy["filled_qty"], str)
+    # A LIMIT order has no stop price -> JSON null.
+    assert btc_buy["stop_price"] is None
+    # venue id is populated by the broker open transition.
+    assert btc_buy["venue_order_id"] is not None
+    assert btc_buy["instrument"] == "BTC/USD"
+
+
+# --- kpi: money strings + the four ratios ---------------------------------- #
+
+
+def test_kpi_realised_pnl_string_matches_engine_and_has_ratios(
+    client: TestClient, engine: Engine
+) -> None:
+    """``/api/kpi`` realised PnL (string) equals the perf service; ratios present."""
+    resp = client.get("/api/kpi")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    # Money as exact Decimal strings matching the engine's performance service.
+    assert body["realised_pnl"] == str(engine.perf.realised_pnl())
+    assert body["fees_paid"] == str(engine.perf.fees_paid())
+    equity = engine.perf.equity_curve()
+    assert body["equity_end"] == str(equity[-1])
+    assert isinstance(body["realised_pnl"], str)
+
+    # The four KPI ratios are present and numeric (floats are fine for ratios).
+    for key in ("sharpe", "sortino", "max_drawdown", "calmar"):
+        assert key in body
+        assert isinstance(body[key], (int, float))
+
+
+def test_kpi_empty_engine_returns_zero_ratios_and_null_equity() -> None:
+    """A fresh engine (no fills): zero ratios, null equity_end, zero money strings."""
+    engine = build_engine(AppConfig.model_validate({"mode": "paper"}))
+    client = TestClient(create_app(engine))
+    body = client.get("/api/kpi").json()
+    assert body["realised_pnl"] == "0"
+    assert body["equity_end"] is None
+    assert body["sharpe"] == 0.0
+
+
+# --- SSE: a FillEvent streams through, queue removed on disconnect ---------- #
+
+
+def _events_route(app: FastAPI) -> Any:
+    """The ``/api/events`` route's async endpoint handler."""
+    route = next(
+        r for r in app.routes if getattr(r, "path", None) == "/api/events"
+    )
+    return route.endpoint
+
+
+async def _never_disconnect() -> dict[str, Any]:
+    """An ASGI ``receive`` that never reports a disconnect (the consumer stays up)."""
+    await asyncio.sleep(3600)
+    return {"type": "http.disconnect"}  # pragma: no cover - never reached
+
+
+async def test_events_stream_delivers_fill_event_and_removes_queue(
+    engine: Engine,
+) -> None:
+    """``/api/events`` streams an emitted ``FillEvent`` (money as strings), cleans up.
+
+    The endpoint serves an **infinite** ``text/event-stream``; the in-process
+    ``TestClient`` deadlocks consuming an endless stream, so this drives the
+    endpoint's real ``StreamingResponse.body_iterator`` directly — the exact
+    generator the route returns, including the bus-queue registration on open and
+    the ``remove_queue`` in its ``finally`` on close.
+    """
+    app = create_app(engine)
+    bus = engine.bus
+    before = len(bus._queues)
+
+    fill = Fill(
+        fill_id="SSE-1",
+        client_order_id="btc-buy-1",
+        instrument=_BTC,
+        side=OrderSide.BUY,
+        qty=money("0.1"),
+        price=money("30000.5"),
+        fee=money("0.3"),
+        ts=1_700_000_000_000,
+    )
+
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/api/events",
+        "headers": [],
+        "query_string": b"",
+        "app": app,
+    }
+    request = Request(scope, _never_disconnect)
+    response = await _events_route(app)(request)
+    assert response.media_type == "text/event-stream"
+
+    frames = response.body_iterator
+    try:
+        # First frame is the immediate ": connected" comment (flushes the start),
+        # and the bus queue is now registered for this consumer.
+        first = await frames.__anext__()
+        assert first.startswith(":")
+        assert len(bus._queues) == before + 1
+
+        # Emit a fill; it must arrive next as a `data:` frame with string money.
+        bus.emit(FillEvent(fill))
+        frame = await frames.__anext__()
+        assert frame.startswith("data:")
+        payload = json.loads(frame[len("data:"):].strip())
+        assert payload["type"] == "fill"
+        assert payload["fill"]["fill_id"] == "SSE-1"
+        # Money in the SSE frame is an exact Decimal string, like the REST routes.
+        assert payload["fill"]["price"] == "30000.5"
+        assert payload["fill"]["fee"] == "0.3"
+        assert payload["fill"]["side"] == "buy"
+    finally:
+        # Closing the stream (client disconnect) runs the generator's `finally`,
+        # which removes the queue from the bus.
+        await frames.aclose()
+
+    assert len(bus._queues) == before
+
+
+# --- no-mutation: the API never places or cancels an order ----------------- #
+
+
+@pytest.mark.parametrize("path", ["/api/orders", "/api/positions", "/api/events"])
+def test_no_mutation_routes(client: TestClient, path: str) -> None:
+    """A POST to a plausible order path is rejected — the API is read-only.
+
+    Only GET is registered, so a POST returns 405 (method not allowed). The
+    absence of an order-placing route is the read-only invariant.
+    """
+    resp = client.post(path, json={"side": "buy", "qty": "1"})
+    assert resp.status_code in {404, 405}
+    # And specifically: no order was created by the attempt.
+
+
+def test_decimal_string_round_trips_to_exact_decimal(client: TestClient) -> None:
+    """Re-parsing a money string with ``Decimal`` is exact (no float in between)."""
+    btc = next(
+        row
+        for row in client.get("/api/positions").json()
+        if row["instrument"] == "BTC/USD"
+    )
+    # Decimal(the string) is exact; Decimal(float(...)) would not be.
+    assert Decimal(btc["net_qty"]) == Decimal("0.06")
+
+
+# --- unit-level coverage of the serialization safety nets ------------------ #
+
+
+def test_decimal_encoder_renders_decimal_as_string_and_rejects_other() -> None:
+    """The JSON ``default`` hook stringifies a Decimal exactly, else raises."""
+    from trading_bot.interfaces.api.app import _default
+
+    assert _default(Decimal("0.1")) == "0.1"
+    assert json.dumps({"x": Decimal("1.5")}, default=_default) == '{"x": "1.5"}'
+    with pytest.raises(TypeError):
+        _default(object())
+
+
+def test_safe_ratio_returns_zero_when_estimator_is_undefined() -> None:
+    """A KPI ratio that fynance rejects (sign-crossing curve) degrades to ``0.0``."""
+    from trading_bot.interfaces.api.app import _safe_ratio
+
+    def _raises() -> float:
+        raise ValueError("initial value X[0] and final value X[-1] ... sign")
+
+    assert _safe_ratio(_raises) == 0.0
+    assert _safe_ratio(lambda: 1.25) == 1.25
+
+
+def test_event_dict_serializes_each_event_type_with_string_money() -> None:
+    """``_event_dict`` tags + renders order/fill/log events (money as strings)."""
+    from trading_bot.application.events import LogEvent, OrderEvent
+    from trading_bot.interfaces.api.app import _event_dict
+
+    order = Order(
+        client_order_id="cid-1",
+        instrument=_BTC,
+        side=OrderSide.BUY,
+        qty=money("0.1"),
+        type=OrderType.LIMIT,
+        limit_price=money("30000"),
+    )
+    order_payload = _event_dict(OrderEvent(order))
+    assert order_payload["type"] == "order"
+    assert order_payload["order"]["qty"] == "0.1"
+    assert order_payload["order"]["side"] == "buy"
+
+    log_payload = _event_dict(LogEvent(message="hi", level="warning"))
+    assert log_payload == {"type": "log", "message": "hi", "level": "warning"}
+
+
+def test_kpi_endpoint_stays_robust_over_a_profitable_curve() -> None:
+    """``/api/kpi`` never 500s even when fynance can/can't define a ratio.
+
+    Drives the perf service with a profitable round-trip (realised PnL +10): the
+    endpoint reports the exact PnL string and a JSON number for every ratio —
+    whichever fynance can compute on this curve, and ``0.0`` (via ``_safe_ratio``)
+    for any it rejects. The point is the read-only KPI view is always 200 + numeric.
+    """
+    engine = build_engine(AppConfig.model_validate({"mode": "paper"}))
+    perf = engine.perf
+    perf.apply(
+        Fill("F1", "c1", _BTC, OrderSide.BUY, money("1"), money("100"),
+             money("0"), 1)
+    )
+    perf.apply(
+        Fill("F2", "c1", _BTC, OrderSide.SELL, money("1"), money("110"),
+             money("0"), 2)
+    )
+    body = TestClient(create_app(engine)).get("/api/kpi").json()
+    # realised PnL +10, rendered as an exact Decimal string.
+    assert body["realised_pnl"] == "10"
+    for key in ("sharpe", "sortino", "max_drawdown", "calmar"):
+        assert isinstance(body[key], (int, float))


### PR DESCRIPTION
## Summary
- First leaf of **E9**: `interfaces/api/app.py` — `create_app(engine)`, a **read-only** FastAPI over the engine. `GET /api/{health,positions,orders,kpi}` + an SSE `GET /api/events` fed by the `EventBus`.
- **Money as Decimal strings** in JSON (never float); KPI ratios as numbers. **No order placement from the web** (POST to an order path → 405).

## Why
- A dashboard must never become a trading surface — keeping the API observe-only means the web can't move money. Decimal-string JSON preserves exactness to the browser. See `doc/dev/03-decisions.md`.

## Note (known gap recorded)
- KPI ratios degrade to `0.0` because `build_engine` wires `PerformanceService(v0=0)` and fynance refuses a zero-crossing equity curve (same root as the CLI `kpi --capital` workaround). Robust (never 500s); a config-driven starting capital is a small follow-up. See `06-status`.

## Changes
- `interfaces/api/{__init__,app.py}` + tests (15, FastAPI `TestClient`); `fastapi`/`uvicorn` confirmed in daemon+dev extras.

## Changelog
Added: `interfaces.api` — read-only FastAPI (positions/orders/KPI + SSE; money as Decimal strings).

## Test plan
- [x] `.venv/bin/python -m pytest` (510 passed, 0 unexpected skips)
- [x] real paper engine: `/api/positions` + `/api/kpi` JSON match the engine exactly; money is exact Decimal strings
- [x] read-only proven (POST → 405); SSE registers/removes its bus queue
- [x] `ruff` + `mypy` clean