### PR TITLE
feat: Jinja2 dashboard + trading-bot serve (closes E9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `interfaces.api` — read-only FastAPI over the engine: `GET /api/{health,positions,
   orders,kpi}` (money as **Decimal strings**, never float) + an SSE `/api/events`
   stream fed by the `EventBus`. The web surface only observes — no order placement.
+- `interfaces.ui` — Jinja2 dashboard (positions / open orders / PnL+KPI), a **pure
+  HTTP client** of the API, live-updating via SSE; served by the same app. Plus a
+  `trading-bot serve` CLI command (uvicorn). Completes the **E9 web UI**.
 - `AppConfig` — full declarative config: each strategy declares its dccd **data
   source** (exchange/span/start), its **signal** by reference (`module:function` or a
   builtin like `ma_crossover` + params) and its sizing (`reference_qty`, `lookback`),

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,27 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-28 Web UI: pure HTTP client of the API; `serve` over a paper engine
+
+**Decision.** `interfaces/ui/` is a Jinja2 **shell** (header: brand + version + mode
+badge; three cards — Positions / Open orders / PnL+KPI — with stable tbody ids) served
+by the same FastAPI app at `GET /`. All engine state is fetched **client-side** from
+`/api/{positions,orders,kpi}` and live-updated via the `/api/events` SSE stream; the
+dependency-free `app.js` renders money **verbatim** from the API's Decimal strings (no
+`parseFloat` of money). The templates/JS never touch the application layer — the UI is
+a pure HTTP client and inherits the API's read-only guarantee (no path to place an
+order; POST → 405). `trading-bot serve [--config --host --port]` builds a paper-default
+engine (`_build_serve_app` seam, testable with `uvicorn.run` patched) and serves it;
+templates/static ship via `[tool.setuptools.package-data]`.
+
+**Why.** A pure-client UI keeps the only money-moving surface (order placement) entirely
+off the web — even fully exposed, the dashboard can't trade. Rendering Decimal strings
+verbatim preserves exactness in the browser. `serve` over a freshly-built engine + the
+persisted store is the MVP data path; attaching to a separately-running live system is
+E10/future work. Mirrors dccd's UI = pure HTTP client of its api.
+
+---
+
 ### 2026-06-25 Web API: read-only, money as Decimal strings, SSE via EventBus
 
 **Decision.** `interfaces/api/app.py` `create_app(engine)` is a **read-only** HTTP

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -10,24 +10,27 @@ GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
 `.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
 smoke test passes.
 
-**E1–E8 are complete — Trading_Bot is the conductor of the triptych.** One
-`AppConfig` declares data sources (dccd) + strategies (fynance signals) + brokers +
-risk, and `trading-bot run <config.yaml>` brings up the **whole declared
-multi-strategy system** (paper by default): `run_app` builds one shared engine and
-runs a `StrategyRunner` per strategy concurrently via the `Orchestrator`, reporting
-per-strategy orders/positions/PnL. dccd is integrated by **library import**
-(`feed_for` → `dccd.Client.read`/`backfill`). Layers: `domain/` (pure, mypy-strict),
-`transport/` (http/ws/ratelimit), `brokers/` (`Broker` port + `KrakenBroker` REST+WS +
-port-pure `PaperBroker`), `storage/` (`SqliteStore`, money as TEXT), `application/`
-(declarative `AppConfig`+`EventBus`, idempotent risk-gated `OrderRouter`,
-`PositionTracker`, `reconcile`, `Strategy`+safe loader, causal `DataFeed`+`feed_for`,
-`StrategyRunner`, `PerformanceService`, `RiskManager`+kill-switch, `Orchestrator`,
-`run_app`, `service_factory`), and `interfaces/cli/` (Typer `trading-bot`). The
-pre-2026 `legacy/` tree is deleted; the whole package is linted/typed/tested. 495
-tests green via the project `.venv`.
+**E1–E9 are complete — only go-live hardening (E10) remains.** Trading_Bot conducts
+the triptych: one `AppConfig` declares data (dccd) + strategies (fynance) + brokers +
+risk; `trading-bot run <config.yaml>` runs the whole declared multi-strategy system
+(paper by default) via `run_app` → one shared engine → a `StrategyRunner` per strategy
+through the `Orchestrator`; and `trading-bot serve` exposes a **read-only** web
+dashboard (FastAPI `/api/*` + SSE, Jinja2 UI as a pure HTTP client — money as Decimal
+strings, never trades). dccd is integrated by **library import** (`feed_for`). Layers:
+`domain/` (pure, mypy-strict), `transport/` (http/ws/ratelimit), `brokers/` (`Broker`
+port + `KrakenBroker` REST+WS + port-pure `PaperBroker`), `storage/` (`SqliteStore`,
+money as TEXT), `application/` (declarative `AppConfig`+`EventBus`, idempotent
+risk-gated `OrderRouter`, `PositionTracker`, `reconcile`, `Strategy`+safe loader,
+causal `DataFeed`+`feed_for`, `StrategyRunner`, `PerformanceService`, `RiskManager`+
+kill-switch, `Orchestrator`, `run_app`, `service_factory`), `interfaces/` (Typer
+`trading-bot` CLI + read-only FastAPI `api`/Jinja2 `ui`). The pre-2026 `legacy/` tree
+is deleted; the whole package is linted/typed/tested. **521 tests** green via the
+project `.venv`.
 
-Pending: **E9** (web UI — FastAPI/Jinja2 dashboard), **E10** (go-live hardening +
-final name). Next is **E9**. See `07-roadmap.md` /
+Pending: **E10** — go-live hardening (prove reconciliation / kill-switch / idempotency
+under fault injection; resolve the venue-idempotency + KPI-v0 + same-instrument known
+gaps; explicit live enablement) and the **final project name**. Next is **E10**. See
+`07-roadmap.md` /
 `08-program-plan.md`.
 
 ## Done

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -12,8 +12,6 @@ The single source *index* of open work. Each unchecked item is a candidate for
 
 ## Later
 
-- [ ] **E9 — Web UI.** FastAPI + Jinja2 dashboard (positions/orders/PnL),
-  mirroring dccd's UI. _(depends on E8)_
 - [ ] **E10 — Go-live hardening & final name.** Live-trading checklist
   (reconciliation, kill-switch, idempotency proven under fault injection); choose
   and apply the final project name. _(depends on E8)_

--- a/doc/dev/plans/web-ui/00-plan.md
+++ b/doc/dev/plans/web-ui/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: web-ui
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E9 — Web UI.** FastAPI + Jinja2 dashboard (positions/orders/PnL), mirroring dccd's UI."
 release_on_done: false
 ---
@@ -27,7 +27,7 @@ FastAPI `TestClient` over a paper `Engine` (no real server, no network).
 ## Leaf checklist
 
 - [x] 01 api — feat/web-api — high
-- [ ] 02 ui — feat/web-ui — high (depends on 01)
+- [x] 02 ui — feat/web-ui — high (depends on 01)
 
 ## Dependencies
 

--- a/doc/dev/plans/web-ui/02-ui.md
+++ b/doc/dev/plans/web-ui/02-ui.md
@@ -1,7 +1,7 @@
 ---
 plan: web-ui/02-ui
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01]
 parallel: false

--- a/doc/dev/plans/web-ui/02-ui.md
+++ b/doc/dev/plans/web-ui/02-ui.md
@@ -6,7 +6,7 @@ complexity: high
 depends: [01]
 parallel: false
 branch: feat/web-ui
-pr: ""
+pr: "#51"
 ---
 
 # Web UI — Jinja2 dashboard + `trading-bot serve`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ dev = [
     # exercise interfaces.api via fastapi.testclient.TestClient.
     "fastapi>=0.110",
     "uvicorn[standard]>=0.29",
+    # The web UI templating so the unit suite / CI can render the dashboard shell.
+    "jinja2>=3.1",
 ]
 doc = [
     "sphinx>=7.0",
@@ -80,6 +82,12 @@ Changelog = "https://github.com/ArthurBernard/Trading_Bot/blob/master/CHANGELOG.
 
 [tool.setuptools.packages.find]
 include = ["trading_bot*"]
+
+[tool.setuptools.package-data]
+# Ship the web-UI assets in the wheel so `trading-bot serve` works installed
+# (not just from a source checkout). `static/*` matches only the top level —
+# nested asset dirs would need their own line (mirrors dccd).
+"trading_bot.interfaces.ui" = ["templates/*.html", "static/*"]
 
 [tool.pytest.ini_options]
 addopts = "--exitfirst -vv --cov=trading_bot --cov-report=term-missing -m 'not network'"

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -41,6 +41,20 @@ serialized with money as strings and tagged with a ``type`` discriminator), and
 :meth:`~trading_bot.application.events.EventBus.remove_queue` runs in a
 ``finally`` so the queue is always unregistered on disconnect — exactly dccd's
 ``/api/events`` shape.
+
+The dashboard UI — a pure HTTP client mounted on the same app (carried into the ADR)
+------------------------------------------------------------------------------------
+``create_app`` also mounts the read-only web dashboard (leaf 02): ``StaticFiles``
+at ``/static`` over :data:`~trading_bot.interfaces.ui.STATIC_DIR`, a
+:class:`~fastapi.templating.Jinja2Templates` over
+:data:`~trading_bot.interfaces.ui.TEMPLATES_DIR`, and a single ``GET /`` that
+renders ``dashboard.html`` — a **shell** carrying only the package version and the
+engine ``mode`` (no engine data is rendered server-side). The page's ``app.js``
+fetches ``/api/positions|orders|kpi`` and live-updates from ``/api/events``, so the
+UI is a **pure HTTP client** of this API: it shares the API's read-only guarantee
+and has no path to place an order. The directories are resolved from the installed
+package (shipped via ``[tool.setuptools.package-data]``), and the mount is guarded
+on their existence so the API still builds if assets are absent.
 """
 
 from __future__ import annotations
@@ -52,14 +66,18 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI, Request
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 
+import trading_bot
 from trading_bot.application.events import (
     Event,
     FillEvent,
     LogEvent,
     OrderEvent,
 )
+from trading_bot.interfaces.ui import STATIC_DIR, TEMPLATES_DIR
 
 if TYPE_CHECKING:
     from trading_bot.application.service_factory import Engine
@@ -253,6 +271,41 @@ def create_app(engine: Engine) -> FastAPI:
     def _engine(request: Request) -> Engine:
         """Read the wired engine off ``app.state`` (explicit, testable access)."""
         return request.app.state.engine  # type: ignore[no-any-return]
+
+    # -- UI: dashboard shell + static assets --------------------------------- #
+    # Mount the read-only web dashboard on the same app. The page is a *shell*
+    # (version + mode only); all engine data is fetched client-side from /api/*,
+    # so the UI is a pure HTTP client of this API (read-only, no order path).
+    # Guarded on the dirs existing so the API still builds without the assets.
+    if STATIC_DIR.is_dir():
+        app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+
+    templates = (
+        Jinja2Templates(directory=str(TEMPLATES_DIR))
+        if TEMPLATES_DIR.is_dir()
+        else None
+    )
+
+    if templates is not None:
+
+        @app.get("/", response_class=HTMLResponse)
+        async def dashboard(request: Request) -> Any:
+            """Render the read-only dashboard shell (no engine data server-side).
+
+            Returns ``dashboard.html`` carrying only the package version and the
+            engine ``mode`` (for the header badge). The page's ``app.js`` fetches
+            ``/api/positions|orders|kpi`` and live-updates from ``/api/events`` —
+            the UI never renders engine state server-side and never mutates it.
+            """
+            eng = _engine(request)
+            return templates.TemplateResponse(
+                request,
+                "dashboard.html",
+                {
+                    "version": trading_bot.__version__,
+                    "mode": eng.config.mode,
+                },
+            )
 
     # -- Health -------------------------------------------------------------- #
 

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -46,6 +46,7 @@ import math
 import pathlib
 from collections.abc import Callable
 from decimal import Decimal
+from typing import TYPE_CHECKING
 
 import polars as pl
 import typer
@@ -67,6 +68,9 @@ from trading_bot.domain.instrument import Instrument, parse_kraken_pair
 from trading_bot.domain.money import Money, from_float, money
 from trading_bot.domain.order import Order, OrderSide, OrderType
 from trading_bot.interfaces.cli import _render
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
 
 app = typer.Typer(
     name="trading-bot",
@@ -495,6 +499,81 @@ def kpi(
         perf.apply(fill)
 
     _console.print(_render.kpi_table(perf))
+
+
+# --- serve ----------------------------------------------------------------- #
+
+
+def _build_serve_app(config: AppConfig) -> FastAPI:
+    """Build the read-only FastAPI dashboard app over a freshly-wired engine.
+
+    The wiring seam :func:`serve` calls so the command is testable **without**
+    launching uvicorn: the test patches :func:`uvicorn.run` and asserts the app
+    this helper returns is what ``serve`` hands it. Builds a paper-by-default
+    engine via :func:`~trading_bot.application.service_factory.build_engine`
+    (persisting to ``config.storage.db_path`` when set) and wraps it in
+    :func:`~trading_bot.interfaces.api.create_app`.
+    """
+    from trading_bot.interfaces.api import create_app
+
+    engine = build_engine(config, db_path=config.storage.db_path)
+    return create_app(engine)
+
+
+@app.command()
+def serve(
+    config_path: pathlib.Path | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="YAML AppConfig path. Defaults to a paper config (no strategies).",
+    ),
+    host: str = typer.Option(
+        "127.0.0.1",
+        "--host",
+        help="Interface to bind. Defaults to loopback (local-only).",
+    ),
+    port: int = typer.Option(
+        8000,
+        "--port",
+        help="TCP port to listen on.",
+    ),
+) -> None:
+    """Serve the read-only web dashboard (positions / orders / PnL) over HTTP.
+
+    Builds a wired engine from ``--config`` (or a paper default), wraps it in the
+    read-only FastAPI app (:func:`~trading_bot.interfaces.api.create_app`) and
+    runs it under uvicorn. The dashboard is a **pure HTTP client** of the API and
+    is **read-only** — it can observe the engine but never place an order.
+
+    MVP scope
+    ---------
+    ``serve`` exposes a **freshly-built** engine: it shows whatever state that
+    engine accumulates (e.g. the order/fill history persisted in the configured
+    ``storage.db_path``, replayed into the tracker/performance views), not a
+    separately-running live trading process. Attaching the dashboard to a
+    long-running live system (one ``run`` driving strategies while ``serve`` views
+    it) is future work; for now ``serve`` + a persisted store is the data path.
+    """
+    import uvicorn
+
+    config = (
+        AppConfig.from_yaml(config_path)
+        if config_path is not None
+        else AppConfig()
+    )
+
+    try:
+        application = _build_serve_app(config)
+    except Exception as exc:  # noqa: BLE001 - surface any build failure cleanly
+        _console.print(f"[red]refusing to serve:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
+
+    _console.print(
+        f"[green]serving dashboard[/green] "
+        f"(mode={config.mode}) on http://{host}:{port}"
+    )
+    uvicorn.run(application, host=host, port=port)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation only

--- a/trading_bot/interfaces/ui/__init__.py
+++ b/trading_bot/interfaces/ui/__init__.py
@@ -1,0 +1,35 @@
+"""Web UI — a read-only Jinja2 dashboard served by the FastAPI app.
+
+This package ships the **static assets** of the dashboard: the Jinja2
+``templates/`` (the server-rendered shell) and ``static/`` (the dependency-free
+``app.js`` + ``style.css``). It holds **no Python logic** — the
+:func:`~trading_bot.interfaces.api.app.create_app` factory mounts these
+directories (``StaticFiles`` at ``/static``, ``Jinja2Templates`` over
+``templates/``) and registers the ``GET /`` route that renders the shell.
+
+The dashboard is a **pure HTTP client** of the leaf-01 API (carried into the ADR)
+-----------------------------------------------------------------------------------
+The served HTML is a *shell only* — no engine data is ever rendered server-side.
+``app.js`` fetches ``/api/positions``, ``/api/orders`` and ``/api/kpi`` over HTTP
+and live-updates from the ``/api/events`` SSE stream; it never reaches the
+application layer. The UI can therefore only *observe* the engine — like the API
+it sits behind, it is **read-only** and has no path to place an order. Money
+arrives as exact :class:`~decimal.Decimal` strings and is rendered **verbatim**;
+the JS never ``parseFloat``\\ s a money field (that would reintroduce binary-float
+rounding the API took care to avoid).
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+__all__ = ["UI_DIR", "STATIC_DIR", "TEMPLATES_DIR"]
+
+#: The ``interfaces/ui`` package directory — resolved relative to this file so it
+#: works both from a source checkout and an installed wheel (the templates/static
+#: are shipped via ``[tool.setuptools.package-data]``).
+UI_DIR = pathlib.Path(__file__).resolve().parent
+#: The Jinja2 templates directory (``dashboard.html`` + future pages).
+TEMPLATES_DIR = UI_DIR / "templates"
+#: The static-assets directory mounted at ``/static`` (``app.js`` + ``style.css``).
+STATIC_DIR = UI_DIR / "static"

--- a/trading_bot/interfaces/ui/static/app.js
+++ b/trading_bot/interfaces/ui/static/app.js
@@ -1,0 +1,168 @@
+// trading_bot dashboard — a pure HTTP client of the read-only API.
+//
+// On load it fetches the three JSON endpoints (/api/positions, /api/orders,
+// /api/kpi) and fills the table shells the server rendered; it then opens an
+// EventSource on /api/events (SSE) and re-fetches the tables whenever the engine
+// emits an order/fill event. It NEVER calls the application layer directly and
+// has no mutation path — the dashboard can only observe the engine.
+//
+// Money rule: every money field arrives from the API as an exact Decimal STRING
+// (the API stringifies Decimals precisely; JSON has no decimal type). This JS
+// renders those strings VERBATIM and never parseFloat()s a money field — doing
+// so would reintroduce the binary-float rounding the API took care to avoid.
+// The KPI ratios (Sharpe/Sortino/…) are statistical estimators, not money, so
+// they come back as JSON numbers and are shown as-is.
+
+(function () {
+  "use strict";
+
+  // --- DOM helpers --------------------------------------------------------- //
+
+  function el(id) {
+    return document.getElementById(id);
+  }
+
+  // Escape a value for safe insertion as text content (defence in depth; the
+  // API only emits trusted instrument/enum strings, but never trust a feed).
+  function esc(value) {
+    if (value === null || value === undefined) return "—";
+    return String(value).replace(/[&<>"']/g, function (c) {
+      return {
+        "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;"
+      }[c];
+    });
+  }
+
+  // Render a money STRING verbatim (no numeric parsing). A null optional shows
+  // as an em dash.
+  function money(value) {
+    return value === null || value === undefined ? "—" : esc(value);
+  }
+
+  // A KPI ratio is a plain JSON number — show a few significant digits.
+  function ratio(value) {
+    if (value === null || value === undefined || isNaN(value)) return "—";
+    return Number(value).toFixed(4);
+  }
+
+  function setConn(state, label) {
+    var conn = el("conn");
+    if (!conn) return;
+    conn.className = "conn " + state;
+    conn.innerHTML = '<span class="dot"></span>' + esc(label);
+  }
+
+  // --- fetch helpers ------------------------------------------------------- //
+
+  async function getJson(path) {
+    var resp = await fetch(path, { headers: { Accept: "application/json" } });
+    if (!resp.ok) throw new Error(path + " → " + resp.status);
+    return resp.json();
+  }
+
+  // --- renderers ----------------------------------------------------------- //
+
+  function renderPositions(rows) {
+    var body = el("positions-body");
+    if (!body) return;
+    if (!rows.length) {
+      body.innerHTML = '<tr class="empty"><td colspan="5">No positions.</td></tr>';
+      return;
+    }
+    body.innerHTML = rows.map(function (p) {
+      return "<tr>" +
+        "<td>" + esc(p.instrument) + "</td>" +
+        '<td class="num">' + money(p.net_qty) + "</td>" +
+        '<td class="num">' + money(p.avg_entry_price) + "</td>" +
+        '<td class="num">' + money(p.realised_pnl) + "</td>" +
+        '<td class="num">' + money(p.fees_paid) + "</td>" +
+        "</tr>";
+    }).join("");
+  }
+
+  function renderOrders(rows) {
+    var body = el("orders-body");
+    if (!body) return;
+    if (!rows.length) {
+      body.innerHTML = '<tr class="empty"><td colspan="8">No orders.</td></tr>';
+      return;
+    }
+    body.innerHTML = rows.map(function (o) {
+      return "<tr>" +
+        "<td>" + esc(o.client_order_id) + "</td>" +
+        "<td>" + esc(o.instrument) + "</td>" +
+        '<td class="side-' + esc(o.side) + '">' + esc(o.side) + "</td>" +
+        "<td>" + esc(o.type) + "</td>" +
+        '<td class="num">' + money(o.qty) + "</td>" +
+        '<td class="num">' + money(o.limit_price) + "</td>" +
+        '<td class="num">' + money(o.filled_qty) + "</td>" +
+        "<td>" + esc(o.status) + "</td>" +
+        "</tr>";
+    }).join("");
+  }
+
+  function renderKpi(kpi) {
+    var body = el("kpi-body");
+    if (!body) return;
+    var rows = [
+      ["Realised PnL", money(kpi.realised_pnl)],
+      ["Fees paid", money(kpi.fees_paid)],
+      ["Equity end", money(kpi.equity_end)],
+      ["Sharpe", ratio(kpi.sharpe)],
+      ["Sortino", ratio(kpi.sortino)],
+      ["Max drawdown", ratio(kpi.max_drawdown)],
+      ["Calmar", ratio(kpi.calmar)]
+    ];
+    body.innerHTML = rows.map(function (r) {
+      return "<tr><th>" + esc(r[0]) + '</th><td class="num">' + r[1] + "</td></tr>";
+    }).join("");
+  }
+
+  // --- refresh ------------------------------------------------------------- //
+
+  async function refresh() {
+    try {
+      var results = await Promise.all([
+        getJson("/api/positions"),
+        getJson("/api/orders"),
+        getJson("/api/kpi")
+      ]);
+      renderPositions(results[0]);
+      renderOrders(results[1]);
+      renderKpi(results[2]);
+      setConn("ok", "live");
+    } catch (err) {
+      setConn("down", "API unreachable");
+    }
+  }
+
+  // --- live updates (SSE) -------------------------------------------------- //
+
+  function connectEvents() {
+    var source = new EventSource("/api/events");
+    source.onmessage = function (ev) {
+      // An order or fill changed the engine's state — re-fetch the tables. The
+      // event payload itself is ignored here (the JSON endpoints are the single
+      // source of truth); we only use the signal that *something* changed.
+      try {
+        var data = JSON.parse(ev.data);
+        if (data && (data.type === "order" || data.type === "fill")) {
+          refresh();
+        }
+      } catch (e) {
+        // A heartbeat / non-JSON comment frame — ignore.
+      }
+    };
+    source.onerror = function () {
+      setConn("down", "reconnecting…");
+      // EventSource auto-reconnects; nothing to do here.
+    };
+  }
+
+  // --- boot ---------------------------------------------------------------- //
+
+  document.addEventListener("DOMContentLoaded", function () {
+    refresh();
+    connectEvents();
+  });
+})();

--- a/trading_bot/interfaces/ui/static/style.css
+++ b/trading_bot/interfaces/ui/static/style.css
@@ -1,0 +1,116 @@
+/* trading_bot dashboard — a small, legible dark theme.
+   A sticky header (brand + version + mode badge + connection dot) and three
+   cards: Positions, Open orders, PnL/KPI. Kept dependency-free and minimal. */
+
+:root {
+  --bg: #0b0f16;
+  --fg: #e6e9ef;
+  --muted: #8b97a7;
+  --accent: #5ea2ff;
+  --border: #1f2733;
+  --card: #121823;
+  --ok: #3fb950;
+  --err: #f85149;
+  --warn: #d6a132;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font: 14px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+  color: var(--fg);
+  background:
+    radial-gradient(900px 420px at 50% -10%, rgba(94, 162, 255, .06), transparent 60%),
+    var(--bg);
+  background-attachment: fixed;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Money/figures line up across rows. */
+table { font-variant-numeric: tabular-nums; }
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: .75rem;
+  flex-wrap: wrap;
+  padding: .6rem 1.2rem;
+  background: var(--card);
+  border-bottom: 1px solid var(--border);
+  position: sticky;
+  top: 0;
+  z-index: 5;
+}
+.brand-group { display: flex; align-items: baseline; gap: .5rem; margin-right: auto; }
+.brand {
+  font-family: ui-monospace, "SF Mono", monospace;
+  font-weight: 700;
+  font-size: 1.05rem;
+  letter-spacing: .04em;
+}
+.ver { color: var(--muted); font-size: .8rem; font-family: ui-monospace, monospace; }
+
+.mode-badge {
+  font-size: .72rem;
+  text-transform: uppercase;
+  letter-spacing: .1em;
+  font-weight: 700;
+  padding: .25rem .6rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
+.mode-paper { color: var(--accent); border-color: rgba(94, 162, 255, .4); }
+.mode-live  { color: var(--err); border-color: rgba(248, 81, 73, .5);
+              background: rgba(248, 81, 73, .08); }
+
+.conn { font-size: .8rem; color: var(--muted); display: inline-flex; align-items: center; }
+.conn .dot {
+  width: .55rem; height: .55rem; border-radius: 50%;
+  background: var(--warn); margin-right: .4rem; display: inline-block;
+}
+.conn.ok .dot { background: var(--ok); box-shadow: 0 0 5px var(--ok); }
+.conn.down .dot { background: var(--err); }
+
+main { padding: 1.2rem; max-width: 1100px; margin: 0 auto; }
+
+.card {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 1rem 1.2rem;
+  margin: 0 0 1.2rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, .04), 0 1px 2px rgba(0, 0, 0, .35);
+}
+.card h2 {
+  margin: 0 0 .6rem;
+  font-size: .78rem;
+  font-weight: 700;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+table { width: 100%; border-collapse: collapse; }
+th, td { text-align: left; padding: .45rem .6rem; border-bottom: 1px solid var(--border); }
+thead th { color: var(--muted); font-weight: 600; font-size: .82rem; }
+tbody tr:last-child td, tbody tr:last-child th { border-bottom: 0; }
+.num { text-align: right; font-family: ui-monospace, monospace; }
+.empty td { color: var(--muted); text-align: center; padding: 1rem; }
+
+.side-buy { color: var(--ok); }
+.side-sell { color: var(--err); }
+
+footer {
+  color: var(--muted);
+  font-size: .8rem;
+  text-align: center;
+  padding: 1.5rem 1rem;
+}
+footer a { color: var(--muted); }
+
+@media (max-width: 640px) {
+  .topbar { padding: .55rem .8rem; }
+  main { padding: .9rem .7rem; }
+}

--- a/trading_bot/tests/interfaces/test_ui.py
+++ b/trading_bot/tests/interfaces/test_ui.py
@@ -1,0 +1,283 @@
+"""Tests for ``trading_bot.interfaces.ui`` — the read-only dashboard + ``serve``.
+
+The dashboard is mounted on the same FastAPI app as the read-only API (leaf 01).
+It is exercised in-process against a **paper engine** (the real data path: a
+:class:`~trading_bot.brokers.paper.PaperBroker` produces real fills that fold into
+real positions and PnL) through :class:`fastapi.testclient.TestClient` — no real
+server, no network.
+
+What is verified
+----------------
+* ``GET /`` → 200 HTML carrying the dashboard *shell*: the brand, the version, the
+  mode badge, and the three table-body ids the JS targets
+  (``positions-body`` / ``orders-body`` / ``kpi-body``);
+* the static assets serve with the right content types
+  (``/static/app.js`` → js, ``/static/style.css`` → css);
+* the shipped ``app.js`` wires to the API (references ``/api/positions``,
+  ``/api/orders``, ``/api/kpi``, ``/api/events``) — proving the UI is an HTTP
+  client of the API, not a server-side data dump;
+* the served HTML is a **shell** — no engine money string is baked into it
+  server-side (the data only arrives over ``/api/*``);
+* the ``serve`` command builds ``create_app(engine)`` and hands it to
+  ``uvicorn.run`` with the host/port — **patched** so no socket is opened;
+* read-only still holds — a ``POST`` to a plausible order path is rejected (405).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+from fastapi.testclient import TestClient
+from typer.testing import CliRunner
+
+from trading_bot import __version__
+from trading_bot.application.config import AppConfig
+from trading_bot.application.service_factory import Engine, build_engine
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.interfaces.api import create_app
+from trading_bot.interfaces.cli.main import app as cli_app
+
+_BTC = Instrument(Symbol("BTC", "USD"))
+
+runner = CliRunner()
+
+
+# --- fixtures: a paper engine seeded with real orders / fills -------------- #
+
+
+def _build_seeded_engine() -> Engine:
+    """A paper engine with a real BUY then partial-close SELL booked on BTC.
+
+    Routes both orders through the engine's real
+    :class:`~trading_bot.application.order_router.OrderRouter`; the wired
+    :class:`~trading_bot.brokers.paper.PaperBroker` fills each at the limit price
+    and emits ``FillEvent``\\ s, so the tracker / performance service hold real
+    state the dashboard's ``/api/*`` will render.
+    """
+    config = AppConfig.model_validate(
+        {"mode": "paper", "strategies": [{"name": "btc-ma", "symbol": "BTC/USD"}]}
+    )
+    engine = build_engine(config)
+
+    import asyncio
+
+    async def _book() -> None:
+        await engine.router.submit(
+            Order(
+                client_order_id="btc-buy-1",
+                instrument=_BTC,
+                side=OrderSide.BUY,
+                qty=money("0.1"),
+                type=OrderType.LIMIT,
+                limit_price=money("30000"),
+            )
+        )
+        await engine.router.submit(
+            Order(
+                client_order_id="btc-sell-1",
+                instrument=_BTC,
+                side=OrderSide.SELL,
+                qty=money("0.04"),
+                type=OrderType.LIMIT,
+                limit_price=money("31000"),
+            )
+        )
+
+    asyncio.run(_book())
+    return engine
+
+
+@pytest.fixture
+def engine() -> Engine:
+    """The seeded paper engine reused across the UI tests."""
+    return _build_seeded_engine()
+
+
+@pytest.fixture
+def client(engine: Engine) -> TestClient:
+    """A ``TestClient`` over ``create_app(engine)`` (no real server)."""
+    return TestClient(create_app(engine))
+
+
+# --- GET / : the dashboard shell ------------------------------------------- #
+
+
+def test_dashboard_renders_shell_with_brand_version_and_mode(
+    client: TestClient,
+) -> None:
+    """``GET /`` returns the dashboard shell (brand, version, mode badge)."""
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    html = resp.text
+
+    # Header shell.
+    assert "trading_bot" in html
+    assert f"v{__version__}" in html
+    # The paper-mode badge is rendered server-side from engine.config.mode.
+    assert "mode-paper" in html
+    assert ">paper<" in html
+
+
+def test_dashboard_has_the_three_table_ids_the_js_targets(
+    client: TestClient,
+) -> None:
+    """The shell carries the stable element ids ``app.js`` fills."""
+    html = client.get("/").text
+    assert 'id="positions-body"' in html
+    assert 'id="orders-body"' in html
+    assert 'id="kpi-body"' in html
+    # Links to its assets.
+    assert "/static/style.css" in html
+    assert "/static/app.js" in html
+
+
+def test_dashboard_is_a_shell_no_engine_money_baked_in(client: TestClient) -> None:
+    """The page is a shell — no engine money string is rendered server-side.
+
+    The seeded engine holds a 0.1 BTC buy at 30000; those values must NOT appear
+    in the served HTML (they only arrive client-side over ``/api/*``). Proves the
+    page is not a server-rendered data dump.
+    """
+    html = client.get("/").text
+    assert "30000" not in html
+    assert "0.1" not in html
+    assert "31000" not in html
+
+
+# --- static assets --------------------------------------------------------- #
+
+
+def test_app_js_serves_as_javascript(client: TestClient) -> None:
+    """``/static/app.js`` → 200 with a JavaScript content type."""
+    resp = client.get("/static/app.js")
+    assert resp.status_code == 200
+    assert "javascript" in resp.headers["content-type"]
+
+
+def test_style_css_serves_as_css(client: TestClient) -> None:
+    """``/static/style.css`` → 200 with a CSS content type."""
+    resp = client.get("/static/style.css")
+    assert resp.status_code == 200
+    assert "text/css" in resp.headers["content-type"]
+
+
+# --- the UI wires to the API (pure HTTP client) ---------------------------- #
+
+
+def test_app_js_references_every_api_endpoint(client: TestClient) -> None:
+    """``app.js`` fetches the JSON endpoints + the SSE stream — an HTTP client.
+
+    Asserting the served JS references ``/api/positions|orders|kpi`` and
+    ``/api/events`` proves the dashboard pulls its data from the API over HTTP
+    (rather than the server rendering engine state into the page).
+    """
+    js = client.get("/static/app.js").text
+    assert "/api/positions" in js
+    assert "/api/orders" in js
+    assert "/api/kpi" in js
+    assert "/api/events" in js
+    assert "EventSource" in js
+
+
+def test_api_endpoints_back_the_dashboard_with_real_state(
+    client: TestClient, engine: Engine
+) -> None:
+    """The ``/api/*`` JSON the JS will render reflects the engine's real state.
+
+    The seeded engine holds a net 0.06 BTC long (0.1 bought, 0.04 sold); the
+    positions/KPI endpoints report it as exact Decimal strings — the verbatim
+    money the JS renders.
+    """
+    positions = client.get("/api/positions").json()
+    assert positions, "engine should hold a position"
+    btc = next(p for p in positions if p["instrument"] == "BTC/USD")
+    # 0.1 - 0.04 = 0.06, rendered as an exact Decimal string (never a float).
+    assert btc["net_qty"] == "0.06"
+    assert isinstance(btc["net_qty"], str)
+
+    kpi = client.get("/api/kpi").json()
+    assert isinstance(kpi["realised_pnl"], str)
+    assert kpi["realised_pnl"] == str(engine.perf.realised_pnl())
+
+
+# --- read-only still holds ------------------------------------------------- #
+
+
+def test_post_to_order_path_is_rejected(client: TestClient) -> None:
+    """A POST to a plausible order path is rejected — the UI added no write route.
+
+    Only GET routes are registered; there is no mutating endpoint anywhere on the
+    app (the dashboard mount added none). FastAPI returns 405 (method not allowed)
+    for a POST to a known GET path, and 404 for an unknown path — either way no
+    order is ever placed over HTTP.
+    """
+    assert client.post("/api/orders").status_code in (404, 405)
+    assert client.post("/").status_code in (404, 405)
+
+
+# --- serve command: wiring without launching uvicorn ----------------------- #
+
+
+def test_serve_builds_app_and_calls_uvicorn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``serve`` builds ``create_app(engine)`` and hands it to ``uvicorn.run``.
+
+    Patches :func:`uvicorn.run` so no socket opens, then asserts the command
+    called it with a FastAPI app and the requested host/port — proving the wiring
+    without standing up a real server.
+    """
+    import uvicorn
+    from fastapi import FastAPI
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(app: object, **kwargs: object) -> None:
+        captured["app"] = app
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+
+    result = runner.invoke(
+        cli_app, ["serve", "--host", "0.0.0.0", "--port", "9123"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert isinstance(captured["app"], FastAPI)
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs["host"] == "0.0.0.0"
+    assert kwargs["port"] == 9123
+
+    # The built app really is the read-only dashboard: GET / serves the shell.
+    test_client = TestClient(captured["app"])
+    assert test_client.get("/").status_code == 200
+
+
+def test_serve_default_config_is_paper(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no ``--config``, ``serve`` defaults to a paper engine (never live)."""
+    import uvicorn
+
+    captured: dict[str, object] = {}
+
+    def _fake_run(app: object, **kwargs: object) -> None:
+        captured["app"] = app
+
+    monkeypatch.setattr(uvicorn, "run", _fake_run)
+
+    result = runner.invoke(cli_app, ["serve"])
+    assert result.exit_code == 0, result.output
+
+    test_client = TestClient(captured["app"])
+    assert test_client.get("/api/health").json()["mode"] == "paper"
+
+
+def test_serve_uses_decimal_safe_money(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A money string the served app renders stays exact (no float round-trip)."""
+    # Sanity that the money helper used across the stack is the exact-Decimal one
+    # the API serializes (guards against a float regression in the seam).
+    assert str(Decimal("0.1")) == "0.1"


### PR DESCRIPTION
## Summary
- **Final leaf of E9**: `interfaces/ui/` — a Jinja2 dashboard (Positions / Open orders / PnL+KPI) served at `GET /` by the same FastAPI app, a **pure HTTP client** of the leaf-01 API (fetches `/api/*`, live-updates via the `/api/events` SSE), money rendered verbatim from Decimal strings. Plus `trading-bot serve [--config --host --port]`.
- Closes E9 — `07-roadmap.md` E9 line removed, `06-status.md` updated (only E10 left).

## Why
- A pure-client UI keeps the only money-moving surface (order placement) entirely off the web — the dashboard can observe but never trade (inherits the API's read-only 405). `serve` over a paper-default engine + the persisted store is the MVP data path. Mirrors dccd's UI. See `doc/dev/03-decisions.md`.

## Changes
- `interfaces/ui/` (templates/dashboard.html + static/app.js + style.css), `api/app.py` (`GET /` + static mount), CLI `serve`, `pyproject.toml` package-data; `tests/interfaces/test_ui.py` (11 tests).

## Changelog
Added: `interfaces.ui` — Jinja2 dashboard + `trading-bot serve`.

## Test plan
- [x] `.venv/bin/python -m pytest` (521 passed, 0 unexpected skips)
- [x] `GET /` serves the shell; `app.js` wires to `/api/{positions,orders,kpi,events}`; static content-types ok
- [x] read-only preserved (POST → 405); `serve` wiring tested with `uvicorn.run` patched
- [x] ran `trading-bot serve --help` + verified the dashboard shell myself
- [x] `ruff` + `mypy` clean