### PR TITLE
docs: plan go-live-hardening (E10)

### DIFF
--- a/doc/dev/plans/go-live-hardening/00-plan.md
+++ b/doc/dev/plans/go-live-hardening/00-plan.md
@@ -1,0 +1,54 @@
+---
+plan: go-live-hardening
+kind: global
+status: planning
+roadmap: "- [ ] **E10 — Go-live hardening & final name.** Live-trading checklist (reconciliation, kill-switch, idempotency proven under fault injection); choose and apply the final project name."
+release_on_done: false
+---
+
+# E10 — Go-live hardening
+
+The last epic. **Scoped (maintainer decision): hardening only.** We prove the
+money-safety invariants under fault injection, close the safe-to-fix known gaps, and
+write the go-live runbook + an explicit live opt-in guard — but **no real live
+trading, no API key, and no order is ever sent to a real venue**. The **final project
+name stays deferred** (out of E10 scope): the package remains `trading_bot`.
+
+## Goal
+
+A trading engine whose safety properties are *demonstrated*, not just asserted in
+unit tests: reconciliation converges and the kill-switch + idempotency hold under
+adversarial fault injection; the recorded known gaps are fixed or guarded; and going
+live is a deliberate, documented opt-in that is **off by default** (paper stays the
+default; the live path raises a clear "not enabled — read the runbook" until
+explicitly turned on, with a real-key sandbox the only thing left to do later).
+
+## Decomposition
+
+1. **fault-injection** — `tests/hardening/`: prove reconcile/kill-switch/idempotency hold under a fault-injecting broker.
+2. **close-known-gaps** — fix KPI-v0 (config starting capital), detect same-instrument commingling, guard/document the venue-idempotency live-submit policy.
+3. **go-live-runbook** — the go-live checklist/runbook + a `LiveTradingNotEnabled` opt-in guard (paper default; no real order ever sent).
+
+## Leaf checklist
+
+- [ ] 01 fault-injection — test/go-live-hardening — high
+- [ ] 02 close-known-gaps — feat/close-known-gaps — high
+- [ ] 03 go-live-runbook — feat/go-live-opt-in — medium (depends on 01, 02)
+
+## Dependencies
+
+- 01 and 02 are independent (run serially, the safe default); 03 depends on 01 + 02.
+
+## Done criteria
+
+- A `tests/hardening/` suite demonstrates: reconcile converges after a simulated
+  disconnect (no order duplicated/lost), idempotent submit under retry/ambiguous
+  failure, kill-switch cancels + halts mid-run — all offline.
+- KPI ratios are meaningful (config-driven starting capital wired through);
+  `run_app` rejects/flags duplicate-symbol strategies; the venue non-idempotent-submit
+  policy is a guarded, documented code path.
+- A go-live runbook exists; the live path is an explicit opt-in that is **off by
+  default** and raises a clear error until enabled. No real order is ever sent.
+- `ruff`/`mypy`/`pytest` green via `.venv`.
+- Last leaf (03) removes the E10 line from `07-roadmap.md` and updates `06-status.md`
+  — but the **deferred "final project name" decision stays open** (not closed by E10).

--- a/doc/dev/plans/go-live-hardening/01-fault-injection.md
+++ b/doc/dev/plans/go-live-hardening/01-fault-injection.md
@@ -1,0 +1,73 @@
+---
+plan: go-live-hardening/01-fault-injection
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: test/go-live-hardening
+pr: ""
+---
+
+# Fault injection — prove the safety invariants adversarially
+
+## Goal
+
+A dedicated `tests/hardening/` suite that *demonstrates* the money-safety invariants
+under **fault injection**, not just in happy-path unit tests: reconciliation
+converges after a simulated disconnect, idempotent submit survives retries/ambiguous
+failures, and the kill-switch cancels + halts mid-run. All offline (PaperBroker + a
+fault-injecting wrapper) — no real venue.
+
+## Files to change
+
+- `trading_bot/tests/hardening/__init__.py` — new (empty).
+- `trading_bot/tests/hardening/_faulty_broker.py` — new; a `FaultyBroker` wrapping
+  `PaperBroker` (or implementing the `Broker` port) that can be told to fail/raise on
+  the next call, drop a response (ambiguous failure), or simulate a disconnect.
+- `trading_bot/tests/hardening/test_reconciliation.py` — new.
+- `trading_bot/tests/hardening/test_idempotency.py` — new.
+- `trading_bot/tests/hardening/test_kill_switch.py` — new.
+
+## Steps
+
+1. Read `application/reconcile.py` (`reconcile(broker, router, tracker)` + `ReconResult`),
+   `application/order_router.py` (`submit` idempotency, `tracked_orders`), `application/risk.py`
+   (`RiskManager.check`/`trip`/`kill`), `brokers/paper.py`, `brokers/base.py`.
+2. `FaultyBroker`: wraps/extends a `PaperBroker`; switches to: raise a `BrokerError`
+   on the next `place_order`; "ambiguous failure" (the order IS recorded by the broker
+   but `place_order` raises/times out as if the response was lost); a "disconnect" that
+   makes the local engine miss some venue orders/fills (so reconcile has real work).
+   Deterministic, injectable.
+3. **Reconciliation under disconnect**: seed the `FaultyBroker` with orders/fills the
+   local engine never saw (simulating a disconnect window), run `reconcile`, assert
+   local orders + positions converge to the broker exactly, **no order duplicated or
+   lost**, and a second `reconcile` is a no-op (idempotent).
+4. **Idempotency under retry / ambiguous failure**: submit an order whose `place_order`
+   suffers an ambiguous failure; assert the engine does not silently create a duplicate
+   on a retry of the same `client_order_id` (the dedup holds); and that reconcile after
+   the ambiguous failure reconciles the truth (the order is adopted if the venue has it,
+   not double-submitted). Document what the engine guarantees vs what needs the E10-02
+   live policy.
+5. **Kill-switch mid-run**: with a `RiskManager`, run a strategy/sequence; `trip()` /
+   `kill(router, broker)` partway; assert open orders are cancelled, further submits are
+   refused (`RiskLimitBreached`), and no order is placed after the trip — engine state
+   stays consistent.
+
+## Tests (via `.venv`)
+
+The suite **is** the deliverable. Each property above is a test asserting the
+money-safety guarantee under the injected fault. Keep them readable — each test tells
+the story of the fault and the invariant it protects.
+
+## Verification on real data
+
+In-process adversarial scenarios (the `FaultyBroker` + PaperBroker are the engine's
+real data under fault). Run the full `tests/hardening/` suite and confirm every
+safety property holds; capture the scenarios exercised. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "Hardening test suite — reconciliation/idempotency/kill-switch proven under fault injection."
+- ADR: the fault-injection methodology + what's proven offline vs what still needs a real-key sandbox.
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/go-live-hardening/02-close-known-gaps.md
+++ b/doc/dev/plans/go-live-hardening/02-close-known-gaps.md
@@ -1,0 +1,74 @@
+---
+plan: go-live-hardening/02-close-known-gaps
+kind: leaf
+status: planned
+complexity: high
+depends: []
+parallel: false
+branch: feat/close-known-gaps
+pr: ""
+---
+
+# Close the safe-to-fix known gaps
+
+## Goal
+
+Fix the recorded known gaps that are safe to close offline:
+(a) **KPI v0** — config-driven starting capital so the KPI ratios are meaningful;
+(b) **same-instrument commingling** — detect & reject (or clearly flag) two strategies
+on the same symbol; (c) **venue-idempotency** — turn the documented live-submit policy
+(don't blindly retry a non-idempotent `AddOrder`; reconcile on ambiguous failure) into
+a guarded, documented code path (live still off — no real order sent).
+
+## Files to change
+
+- `trading_bot/application/config.py` — add a starting-capital field (e.g.
+  `AppConfig.starting_capital: Decimal = money("100000")` or on `StorageConfig`/a new
+  section — pick the cleanest, document).
+- `trading_bot/application/service_factory.py` — wire `PerformanceService(v0=config.starting_capital)`.
+- `trading_bot/application/run_app.py` — reject/flag duplicate-symbol strategies in `build_runners`.
+- `trading_bot/interfaces/cli/main.py` — the `kpi --capital` default can fall back to the config's starting capital (keep the flag, document precedence).
+- `trading_bot/brokers/kraken.py` — guard/document the non-idempotent `AddOrder` retry policy (the live-submit path: don't blindly retry; reconcile-on-ambiguous-failure). A clear docstring + a guard that surfaces the risk if a retry would re-place a non-idempotent order. Live stays disabled — no real call.
+- Tests: `tests/application/test_config.py`, `test_service_factory.py`, `test_run_app.py`, `tests/brokers/test_kraken_rest.py` (extend), as needed.
+
+## Steps
+
+1. **KPI v0**: add `starting_capital` to the config (default `money("100000")`, positive
+   validator). `build_engine` passes it to `PerformanceService(v0=...)`. Now Sharpe/
+   Sortino/Calmar over a real run are meaningful (curve doesn't sign-cross). The CLI
+   `kpi --capital` overrides the config value; document the precedence. The API/UI KPI
+   inherit it automatically (they read `engine.perf`).
+2. **Same-instrument detection**: in `build_runners`/`run_app`, if two `StrategyConfig`s
+   declare the same `symbol`, raise a clear `ConfigError` (per-strategy attribution
+   isn't available — the shared per-instrument tracker would commingle them). Document
+   why; a future per-strategy book is the real fix.
+3. **Venue-idempotency policy**: in `KrakenBroker`, make the non-idempotent-`AddOrder`
+   retry behaviour an explicit, documented decision: the AddOrder path should NOT be
+   blindly retried by the transport on an ambiguous failure (a lost response after the
+   order landed). Implement the guard (e.g. mark order-placing POSTs non-retryable, or
+   surface an "ambiguous — reconcile before retrying" error) + a docstring pointing at
+   `reconcile`. Live is still off, so this is a guarded code path, not a live call.
+
+## Tests (via `.venv`)
+
+- `starting_capital`: a config value flows to `engine.perf` so a real run's KPIs are
+  non-trivial (Sharpe finite/non-zero on a winning curve); the CLI `--capital` override
+  wins over the config; default is `100000`.
+- duplicate-symbol config → `build_runners`/`run_app` raises `ConfigError` (clear message);
+  distinct symbols still build fine.
+- AddOrder retry guard: a simulated ambiguous failure on `AddOrder` does not silently
+  retry-and-duplicate (assert the guard fires / the error is the documented one), with
+  the broker mocked (no real venue).
+
+## Verification on real data
+
+In-process. Run a winning paper strategy with a config `starting_capital` and assert
+the API `/api/kpi` now returns a meaningful Sharpe (not `0.0`); assert a 2-strategy
+same-symbol config is rejected; assert the AddOrder ambiguous-failure guard via mocks.
+Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added/Changed/Fixed): "config `starting_capital` → meaningful KPIs; reject same-symbol strategies; guard non-idempotent AddOrder retries."
+- ADR: the three gap closures + their rationale; update `06-status` known-gaps (resolve/scope them).
+- Status/roadmap: deferred to leaf 03.

--- a/doc/dev/plans/go-live-hardening/03-go-live-runbook.md
+++ b/doc/dev/plans/go-live-hardening/03-go-live-runbook.md
@@ -1,0 +1,79 @@
+---
+plan: go-live-hardening/03-go-live-runbook
+kind: leaf
+status: planned
+complexity: medium
+depends: [01, 02]
+parallel: false
+branch: feat/go-live-opt-in
+pr: ""
+---
+
+# Go-live runbook + explicit opt-in guard (live OFF by default)
+
+## Goal
+
+A **go-live runbook** (the deliberate opt-in steps, credentials via `.env`, the
+pre-trade safety checklist, what's proven vs what still needs a real-key sandbox), and
+a **`LiveTradingNotEnabled` opt-in guard** that makes live trading an explicit,
+documented, off-by-default choice: paper stays the default; the live path raises a
+clear "not enabled — read the runbook" until a deliberate opt-in flag is set. **No real
+order is ever sent.** The last E10 leaf — closes the E10 roadmap line (the deferred
+**final name** decision stays open).
+
+## Files to change
+
+- `doc/dev/09-go-live.md` — new; the go-live runbook/checklist.
+- `trading_bot/domain/errors.py` — add `LiveTradingNotEnabled(TradingBotError)`.
+- `trading_bot/application/service_factory.py` — gate live: when `config.mode == "live"`,
+  `build_engine` raises `LiveTradingNotEnabled` unless an explicit opt-in is set
+  (e.g. `config.live_enabled: bool = False` **and** credentials present), with a message
+  pointing at the runbook. Keep the existing credential check. Paper unaffected.
+- `trading_bot/application/config.py` — add the `live_enabled: bool = False` opt-in flag.
+- `trading_bot/interfaces/cli/main.py` — `run --live` / `serve` surface the guard clearly
+  (the `--live` ack already exists; now it also needs `live_enabled` + the runbook ack).
+- Tests: `tests/application/test_service_factory.py`, `tests/interfaces/` as needed.
+
+## Steps
+
+1. `LiveTradingNotEnabled` error (rooted at `TradingBotError`) with a message that names
+   the runbook and the opt-in flag.
+2. `config.live_enabled: bool = False`. `build_engine`: for `mode == "live"`, require
+   **both** `live_enabled is True` **and** credentials, else raise `LiveTradingNotEnabled`
+   (off-by-default). Paper path is unchanged. Document that even enabled, the real-venue
+   adapter still needs a real-key sandbox validation (deferred) before any real order —
+   this leaf does NOT send a real order.
+3. CLI: the `--live` ack flow now also checks `live_enabled` (config) and points the user
+   at `doc/dev/09-go-live.md`; a clear refusal otherwise. No order placed on refusal.
+4. `doc/dev/09-go-live.md` runbook: the explicit enable steps (set `live_enabled`,
+   provide `.env` credentials, run the hardening suite, validate against a real-key
+   sandbox); the pre-trade safety checklist (risk limits set, kill-switch tested,
+   reconcile on startup, paper-validated strategy); a "proven vs pending" table
+   (what E10-01 demonstrated offline vs what needs a real key/sandbox); the paper-default
+   and "never trade money you can't lose" disclaimer.
+5. Update the program docs: `06-status` (E10 hardening done; **final name still
+   deferred**), `01-overview`/`README` go-live note if useful.
+
+## Tests (via `.venv`)
+
+- `build_engine` with `mode="live"`, `live_enabled=False` → `LiveTradingNotEnabled`
+  (clear message), regardless of credentials. Paper config builds fine.
+- `mode="live"`, `live_enabled=True`, **no** credentials → still refused (credential
+  check). With dummy creds + `live_enabled=True` → builds the live adapter object (but
+  the test asserts **no network/order** — construction only, or assert it's the kraken
+  adapter without calling it).
+- CLI `run --live` without the runbook opt-in → refused, nothing placed.
+
+## Verification on real data
+
+In-process. Assert the live path is off by default (raises `LiveTradingNotEnabled`),
+that paper is unaffected (the whole suite still runs paper), and that enabling the flag
++ dummy creds constructs the adapter without ever sending an order. Gates via `.venv`.
+
+## Closeout
+
+- CHANGELOG (Added): "Go-live runbook (`doc/dev/09-go-live.md`) + `LiveTradingNotEnabled` opt-in guard — live is off by default and explicit."
+- ADR: live opt-in is off-by-default + the runbook; restate **no real order sent**; note
+  the **final project name remains deferred** (not decided by E10).
+- Status/roadmap: **remove the E10 line** from `07-roadmap.md`; mark E10 (hardening) done
+  in `06-status.md`, and keep the **final-name** deferred decision open.


### PR DESCRIPTION
Plan tree for the **last epic, E10 — Go-live hardening**. **Scoped per maintainer decision: hardening only** — no real live trading, no key, **no order ever sent to a real venue**; and the **final project name stays deferred** (package remains `trading_bot`).

## Goal
Prove the money-safety invariants under fault injection, close the safe-to-fix known gaps, and make going live a deliberate, documented, **off-by-default** opt-in with a runbook.

## Leaves
- [ ] 01 fault-injection — test/go-live-hardening — high (prove reconcile/idempotency/kill-switch under a FaultyBroker)
- [ ] 02 close-known-gaps — feat/close-known-gaps — high (KPI-v0 config capital; reject same-symbol strategies; guard non-idempotent AddOrder retries)
- [ ] 03 go-live-runbook — feat/go-live-opt-in — medium, depends 01,02 (runbook + `LiveTradingNotEnabled` opt-in guard, live OFF by default)

Everything offline-testable. Leaf 03 removes the E10 roadmap line; the **final-name decision stays open**.
After merge: `/execute-leaf go-live-hardening next`.