### PR TITLE
test: hardening suite — reconcile/idempotency/kill-switch under fault injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Hardening test suite (`tests/hardening/`) — proves the money-safety invariants
+  under **fault injection** (a `FaultyBroker` over `PaperBroker`): reconciliation
+  converges after a simulated disconnect (no order duplicated/lost), idempotent submit
+  survives retries/ambiguous failures, and the kill-switch cancels + halts mid-run.
+
 - `interfaces.api` — read-only FastAPI over the engine: `GET /api/{health,positions,
   orders,kpi}` (money as **Decimal strings**, never float) + an SSE `/api/events`
   stream fed by the `EventBus`. The web surface only observes — no order placement.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,29 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-28 Hardening: prove safety invariants under fault injection (offline)
+
+**Decision.** `tests/hardening/` *demonstrates* the money-safety invariants
+adversarially via a `FaultyBroker` wrapping `PaperBroker` — deterministic one-shot
+faults (`fail_next_place`, `ambiguous_next_place` = the venue records the order but the
+response is "lost", `disconnect`/seed) that change only what the *caller* observes,
+never the venue's recorded truth. Eleven tests prove: reconcile converges after a
+disconnect (no order duplicated/lost; second pass a no-op); engine-side idempotency
+holds under sequential **and** concurrent retries; an ambiguous failure surfaces rather
+than fabricating success, and `reconcile` is the recovery (adopt the live order, never
+re-submit); the kill-switch cancels open orders + halts new ones mid-run.
+
+**Why.** A money-handling engine's safety can't rest on happy-path unit tests — the
+dangerous cases are faults (lost responses, disconnects, concurrent retries). **Proven
+offline:** engine-side idempotency, ambiguous-failure surfacing, reconcile-as-recovery,
+kill-switch. **Still needs a real-key sandbox (E10-02 / live):** *venue-level*
+idempotency — a venue-side dedup token so a retry the engine *forgot* (e.g. a crash
+before the reject was persisted) can't create a second order at the exchange. Today the
+dedup is in-memory engine-side only; this gap is documented at the ambiguous-failure
+tests.
+
+---
+
 ### 2026-06-28 Web UI: pure HTTP client of the API; `serve` over a paper engine
 
 **Decision.** `interfaces/ui/` is a Jinja2 **shell** (header: brand + version + mode

--- a/doc/dev/plans/go-live-hardening/00-plan.md
+++ b/doc/dev/plans/go-live-hardening/00-plan.md
@@ -31,7 +31,7 @@ explicitly turned on, with a real-key sandbox the only thing left to do later).
 
 ## Leaf checklist
 
-- [ ] 01 fault-injection — test/go-live-hardening — high
+- [x] 01 fault-injection — test/go-live-hardening — high
 - [ ] 02 close-known-gaps — feat/close-known-gaps — high
 - [ ] 03 go-live-runbook — feat/go-live-opt-in — medium (depends on 01, 02)
 

--- a/doc/dev/plans/go-live-hardening/01-fault-injection.md
+++ b/doc/dev/plans/go-live-hardening/01-fault-injection.md
@@ -1,7 +1,7 @@
 ---
 plan: go-live-hardening/01-fault-injection
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: []
 parallel: false

--- a/doc/dev/plans/go-live-hardening/01-fault-injection.md
+++ b/doc/dev/plans/go-live-hardening/01-fault-injection.md
@@ -6,7 +6,7 @@ complexity: high
 depends: []
 parallel: false
 branch: test/go-live-hardening
-pr: ""
+pr: "#53"
 ---
 
 # Fault injection — prove the safety invariants adversarially

--- a/trading_bot/tests/hardening/_faulty_broker.py
+++ b/trading_bot/tests/hardening/_faulty_broker.py
@@ -1,0 +1,244 @@
+"""``FaultyBroker`` — a fault-injecting wrapper around :class:`PaperBroker`.
+
+The hardening suite needs to drive the engine *adversarially*: not "does the
+happy path work?" but "does a money-safety invariant still hold when the broker
+misbehaves?". A real venue misbehaves in three ways that matter for safety, and
+each is a controllable fault here — everything in-process, no network, no key:
+
+* **clean rejection** — :meth:`fail_next_place` makes the next
+  :meth:`place_order` raise *without* recording anything on the venue. The order
+  never landed; the engine should drive it to ``REJECTED`` and a retry is free to
+  try again.
+* **ambiguous failure** — :meth:`ambiguous_next_place` is the dangerous one: the
+  next :meth:`place_order` **records the order on the wrapped venue** (so
+  :meth:`open_orders` / :meth:`fills` show it) but **raises to the caller**, as if
+  the venue accepted the order and the *response* was then lost. The engine
+  cannot tell this apart from a clean rejection at submit time — the order may or
+  may not be live. This is precisely the case where a naive retry would
+  double-submit and reconciliation must adopt the truth instead.
+* **disconnect window** — :meth:`seed_order` / :meth:`seed_fills` (and
+  :meth:`disconnect` as a readable alias) put orders/fills directly on the wrapped
+  broker that the local engine never tracked, simulating the gap where the engine
+  was offline while the venue kept working. :func:`reconcile` then has real work.
+
+Determinism
+-----------
+The wrapper holds no clock and no randomness: faults are *armed* one-shot flags
+consumed by the next call, so a test reads top-to-bottom as a story ("arm the
+ambiguous failure, submit, assert the engine did not lie"). Every non-faulty
+method delegates straight to the wrapped :class:`PaperBroker`, so the venue's
+recorded truth (open orders, fills, balances) is exactly the paper broker's —
+the wrapper only changes *what the caller observes*, never corrupts the truth.
+
+The wrapper satisfies the :class:`~trading_bot.brokers.base.Broker` port
+structurally (it has every method + ``capabilities``), so it drops into the
+:class:`~trading_bot.application.order_router.OrderRouter`,
+:func:`~trading_bot.application.reconcile.reconcile` and
+:meth:`~trading_bot.application.risk.RiskManager.kill` unchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from trading_bot.brokers.base import Broker, Capability
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain.errors import BrokerError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument
+from trading_bot.domain.money import Money
+from trading_bot.domain.order import Order
+
+__all__ = ["FaultyBroker"]
+
+
+class FaultyBroker(Broker):
+    """A :class:`PaperBroker` wrapper that injects controllable faults.
+
+    Wrap a paper broker, then arm a one-shot fault before the call you want to
+    perturb. Non-faulty calls delegate to the wrapped broker, so the venue's
+    recorded state stays exactly the paper broker's truth — only what the
+    *caller* observes changes.
+
+    Parameters
+    ----------
+    inner : PaperBroker
+        The wrapped broker that holds the real (simulated) venue state.
+
+    Attributes
+    ----------
+    inner : PaperBroker
+        The wrapped broker (exposed so a test can read the venue's truth, e.g.
+        ``broker.inner.open_orders()`` is the same as ``broker.open_orders()``).
+    name : str
+        ``"faulty"`` — a distinct venue key from the wrapped ``"paper"``.
+
+    """
+
+    name = "faulty"
+
+    def __init__(self, inner: PaperBroker) -> None:
+        self.inner = inner
+        # One-shot fault flags, consumed by the next ``place_order``.
+        self._fail_next: BrokerError | None = None
+        self._ambiguous_next = False
+        # The venue id assigned to the most recent ambiguous placement (the order
+        # that landed despite the caller seeing a failure); for test inspection.
+        self.last_ambiguous_venue_id: str | None = None
+        # Count of orders that actually reached the wrapped venue (delegated or
+        # ambiguous placements — NOT clean rejections, which never touch it). The
+        # honest "how many orders did the venue receive?" counter for tests.
+        self.venue_place_count = 0
+
+    # --- fault arming (one-shot) ------------------------------------------ #
+
+    def fail_next_place(
+        self, exc: BrokerError | None = None
+    ) -> None:
+        """Arm the next :meth:`place_order` to **cleanly reject** — no record.
+
+        The next placement raises ``exc`` (default a generic
+        :class:`~trading_bot.domain.errors.BrokerError`) *before* touching the
+        wrapped venue: nothing is recorded, so the order genuinely never landed.
+        Models a venue that rejected the request outright (bad params, rate
+        limit, auth) — the safe failure, where a retry is correct.
+
+        Parameters
+        ----------
+        exc : BrokerError, optional
+            The error to raise. Defaults to ``BrokerError("simulated clean
+            rejection")``.
+
+        """
+        self._fail_next = exc or BrokerError("simulated clean rejection")
+
+    def ambiguous_next_place(self) -> None:
+        """Arm the next :meth:`place_order` to **land then lose its response**.
+
+        The next placement first records the order on the wrapped venue (so
+        :meth:`open_orders` / :meth:`fills` will show it — the order *is* live)
+        and **then** raises a :class:`~trading_bot.domain.errors.BrokerError`, as
+        if the venue accepted the order and the acknowledgement was lost in
+        transit. The caller cannot tell this from a clean rejection at submit
+        time: the order may or may not be live. This is the failure that makes a
+        naive retry double-submit, and the one reconciliation must resolve by
+        adopting the venue's truth.
+        """
+        self._ambiguous_next = True
+
+    async def disconnect(self, *orders: Order) -> list[str]:
+        """Simulate a disconnect window: land ``orders`` the engine never saw.
+
+        An ergonomic async seam for the reconciliation story — while the engine
+        was "offline", the venue placed these ``orders`` (recorded on the wrapped
+        broker, with their own simulated fills), but the local router/tracker
+        never tracked any of it. :func:`reconcile` then has real divergence to
+        converge. Equivalent to :meth:`seed_order` per order.
+
+        Parameters
+        ----------
+        *orders : Order
+            Orders to place directly on the wrapped broker (bypassing the
+            engine), as if submitted before/while the engine was disconnected.
+
+        Returns
+        -------
+        list of str
+            The venue order ids the wrapped broker assigned, in order.
+
+        """
+        return [await self.seed_order(order) for order in orders]
+
+    async def seed_order(self, order: Order) -> str:
+        """Place ``order`` **directly** on the wrapped venue (no fault, no engine).
+
+        The async seam used to set up a disconnect: the order is recorded on the
+        wrapped paper broker exactly as a real venue would have it, but the
+        engine's router never tracked it. Returns the venue order id.
+
+        Parameters
+        ----------
+        order : Order
+            The order to land directly on the venue.
+
+        Returns
+        -------
+        str
+            The synthetic venue order id from the wrapped broker.
+
+        """
+        return await self.inner.place_order(order)
+
+    def seed_fills(self, fills: Iterable[Fill]) -> None:
+        """Record ``fills`` directly on the wrapped venue's fill history.
+
+        A standalone-fill seam for a disconnect: the venue confirmed these
+        executions while the engine was offline, so they are the PnL truth a
+        rebuild must fold in even with no matching tracked order.
+
+        Parameters
+        ----------
+        fills : Iterable[Fill]
+            The fills to append to the wrapped broker's recorded history.
+
+        """
+        self.inner._fills.extend(fills)
+
+    # --- Broker port ------------------------------------------------------ #
+
+    async def place_order(self, order: Order) -> str:
+        """Submit ``order``, applying any armed one-shot fault.
+
+        Resolves the armed fault (if any) first:
+
+        * a :meth:`fail_next_place` arming raises **before** the wrapped broker
+          is touched — nothing is recorded (clean rejection);
+        * an :meth:`ambiguous_next_place` arming places on the wrapped broker
+          **then** raises — the order is live but the caller sees a failure.
+
+        With no fault armed, this delegates straight to the wrapped broker.
+        """
+        clean_fail = self._fail_next
+        self._fail_next = None
+        if clean_fail is not None:
+            # Clean rejection: do not touch the venue. The order never landed.
+            raise clean_fail
+
+        ambiguous = self._ambiguous_next
+        self._ambiguous_next = False
+        if ambiguous:
+            # The order DOES land on the venue (recorded by the wrapped broker)...
+            self.venue_place_count += 1
+            self.last_ambiguous_venue_id = await self.inner.place_order(order)
+            # ...but the caller sees a failure, as if the response was lost.
+            raise BrokerError(
+                "simulated ambiguous failure: order placed on venue but "
+                "acknowledgement lost in transit"
+            )
+
+        self.venue_place_count += 1
+        return await self.inner.place_order(order)
+
+    async def cancel_order(self, venue_order_id: str) -> None:
+        """Cancel ``venue_order_id`` on the wrapped broker (no fault injected)."""
+        await self.inner.cancel_order(venue_order_id)
+
+    async def open_orders(self) -> list[Order]:
+        """Return the wrapped broker's open orders — the venue's truth."""
+        return await self.inner.open_orders()
+
+    async def balances(self) -> dict[str, Money]:
+        """Return the wrapped broker's balances — the venue's truth."""
+        return await self.inner.balances()
+
+    async def fills(self, since_ms: int | None = None) -> list[Fill]:
+        """Return the wrapped broker's fills — the PnL source of truth."""
+        return await self.inner.fills(since_ms)
+
+    async def ticker(self, instrument: Instrument) -> Money:
+        """Return the wrapped broker's mark price for ``instrument``."""
+        return await self.inner.ticker(instrument)
+
+    def capabilities(self) -> set[Capability]:
+        """Mirror the wrapped broker's declared capabilities."""
+        return self.inner.capabilities()

--- a/trading_bot/tests/hardening/test_idempotency.py
+++ b/trading_bot/tests/hardening/test_idempotency.py
@@ -1,0 +1,238 @@
+"""Hardening: idempotent submit survives retries and ambiguous failures.
+
+The invariant under test — **order submission is idempotent**: a retry (or a
+concurrent double-submit) of the same ``client_order_id`` never creates a second
+venue order, and an *ambiguous* placement failure (the venue took the order but
+the acknowledgement was lost) never leaves the engine silently believing it
+succeeded — reconciliation adopts the venue's truth rather than the engine
+re-submitting a duplicate.
+
+Fault story
+-----------
+Two faults, two guarantees:
+
+* **retry / concurrency** — submitting one id twice (sequentially and via
+  ``asyncio.gather``) calls ``place_order`` **exactly once** (the router's dedup
+  map + in-flight-future guard).
+* **ambiguous failure** —
+  :meth:`~trading_bot.tests.hardening._faulty_broker.FaultyBroker.
+  ambiguous_next_place` lands the order on the venue but raises to the caller.
+  The engine must **not** silently track a success: ``submit`` raises, and the
+  order is recorded ``REJECTED`` locally (an honest "we do not know it is live").
+  A naive retry of the same id is then deduped (no second venue order), and
+  :func:`~trading_bot.application.reconcile.reconcile` converges to the venue's
+  truth — **exactly one order exists for that intent** afterwards.
+
+What the engine guarantees vs the E10-02 live policy
+----------------------------------------------------
+Offline, the engine guarantees: (1) no duplicate venue order from a retry of a
+known id; (2) an ambiguous failure surfaces (never a silent success); (3)
+reconcile is the recovery — it adopts the live venue order rather than letting a
+retry double-submit. What it does **not** yet do, and what the **E10-02 live
+policy** will add, is *venue-level* idempotency: a venue-side dedup token on the
+order so that even a retry the *engine* forgot (e.g. across a crash before the
+``REJECTED`` record persisted) cannot create a second order at the venue. Today
+the dedup is purely engine-side (in-memory map); E10-02 makes the venue itself
+reject the duplicate. These tests prove the engine-side half and document the gap.
+
+All offline: :class:`~trading_bot.brokers.paper.PaperBroker` under a fault
+wrapper. Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from trading_bot.application import (
+    EventBus,
+    OrderRouter,
+    PositionTracker,
+    reconcile,
+)
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain import (
+    BrokerError,
+    Instrument,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Symbol,
+    money,
+)
+from trading_bot.tests.hardening._faulty_broker import FaultyBroker
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+def _limit(cid: str, qty: str = "1", price: str = "30000") -> Order:
+    """A realistic limit BUY order keyed by ``cid`` (the idempotency key)."""
+    return Order(
+        client_order_id=cid,
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money(qty),
+        type=OrderType.LIMIT,
+        limit_price=money(price),
+    )
+
+
+def _engine(
+    broker: FaultyBroker,
+) -> tuple[EventBus, OrderRouter, PositionTracker]:
+    """Wire a fresh bus + router + tracker over ``broker``."""
+    bus = EventBus()
+    router = OrderRouter(broker, bus)
+    tracker = PositionTracker()
+    return bus, router, tracker
+
+
+async def test_sequential_duplicate_submit_places_once() -> None:
+    """Two sequential submits of one id place exactly one venue order.
+
+    The steady-state dedup: the second ``submit`` of the same ``client_order_id``
+    returns the already-tracked order and never re-calls the broker.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    _, router, _ = _engine(broker)
+
+    # Half-fill so the order stays open (a single live order to count).
+    inner.arm_partial(money("0.5"))
+    first = await router.submit(_limit("dup-1", qty="4"))
+    second = await router.submit(_limit("dup-1", qty="4"))
+
+    assert second is first  # same tracked object, not a new submission
+    assert broker.venue_place_count == 1  # exactly one venue order
+    assert len(await broker.open_orders()) == 1
+
+
+async def test_concurrent_duplicate_submit_places_once() -> None:
+    """``asyncio.gather`` of two submits of one id still places exactly once.
+
+    The concurrency guard: two coroutines racing on the same id interleave at the
+    first ``await``; the in-flight-future map ensures only one reaches the broker
+    and the other awaits its result.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    _, router, _ = _engine(broker)
+
+    inner.arm_partial(money("0.5"))
+    a, b = await asyncio.gather(
+        router.submit(_limit("race-1", qty="4")),
+        router.submit(_limit("race-1", qty="4")),
+    )
+
+    assert a is b  # both resolved to the same tracked order
+    assert broker.venue_place_count == 1  # exactly one venue order despite the race
+    assert len(await broker.open_orders()) == 1
+
+
+async def test_ambiguous_failure_is_not_a_silent_success() -> None:
+    """An ambiguous placement raises — the engine never silently tracks a success.
+
+    The order lands on the venue but the response is "lost": ``submit`` must
+    raise (not return a happy order), and the locally tracked order must be
+    ``REJECTED`` — an honest "we do not know this is live", never a fabricated
+    OPEN.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    _, router, _ = _engine(broker)
+
+    inner.arm_partial(money("0.5"))  # leave the landed order open on the venue
+    broker.ambiguous_next_place()
+    with pytest.raises(BrokerError):
+        await router.submit(_limit("amb-1", qty="4"))
+
+    # The engine did NOT invent a success: the tracked order is REJECTED.
+    tracked = router.get("amb-1")
+    assert tracked is not None
+    assert tracked.status is OrderStatus.REJECTED
+    # But the venue actually HAS the order live (the ambiguity).
+    venue_open = await broker.open_orders()
+    assert {o.client_order_id for o in venue_open} == {"amb-1"}
+
+
+async def test_retry_after_ambiguous_failure_does_not_double_submit() -> None:
+    """A retry of the same id after an ambiguous failure is deduped (no 2nd order).
+
+    The dangerous reflex is "submit failed, retry it" — which, with the order
+    already live on the venue, would double-submit. The engine-side dedup map
+    holds: the retry of the same id returns the recorded (REJECTED) attempt and
+    never re-calls the broker, so the venue still has exactly one order.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    _, router, _ = _engine(broker)
+
+    broker.ambiguous_next_place()
+    with pytest.raises(BrokerError):
+        await router.submit(_limit("amb-2", qty="4"))
+    assert broker.venue_place_count == 1  # the ambiguous order landed: one venue order
+
+    # Naive retry of the same id: deduped, no second placement.
+    retried = await router.submit(_limit("amb-2", qty="4"))
+    assert retried.status is OrderStatus.REJECTED  # the recorded attempt
+    assert broker.venue_place_count == 1  # STILL one venue order — no duplicate
+
+
+async def test_reconcile_after_ambiguous_failure_yields_one_order() -> None:
+    """Reconcile is the recovery: it converges to exactly one order for the intent.
+
+    After an ambiguous failure the venue holds the order live and the engine has
+    a stale ``REJECTED`` record under the same id. ``reconcile`` reads the venue's
+    truth and converges: the order is **adopted** (not ingested as a second
+    object, not re-submitted), so there is **exactly one** order for that intent —
+    the venue's — and the position is rebuilt from the venue's confirmed fills.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    bus, router, tracker = _engine(broker)
+
+    # Ambiguous placement: order lands, caller sees failure.
+    inner.arm_partial(money("0.5"))  # stays open on the venue
+    broker.ambiguous_next_place()
+    with pytest.raises(BrokerError):
+        await router.submit(_limit("amb-3", qty="4"))
+    assert broker.venue_place_count == 1
+
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+
+    # The venue order shares the cid the router already holds (the REJECTED
+    # record), so reconcile *adopts* it in place — never ingests a second object
+    # and never re-submits.
+    assert result.adopted_orders == 1
+    assert result.ingested_orders == 0
+    # No re-submission and no duplicate: the venue order is reconciled in place.
+    assert broker.venue_place_count == 1
+    # Exactly one tracked entry for the intent, matching the one venue order.
+    venue_open = await broker.open_orders()
+    assert {o.client_order_id for o in venue_open} == {"amb-3"}
+    assert list(router.tracked_orders()) == ["amb-3"]
+    # The position is rebuilt from the venue's confirmed fills (the partial fill).
+    assert tracker.position(BTC_USD) is not None
+    assert tracker.position(BTC_USD).net_qty == money("2")  # half of 4
+
+    # And it is idempotent thereafter.
+    again = await reconcile(broker, router, tracker, event_bus=bus)
+    assert broker.venue_place_count == 1
+    assert again.ingested_orders == 0

--- a/trading_bot/tests/hardening/test_kill_switch.py
+++ b/trading_bot/tests/hardening/test_kill_switch.py
@@ -1,0 +1,190 @@
+"""Hardening: the kill-switch cancels open orders and halts new ones mid-run.
+
+The invariant under test — **the kill-switch gates every order**: once tripped it
+cancels all open orders and refuses every subsequent submission, so a runaway
+strategy (or a human pulling the cord) stops *now* — no order placed after the
+halt, and the engine's local state stays consistent with the venue.
+
+Fault story
+-----------
+This is the deliberate operator fault, not a broker malfunction: partway through a
+run we call :meth:`~trading_bot.application.risk.RiskManager.kill` (the panic
+entry point). The test asserts:
+
+* every order the engine had open is **cancelled** on the venue (no live order
+  left behind);
+* every later :meth:`~trading_bot.application.order_router.OrderRouter.submit`
+  raises :class:`~trading_bot.domain.errors.RiskLimitBreached` and **places
+  nothing** — the broker's venue placement count does not move;
+* the engine's local order state stays consistent (the cancelled orders are
+  ``CANCELLED`` locally, the refused ones leave no tracked record).
+
+A second variant proves the broker-direct halt (``kill(broker=...)``) and that a
+``trip`` alone (no cancel) still refuses new orders.
+
+All offline: :class:`~trading_bot.brokers.paper.PaperBroker` under a fault
+wrapper. Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trading_bot.application import (
+    EventBus,
+    OrderRouter,
+    PositionTracker,
+    RiskManager,
+)
+from trading_bot.application.config import RiskConfig
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain import (
+    Instrument,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    RiskLimitBreached,
+    Symbol,
+    money,
+)
+from trading_bot.tests.hardening._faulty_broker import FaultyBroker
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+def _limit(cid: str, qty: str = "4", price: str = "30000") -> Order:
+    """A realistic limit BUY order keyed by ``cid``."""
+    return Order(
+        client_order_id=cid,
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money(qty),
+        type=OrderType.LIMIT,
+        limit_price=money(price),
+    )
+
+
+def _engine_with_risk(
+    broker: FaultyBroker,
+    rm: RiskManager,
+) -> tuple[EventBus, OrderRouter, PositionTracker]:
+    """Wire a bus + risk-gated router + tracker over ``broker``."""
+    bus = EventBus()
+    router = OrderRouter(broker, bus, risk_manager=rm)
+    tracker = PositionTracker()
+    return bus, router, tracker
+
+
+async def test_kill_via_router_cancels_open_orders_and_halts() -> None:
+    """``kill(router=...)`` cancels every open order and refuses all new submits.
+
+    Two orders are open mid-run; ``kill`` cancels both on the venue (driving the
+    local orders to ``CANCELLED``) and trips the switch. Every later submit then
+    raises ``RiskLimitBreached`` and places nothing — the venue placement count is
+    frozen at the pre-kill total.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    rm = RiskManager(RiskConfig())  # no limits — isolate the kill-switch
+    _, router, _ = _engine_with_risk(broker, rm)
+
+    # Two live (half-filled, so still open) orders mid-run.
+    inner.arm_partial(money("0.5"))
+    o1 = await router.submit(_limit("ks-1", qty="4"))
+    inner.arm_partial(money("0.5"))
+    o2 = await router.submit(_limit("ks-2", qty="4"))
+    assert o1.status is OrderStatus.OPEN
+    assert o2.status is OrderStatus.OPEN
+    assert len(await broker.open_orders()) == 2
+    places_before_kill = broker.venue_place_count
+
+    # --- pull the cord ------------------------------------------------------ #
+    await rm.kill(router=router)
+
+    assert rm.tripped is True
+    # Every open order is cancelled on the venue and locally.
+    assert await broker.open_orders() == []
+    assert o1.status is OrderStatus.CANCELLED
+    assert o2.status is OrderStatus.CANCELLED
+
+    # Every subsequent submit is refused and places NOTHING.
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_limit("ks-3", qty="1"))
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_limit("ks-4", qty="1"))
+
+    assert broker.venue_place_count == places_before_kill  # no new venue order
+    assert await broker.open_orders() == []  # still nothing live
+    # A refused order leaves no tracked record (it was never a submission).
+    assert router.get("ks-3") is None
+    assert router.get("ks-4") is None
+
+
+async def test_kill_via_broker_cancels_open_orders_directly() -> None:
+    """``kill(broker=...)`` cancels the venue's open orders without a router.
+
+    The broker-direct halt path: with no router to source tracked orders from,
+    ``kill`` reads ``broker.open_orders()`` and cancels each on the venue. After
+    the kill no order is live on the venue and the switch is tripped.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    rm = RiskManager(RiskConfig())
+
+    # Orders placed straight on the venue (e.g. recovered, no router yet).
+    inner.arm_partial(money("0.5"))
+    await broker.seed_order(_limit("kb-1", qty="4"))
+    inner.arm_partial(money("0.5"))
+    await broker.seed_order(_limit("kb-2", qty="4"))
+    assert len(await broker.open_orders()) == 2
+
+    await rm.kill(broker=broker)
+
+    assert rm.tripped is True
+    assert await broker.open_orders() == []  # all cancelled directly on the venue
+
+    # The tripped switch refuses any order routed through a risk-gated router.
+    _, router, _ = _engine_with_risk(broker, rm)
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_limit("kb-3", qty="1"))
+    assert broker.venue_place_count == 0  # seeded orders bypass the wrapper count
+
+
+async def test_trip_without_cancel_still_refuses_new_orders() -> None:
+    """``trip`` alone halts new submissions even without cancelling live orders.
+
+    ``trip`` is the soft halt (refuse new orders) distinct from ``kill`` (cancel +
+    halt). After ``trip`` an existing open order is left live on the venue, but
+    every new submit is refused and places nothing — proving the gate is the
+    kill-switch flag, independent of the cancellation step.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    rm = RiskManager(RiskConfig())
+    _, router, _ = _engine_with_risk(broker, rm)
+
+    inner.arm_partial(money("0.5"))
+    live = await router.submit(_limit("tr-1", qty="4"))
+    assert live.status is OrderStatus.OPEN
+    places_before_trip = broker.venue_place_count
+
+    rm.trip("manual halt")
+
+    # The live order is untouched by a bare trip...
+    assert live.status is OrderStatus.OPEN
+    assert len(await broker.open_orders()) == 1
+    # ...but new orders are refused and never reach the venue.
+    with pytest.raises(RiskLimitBreached):
+        await router.submit(_limit("tr-2", qty="1"))
+    assert broker.venue_place_count == places_before_trip
+    assert router.get("tr-2") is None

--- a/trading_bot/tests/hardening/test_reconciliation.py
+++ b/trading_bot/tests/hardening/test_reconciliation.py
@@ -1,0 +1,243 @@
+"""Hardening: reconciliation converges after a simulated disconnect.
+
+The invariant under test — **reconcile, don't assume**: after the engine has been
+disconnected from the venue (orders placed and fills landed while it was offline,
+plus a local order the venue never knew about), one
+:func:`~trading_bot.application.reconcile.reconcile` pass converges the engine's
+two local views to the venue's truth, with **no order duplicated and none lost**,
+and a second pass is a no-op.
+
+Fault story
+-----------
+The :class:`~trading_bot.tests.hardening._faulty_broker.FaultyBroker` is used to
+*disconnect*: orders are placed directly on the wrapped venue (via
+``broker.disconnect(...)``) so the venue holds open orders + a fill history the
+local router/tracker never saw. We additionally track a local order the venue has
+no record of — an *orphan*. ``reconcile`` must:
+
+* **ingest** the venue's open orders the router missed (adopt, never re-submit);
+* **rebuild** positions to exactly ``Position.from_fills`` over the venue's fills;
+* **close-and-forget** the orphan (the venue is the truth; a phantom must not stay
+  "live");
+* leave the router tracking **exactly** the venue's open set — no duplicate, no
+  loss;
+* be **idempotent** — a second pass reports all zeros / ``changed is False``.
+
+All offline: :class:`~trading_bot.brokers.paper.PaperBroker` under a fault wrapper,
+no venue, no key, no network. Async tests run un-decorated
+(``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+from trading_bot.application import (
+    EventBus,
+    OrderRouter,
+    PositionTracker,
+    reconcile,
+)
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain import (
+    Instrument,
+    Order,
+    OrderSide,
+    OrderStatus,
+    OrderType,
+    Position,
+    Symbol,
+    money,
+)
+from trading_bot.tests.hardening._faulty_broker import FaultyBroker
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+ETH_USD = Instrument(Symbol("ETH", "USD"))
+
+
+def _limit(
+    cid: str,
+    side: OrderSide = OrderSide.BUY,
+    qty: str = "1",
+    price: str = "30000",
+    instrument: Instrument = BTC_USD,
+) -> Order:
+    """A realistic limit order for seeding the broker or the router."""
+    return Order(
+        client_order_id=cid,
+        instrument=instrument,
+        side=side,
+        qty=money(qty),
+        type=OrderType.LIMIT,
+        limit_price=money(price),
+    )
+
+
+def _engine(
+    broker: FaultyBroker,
+) -> tuple[EventBus, OrderRouter, PositionTracker]:
+    """Wire a fresh bus + router + tracker over ``broker`` (both empty)."""
+    bus = EventBus()
+    router = OrderRouter(broker, bus)
+    tracker = PositionTracker()
+    return bus, router, tracker
+
+
+def _positions_from_broker_fills(
+    broker_fills: list,
+) -> dict[Instrument, Position]:
+    """``Position.from_fills`` per instrument over ``broker_fills`` — the truth."""
+    by_instrument: dict[Instrument, list] = {}
+    for f in broker_fills:
+        by_instrument.setdefault(f.instrument, []).append(f)
+    return {
+        inst: Position.from_fills(fills)
+        for inst, fills in by_instrument.items()
+    }
+
+
+async def test_reconcile_converges_after_disconnect() -> None:
+    """A disconnect leaves the venue ahead of the engine; reconcile converges it.
+
+    Scenario: while the engine was offline the venue executed a full BUY (closed,
+    no open order but a fill), left a half-filled BUY *open*, and executed a
+    standalone SELL on a second instrument. The router and tracker are empty. One
+    ``reconcile`` pass must ingest the open order, rebuild positions to exactly
+    the fold over the venue's fills, duplicate or lose nothing, and a second pass
+    must be a no-op.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000"), ETH_USD: money("2000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    bus, router, tracker = _engine(broker)
+
+    # --- disconnect window: the venue works while the engine is offline ----- #
+    # A full BUY closes (fill, no open order).
+    await broker.disconnect(_limit("disc-full", qty="2", price="30000"))
+    # A half-filled BUY stays open on the venue.
+    inner.arm_partial(money("0.5"))
+    await broker.disconnect(_limit("disc-open", qty="4", price="30000"))
+    # A standalone SELL on a second instrument (fully fills, closes).
+    await broker.disconnect(
+        _limit("disc-eth", side=OrderSide.SELL, qty="3", price="2000",
+               instrument=ETH_USD)
+    )
+
+    # The engine saw none of it.
+    assert router.tracked_orders() == {}
+    assert tracker.all_positions() == {}
+
+    venue_open_before = await broker.open_orders()
+    venue_open_cids = {o.client_order_id for o in venue_open_before}
+    assert venue_open_cids == {"disc-open"}  # only the half-filled order is open
+
+    # --- one reconcile pass ------------------------------------------------- #
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+    assert result.changed is True
+    assert result.ingested_orders == 1  # disc-open adopted
+    assert result.adopted_orders == 0
+    assert result.closed_orphans == 0
+
+    # No order duplicated or lost: the router tracks EXACTLY the venue's open set.
+    tracked_nonterminal = {
+        cid
+        for cid, o in router.tracked_orders().items()
+        if not o.is_terminal
+    }
+    assert tracked_nonterminal == venue_open_cids
+    # The ingested order carries the venue's view (OPEN, venue id, partial fill).
+    ingested = router.get("disc-open")
+    assert ingested is not None
+    assert ingested.status is OrderStatus.PARTIALLY_FILLED
+    assert ingested.venue_order_id is not None
+
+    # Positions are EXACTLY the fold over the venue's confirmed fills.
+    broker_fills = await broker.fills()
+    assert tracker.all_positions() == _positions_from_broker_fills(broker_fills)
+    # Both instruments traded, so both have a folded position.
+    assert set(tracker.all_positions()) == {BTC_USD, ETH_USD}
+
+    # --- idempotency: a second pass changes nothing ------------------------- #
+    again = await reconcile(broker, router, tracker, event_bus=bus)
+    assert again.changed is False
+    assert again.ingested_orders == 0
+    assert again.closed_orphans == 0
+    # Positions unchanged by the second fold of the same fills.
+    assert tracker.all_positions() == _positions_from_broker_fills(broker_fills)
+
+
+async def test_reconcile_closes_local_orphan_the_venue_never_knew() -> None:
+    """A local non-terminal order the venue has no record of is closed-and-forgotten.
+
+    The other divergence direction: the engine believes an order is live but the
+    venue lists it neither as open nor in any fill (e.g. it was rejected after the
+    engine recorded it, or cancelled out-of-band). The orphan policy is to drive
+    it terminal (``CANCELLED``) and drop it from the tracked map, so the engine
+    stops acting on a phantom — never leaving a lost order live.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    bus, router, tracker = _engine(broker)
+
+    # Track a live order locally that the venue does NOT know about. Built and
+    # driven OPEN by hand (ingest records it as-is) to model "engine thinks it is
+    # live, venue has no record".
+    orphan = _limit("orphan-1", qty="1", price="30000")
+    orphan.submit()
+    orphan.open("PHANTOM-VID")
+    router.ingest(orphan)
+    assert router.get("orphan-1") is not None
+    assert not orphan.is_terminal
+
+    # The venue has nothing: no open orders, no fills.
+    assert await broker.open_orders() == []
+    assert await broker.fills() == []
+
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+
+    # The orphan is closed and forgotten — not left live, not duplicated.
+    assert result.closed_orphans == 1
+    assert result.changed is True
+    assert router.get("orphan-1") is None
+    assert orphan.status is OrderStatus.CANCELLED
+
+    # A second pass is clean (the orphan is gone, nothing else diverges).
+    again = await reconcile(broker, router, tracker, event_bus=bus)
+    assert again.changed is False
+    assert again.closed_orphans == 0
+
+
+async def test_reconcile_adopts_already_tracked_order_without_duplicating() -> None:
+    """An order the engine already tracks AND the venue lists open is adopted, not duped.
+
+    Guards the "no duplicate" half of the invariant from the adopt side: the
+    engine submitted an order normally (so the router tracks it and the venue
+    holds it open), then reconcile runs. The order must be *adopted* — counted,
+    left as the engine's own object — and never ingested a second time, so the
+    tracked map still has exactly one entry for that id.
+    """
+    inner = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("10000000")},
+    )
+    broker = FaultyBroker(inner)
+    bus, router, tracker = _engine(broker)
+
+    # Submit through the engine, leaving the order half-filled and open.
+    inner.arm_partial(money("0.5"))
+    submitted = await router.submit(_limit("kept-open", qty="4", price="30000"))
+    assert submitted.status is OrderStatus.OPEN
+    own_object = router.get("kept-open")
+
+    result = await reconcile(broker, router, tracker, event_bus=bus)
+
+    # Adopted (already tracked), not ingested or duplicated.
+    assert result.adopted_orders == 1
+    assert result.ingested_orders == 0
+    assert result.changed is False  # adopt alone is not a mutation
+    # The router still holds the engine's own object, exactly once.
+    assert router.get("kept-open") is own_object
+    assert list(router.tracked_orders()) == ["kept-open"]


### PR DESCRIPTION
## Summary
- First leaf of **E10** (hardening-only): `tests/hardening/` — proves the money-safety invariants under **fault injection** via a `FaultyBroker` over `PaperBroker` (11 tests). Everything offline; no venue/key/real order.
- Scenarios: reconcile converges after a simulated disconnect (no order duplicated/lost; second pass no-op); engine-side idempotency under sequential AND concurrent retries; an ambiguous failure surfaces (not a silent success) and `reconcile` is the recovery; kill-switch cancels open orders + halts new ones mid-run.

## Why
- A money-handling engine's safety can't rest on happy-path tests — the dangerous cases are faults (lost responses, disconnects, concurrent retries). This demonstrates them. **Still needs a real-key sandbox**: venue-level idempotency (a venue dedup token) — documented at the ambiguous-failure tests. See `doc/dev/03-decisions.md`.

## Changes
- `tests/hardening/` (`_faulty_broker.py` + reconciliation/idempotency/kill-switch tests). No production code change.

## Changelog
Added: hardening test suite (reconcile/idempotency/kill-switch under fault injection).

## Test plan
- [x] `.venv/bin/python -m pytest trading_bot/tests/hardening` (11 passed)
- [x] `.venv/bin/python -m pytest` (532 passed, 0 unexpected skips)
- [x] `ruff` + `mypy` clean