### PR TITLE
feat: close known gaps — KPI capital, reject same-symbol, AddOrder retry guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   under **fault injection** (a `FaultyBroker` over `PaperBroker`): reconciliation
   converges after a simulated disconnect (no order duplicated/lost), idempotent submit
   survives retries/ambiguous failures, and the kill-switch cancels + halts mid-run.
+- `AppConfig.starting_capital` (default 100000) — wired into `PerformanceService(v0=)`
+  so the KPI ratios (Sharpe/Sortino/max-drawdown/Calmar) are **meaningful** (the equity
+  curve no longer starts at zero and sign-crosses); CLI `kpi --capital` overrides it.
+
+### Changed
+
+- `run_app`/`build_runners` now **reject** two strategies declaring the same instrument
+  (a `ConfigError`, catching aliases like `XBT/USD`≡`BTC/USD`) — the shared per-instrument
+  tracker has no per-strategy attribution, so commingling is refused up front.
+- `transport.AsyncHTTPClient.post(retry=...)` — a POST can opt out of retries
+  (`retry=False` → at-most-once, raising `AmbiguousRequestError` on a transient failure
+  so the caller reconciles before retrying). `KrakenBroker.place_order` (`AddOrder`) uses
+  the non-retry path; idempotent reads keep retrying. Closes the blind-retry double-submit
+  window (engine-side; venue-side dedup token still needs a real-key sandbox).
 
 - `interfaces.api` — read-only FastAPI over the engine: `GET /api/{health,positions,
   orders,kpi}` (money as **Decimal strings**, never float) + an SSE `/api/events`

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,30 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-28 Close known gaps: KPI capital, reject same-symbol, AddOrder non-retry
+
+**Decision.** Three recorded gaps closed (offline; live still off):
+(a) **KPI v0** — `AppConfig.starting_capital` (default `money("100000")`, strictly
+positive) is wired into `PerformanceService(v0=)`; a fill-driven equity curve anchored
+at 0 sign-crosses on the first fee, making fynance's ratio estimators degenerate, so a
+positive anchor makes Sharpe/Sortino/Calmar meaningful (CLI `--capital` > config > the
+built-in default; the API `_safe_ratio` also coerces `inf`/`nan` → `0.0`, since a winning
+curve can now make fynance *return* `inf`). (b) **Same-instrument** — `build_runners`
+**rejects** two strategies on the same normalised `Symbol` with a `ConfigError` (catches
+the `XBT/USD`≡`BTC/USD` alias) rather than silently commingling them in the shared
+per-instrument tracker. (c) **AddOrder retry** — `AsyncHTTPClient.post` gains
+`retry=False` (at-most-once, raising `AmbiguousRequestError`); `KrakenBroker.place_order`
+uses it so a `AddOrder` is never blind-retried after an ambiguous failure, pointing the
+caller at `reconcile`; idempotent reads keep retrying.
+
+**Why.** These were the gaps safe to close without a real venue. (a) and (b) make the
+observability/orchestration honest; (c) closes the transport-level double-submit window
+the router's in-memory dedup didn't cover. **Still deferred to a real-key sandbox:**
+true *venue-level* idempotency (a venue dedup token surviving an engine crash). The
+**final project name** and **default paper-vs-live** also remain deferred.
+
+---
+
 ### 2026-06-28 Hardening: prove safety invariants under fault injection (offline)
 
 **Decision.** `tests/hardening/` *demonstrates* the money-safety invariants

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -44,30 +44,28 @@ gaps; explicit live enablement) and the **final project name**. Next is **E10**.
 
 ## Pending
 
-Everything remaining in [`07-roadmap.md`](07-roadmap.md): the
-Kraken broker + paper broker, the order router, the strategy runner, performance/
-risk, the CLI, the orchestration layer, and (later) the UI and go-live hardening.
+Only **E10-03** (go-live runbook + an explicit, off-by-default live opt-in guard) — see
+[`07-roadmap.md`](07-roadmap.md). After that the rewrite is feature-complete; real live
+trading still needs a real-key sandbox validation, and the **final project name** stays
+deferred.
 
 ## Known gaps / deferred
 
 - **Final project name** — kept as `trading_bot` for now (deferred decision).
-- **Default paper-vs-live beyond MVP** — paper-first for now; revisit at go-live.
-- **KPI ratios need a positive starting capital** — `service_factory.build_engine`
-  wires `PerformanceService(v0=0)`, and fynance refuses an equity curve that crosses
-  zero, so the Sharpe/Sortino/Calmar shown by the API (and the CLI `kpi` absent
-  `--capital`) degrade to `0.0`. Robust (never errors), but the ratios are meaningless
-  until a config-driven starting capital is wired into `build_engine` (small follow-up).
-- **Same-instrument strategies commingle in `run_app`** — the orchestrated system
-  shares one engine, and the `PositionTracker`/`PerformanceService` key state **by
-  instrument**, so two strategies declared on the *same* symbol fold their fills into
-  one shared position/PnL (silently commingled). Fine for the nominal one-strategy-
-  per-symbol case; per-strategy attribution (or rejecting duplicate symbols) is a
-  later refinement. Distinct-symbol strategies are fully isolated.
+- **Default paper-vs-live beyond MVP** — paper-first; live behind an explicit
+  off-by-default opt-in (E10-03).
+- ~~**KPI ratios need a positive starting capital**~~ — **resolved (E10)**:
+  `AppConfig.starting_capital` (default 100000) is wired into `PerformanceService(v0=)`,
+  so the ratios are meaningful; CLI `kpi --capital` overrides it.
+- ~~**Same-instrument strategies commingle in `run_app`**~~ — **resolved (E10)**:
+  `build_runners` now **rejects** two strategies on the same symbol (`ConfigError`,
+  alias-aware). A per-strategy book (to *allow* it) remains a future refinement.
 - ~~**dccd↔trading_bot orchestration depth**~~ — **resolved (E8)**: library import,
   not a service (`feed_for` uses `dccd.Client.read`/`backfill` in-process). See ADR.
-- **`AddOrder` idempotency at the venue** — the transport retries POSTs on
-  5xx/network errors, but `AddOrder` carries no venue idempotency key, so a retry
-  after an *ambiguous* failure (order placed, response lost) could double-submit.
-  Today idempotency is engine-side only (`OrderRouter` client-order-id dedup);
-  venue-level idempotency / reconcile-on-ambiguous-failure is go-live hardening
-  (groundwork in E4's order-router, finished in E10).
+- **`AddOrder` idempotency at the venue** — *transport guard added (E10)*:
+  `place_order` now sends `AddOrder` **at most once** (`post(retry=False)` → raises
+  `AmbiguousRequestError` so the caller reconciles before retrying), closing the
+  blind-retry double-submit window. Still **not fully closed**: there is no
+  *venue-side* dedup token, so a retry the engine *forgot* (e.g. a crash before the
+  reject was persisted) could still double-submit — that needs a real-key sandbox to
+  build/validate (the only live-trading prerequisite left).

--- a/doc/dev/plans/go-live-hardening/00-plan.md
+++ b/doc/dev/plans/go-live-hardening/00-plan.md
@@ -32,7 +32,7 @@ explicitly turned on, with a real-key sandbox the only thing left to do later).
 ## Leaf checklist
 
 - [x] 01 fault-injection — test/go-live-hardening — high
-- [ ] 02 close-known-gaps — feat/close-known-gaps — high
+- [x] 02 close-known-gaps — feat/close-known-gaps — high
 - [ ] 03 go-live-runbook — feat/go-live-opt-in — medium (depends on 01, 02)
 
 ## Dependencies

--- a/doc/dev/plans/go-live-hardening/02-close-known-gaps.md
+++ b/doc/dev/plans/go-live-hardening/02-close-known-gaps.md
@@ -1,7 +1,7 @@
 ---
 plan: go-live-hardening/02-close-known-gaps
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: []
 parallel: false

--- a/doc/dev/plans/go-live-hardening/02-close-known-gaps.md
+++ b/doc/dev/plans/go-live-hardening/02-close-known-gaps.md
@@ -6,7 +6,7 @@ complexity: high
 depends: []
 parallel: false
 branch: feat/close-known-gaps
-pr: ""
+pr: "#54"
 ---
 
 # Close the safe-to-fix known gaps

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -9,6 +9,12 @@
 
 mode: paper
 
+# Starting account capital (quote units) that anchors the equity curve the KPI
+# ratios (Sharpe/Sortino/Calmar) are computed over: equity = starting_capital +
+# cumulative realised PnL. Must be strictly positive (keeps the curve off zero so
+# the ratio math is well-defined). Exact Decimal; defaults to 100000 if omitted.
+starting_capital: "100000"
+
 # Where the engine persists state and finds market data on disk.
 storage:
   db_path: ./var/trading_bot.sqlite   # append-only order/fill history + state

--- a/trading_bot/application/config.py
+++ b/trading_bot/application/config.py
@@ -12,10 +12,15 @@ Design choices (carried into the ADR):
   trades real money by accident. Switching to ``"live"`` is always an explicit,
   deliberate edit. ``mode`` is a ``Literal["paper", "live"]`` so any other value
   is rejected at validation time.
-* **Money stays exact.** Risk limits (:class:`RiskConfig`) are
-  :class:`~decimal.Decimal`, parsed from ``str``/``int`` without ever touching
-  ``float`` — pydantic builds a ``Decimal`` directly from the YAML scalar, so a
-  value like ``0.1`` keeps its exact decimal meaning.
+* **Money stays exact.** Risk limits (:class:`RiskConfig`) and the
+  ``starting_capital`` are :class:`~decimal.Decimal`, parsed from ``str``/``int``
+  without ever touching ``float`` — pydantic builds a ``Decimal`` directly from
+  the YAML scalar, so a value like ``0.1`` keeps its exact decimal meaning.
+* **KPIs anchor to a real account value.** ``starting_capital`` seeds the
+  performance service's equity curve (``equity = starting_capital + cumulative
+  realised PnL``). Defaulting it to a strictly-positive ``100000`` keeps the
+  curve from crossing zero, so the KPI ratios (Sharpe/Sortino/Calmar) computed
+  over a real run are statistically meaningful rather than degenerate.
 * **Skeletons that grow.** :class:`StrategyConfig` and :class:`RiskConfig` are
   intentionally minimal here (just enough to parse a realistic file); they gain
   fields in later leaves (E5 / E8). :class:`BrokerConfig` carries only the
@@ -34,6 +39,8 @@ from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, Field, field_validator
+
+from trading_bot.domain.money import money
 
 __all__ = [
     "BrokerConfig",
@@ -284,6 +291,15 @@ class AppConfig(BaseModel):
         Execution mode. Defaults to ``"paper"`` so a fresh config never trades
         real money by accident; ``"live"`` must be set deliberately. Any other
         value is rejected.
+    starting_capital : Decimal, optional
+        Initial account capital (quote units) that anchors the equity curve the
+        KPI ratios are computed over (``equity = starting_capital + cumulative
+        realised PnL``). Parsed exactly from a YAML scalar (``str``/``int``)
+        without touching ``float``. Must be **strictly positive** so the curve
+        stays above zero and the ratio math is well-defined. Defaults to
+        ``Decimal("100000")``. Wired into the engine's
+        :class:`~trading_bot.application.performance_service.PerformanceService`
+        (``v0``) by :func:`~trading_bot.application.service_factory.build_engine`.
     brokers : list of BrokerConfig, optional
         The brokers to wire up. Empty by default.
     strategies : list of StrategyConfig, optional
@@ -310,10 +326,25 @@ class AppConfig(BaseModel):
     """
 
     mode: Literal["paper", "live"] = "paper"
+    starting_capital: Decimal = Field(default_factory=lambda: money("100000"))
     brokers: list[BrokerConfig] = Field(default_factory=list)
     strategies: list[StrategyConfig] = Field(default_factory=list)
     risk: RiskConfig = Field(default_factory=RiskConfig)
     storage: StorageConfig = Field(default_factory=StorageConfig)
+
+    @field_validator("starting_capital")
+    @classmethod
+    def _positive_capital(cls, v: Decimal) -> Decimal:
+        """Reject a non-positive ``starting_capital`` (zero too).
+
+        The equity curve the KPI ratios are computed over is
+        ``starting_capital + cumulative realised PnL``; a non-positive anchor
+        would let the curve sit at / cross zero, where the ratio estimators are
+        undefined.
+        """
+        if v <= 0:
+            raise ValueError(f"starting_capital must be positive, got {v}")
+        return v
 
     @classmethod
     def from_yaml(cls, path: str | pathlib.Path) -> AppConfig:

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -84,7 +84,7 @@ from trading_bot.application.strategy import (
 )
 from trading_bot.application.strategy_runner import StrategyRunner
 from trading_bot.domain.errors import ConfigError
-from trading_bot.domain.instrument import Instrument, parse_kraken_pair
+from trading_bot.domain.instrument import Instrument, Symbol, parse_kraken_pair
 from trading_bot.domain.money import Money, from_float
 from trading_bot.domain.order import Order, OrderSide, OrderType
 
@@ -266,6 +266,45 @@ def _limit_at_close_factory(
     return _factory
 
 
+def _reject_commingled(config: AppConfig) -> None:
+    """Reject two strategies declaring the **same** instrument.
+
+    The whole declared system shares **one** engine — one position tracker, one
+    performance service — keyed *per instrument*, with no per-strategy
+    attribution today (see the single-engine rationale above). So two strategies
+    on the same instrument would **commingle**: their fills fold into the one
+    shared per-instrument position/PnL view and can no longer be told apart (a
+    BUY from one and a SELL from the other net against each other; the reported
+    PnL is the blend, not either strategy's). Rather than silently produce a
+    meaningless blended book, reject the config up front with a clear
+    :class:`~trading_bot.domain.errors.ConfigError` naming the duplicated symbol
+    and the two offending strategies.
+
+    Symbols are compared by their **normalised**
+    :class:`~trading_bot.domain.instrument.Symbol` (via
+    :func:`~trading_bot.domain.instrument.parse_kraken_pair`), so two different
+    spellings of the same pair (e.g. ``"BTC/USD"`` and ``"XBT/USD"``) are still
+    caught as the same instrument.
+
+    The real fix — a **per-strategy book** that attributes fills back to the
+    strategy that originated them — is deferred future work; until it lands,
+    one-instrument-per-strategy is the invariant this guard enforces.
+    """
+    seen: dict[Symbol, str] = {}
+    for strategy_cfg in config.strategies:
+        symbol = parse_kraken_pair(strategy_cfg.symbol)
+        previous = seen.get(symbol)
+        if previous is not None:
+            raise ConfigError(
+                f"strategies {previous!r} and {strategy_cfg.name!r} both trade "
+                f"the same instrument {strategy_cfg.symbol!r}: the shared "
+                "per-instrument tracker/performance view would commingle them "
+                "(no per-strategy attribution today). Give each strategy a "
+                "distinct instrument, or run them as separate systems."
+            )
+        seen[symbol] = strategy_cfg.name
+
+
 def build_runners(
     config: AppConfig,
     engine: Engine,
@@ -313,9 +352,12 @@ def build_runners(
     ------
     ConfigError
         If a strategy declares no ``signal`` or no ``data`` source, names an
-        unknown builtin signal, or its signal cannot be built / imported.
+        unknown builtin signal, its signal cannot be built / imported, or two
+        strategies declare the **same** instrument (see :func:`_reject_commingled`).
 
     """
+    _reject_commingled(config)
+
     runners: list[StrategyRunner] = []
     for strategy_cfg in config.strategies:
         instrument = Instrument(parse_kraken_pair(strategy_cfg.symbol))

--- a/trading_bot/application/service_factory.py
+++ b/trading_bot/application/service_factory.py
@@ -152,7 +152,10 @@ def build_engine(
     broker = _build_broker(config, bus)
 
     tracker = PositionTracker(event_bus=bus)
-    perf = PerformanceService(event_bus=bus)
+    # Seed the equity curve with the configured starting capital so the KPI
+    # ratios are computed over a strictly-positive account value (the curve does
+    # not sign-cross), making Sharpe/Sortino/Calmar over a real run meaningful.
+    perf = PerformanceService(v0=config.starting_capital, event_bus=bus)
     risk = RiskManager(config.risk, position_tracker=tracker)
     router = OrderRouter(broker, bus, risk_manager=risk)
 

--- a/trading_bot/brokers/kraken.py
+++ b/trading_bot/brokers/kraken.py
@@ -139,6 +139,20 @@ class KrakenBroker(Broker):
     :func:`_sign`. A private call attempted without credentials raises
     :class:`~trading_bot.domain.errors.BrokerError` before any I/O.
 
+    Retry policy — idempotency-aware
+    --------------------------------
+    The transport retries transient failures (5xx / 429 / dropped connections)
+    with backoff. That is safe for the **idempotent** private endpoints — the
+    read/query calls :meth:`balances`, :meth:`open_orders`, :meth:`fills`,
+    :meth:`cancel_order` (cancelling an already-cancelled order is a no-op) — so
+    they keep retrying. It is **not** safe for :meth:`place_order` (``AddOrder``):
+    a blind retry after an *ambiguous* failure (the order landed but the response
+    was lost) would place a **second** order. :meth:`place_order` therefore opts
+    out of retries (``retry=False``); on an ambiguous failure the transport
+    raises :class:`~trading_bot.transport.http.AmbiguousRequestError` and the
+    caller must reconcile
+    (:func:`~trading_bot.application.reconcile.reconcile`) — never blind-retry.
+
     Parameters
     ----------
     api_key : str, optional
@@ -261,13 +275,25 @@ class KrakenBroker(Broker):
         return self._raise_on_error(payload, context=endpoint)
 
     async def _private_post(
-        self, endpoint: str, data: Mapping[str, Any]
+        self, endpoint: str, data: Mapping[str, Any], *, retry: bool = True
     ) -> dict[str, Any]:
         """Sign and POST a private endpoint, returning its ``result`` (or raise).
 
         Builds a fresh ``nonce``-first body, throttles via the Kraken call
         counter at the endpoint's cost, signs with :func:`_sign`, and sends the
         ``API-Key`` / ``API-Sign`` headers. Requires credentials.
+
+        Parameters
+        ----------
+        endpoint : str
+            The private endpoint name (e.g. ``"Balance"``, ``"AddOrder"``).
+        data : mapping
+            The endpoint body (the ``nonce`` is prepended here).
+        retry : bool, default True
+            Forwarded to :meth:`~trading_bot.transport.http.AsyncHTTPClient.post`.
+            ``True`` for **idempotent** endpoints (queries/reads — a duplicate is
+            harmless); ``False`` for the **non-idempotent** ``AddOrder`` so a
+            blind retry can never double-submit (see :meth:`place_order`).
         """
         self._require_credentials()
         path = f"{_PRIVATE}/{endpoint}"
@@ -280,7 +306,9 @@ class KrakenBroker(Broker):
         await self._counter.acquire_method(endpoint)
         url = f"{_API_BASE}{path}"
         async with self._http as client:
-            payload = await client.post(url, data=body, headers=headers)
+            payload = await client.post(
+                url, data=body, headers=headers, retry=retry
+            )
         return self._raise_on_error(payload, context=endpoint)
 
     # --- public endpoints -------------------------------------------------- #
@@ -389,6 +417,22 @@ class KrakenBroker(Broker):
         stop-loss from :class:`OrderType`, ``volume``=qty, ``pair`` from the
         instrument, ``price``=``limit_price`` (limit) or ``stop_price`` (stop).
 
+        Venue-idempotency
+        -----------------
+        ``AddOrder`` is **non-idempotent** — a second submission places a second
+        order. So this call is sent **at most once** (``retry=False``): the
+        transport will not blindly retry it on an ambiguous transient failure (a
+        5xx / dropped connection after the order may already have landed).
+        Instead it raises
+        :class:`~trading_bot.transport.http.AmbiguousRequestError`, signalling
+        the caller to reconcile
+        (:func:`~trading_bot.application.reconcile.reconcile` — refetch open
+        orders + fills) and decide from the venue's actual state — **never** to
+        blind-retry and risk a duplicate. (Engine-side, the
+        :class:`~trading_bot.application.order_router.OrderRouter`'s
+        client-order-id dedup also guards against re-submitting the *same* logical
+        order; this guard closes the remaining transport-level retry window.)
+
         Parameters
         ----------
         order : Order
@@ -404,9 +448,15 @@ class KrakenBroker(Broker):
         BrokerError
             Without credentials, on a Kraken error, or if no ``txid`` is
             returned.
+        AmbiguousRequestError
+            On an ambiguous transient failure — the order may have landed;
+            reconcile (:func:`~trading_bot.application.reconcile.reconcile`)
+            before any retry.
 
         """
-        result = await self._private_post("AddOrder", self._add_order_params(order))
+        result = await self._private_post(
+            "AddOrder", self._add_order_params(order), retry=False
+        )
         txids = result.get("txid") or []
         if not txids:
             raise BrokerError(
@@ -424,9 +474,10 @@ class KrakenBroker(Broker):
         The domain ``client_order_id`` is **not** forwarded to Kraken here:
         Kraken's ``cl_ord_id`` requires a UUID and ``userref`` is a 32-bit int,
         neither of which fits an arbitrary id. Idempotency is enforced
-        engine-side by the ``OrderRouter`` (client-order-id dedup); venue-level
-        idempotency — and *not* blindly retrying a non-idempotent ``AddOrder``
-        POST — is a deferred go-live hardening item (see ``doc/dev/06-status.md``).
+        engine-side by the ``OrderRouter`` (client-order-id dedup); the
+        transport-level half — *not* blindly retrying a non-idempotent
+        ``AddOrder`` POST on an ambiguous failure — is enforced by
+        :meth:`place_order` (``retry=False``; reconcile-before-retry).
         """
         params: dict[str, str] = {
             "pair": order.instrument.symbol.to_venue_symbol(self.name),

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -61,6 +61,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 from collections.abc import Callable
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
@@ -199,19 +200,32 @@ def _fill_dict(fill: Fill) -> dict[str, Any]:
 def _safe_ratio(compute: Callable[[], float]) -> float:
     """Evaluate a KPI ratio, returning ``0.0`` when it is undefined on this curve.
 
-    The fynance-backed ratio estimators reject some real equity curves the
-    fill-driven :class:`~trading_bot.application.performance_service.
-    PerformanceService` produces: with the factory's default ``v0 = 0`` the
-    equity series starts at (or crosses) zero the moment a fee is charged, and
-    fynance raises a :class:`ValueError` ("initial value cannot be null" / "must
-    be of the same sign"). A read-only KPI view must not turn that into a 500;
-    instead it reports ``0.0`` — the same "undefined estimator → 0.0" convention
-    the service already uses for a too-short series.
+    The fynance-backed ratio estimators can both *raise* and *return a
+    non-finite value* on some real equity curves the fill-driven
+    :class:`~trading_bot.application.performance_service.PerformanceService`
+    produces:
+
+    * they **raise** a :class:`ValueError` when the curve is degenerate (e.g. a
+      curve that starts at / crosses zero — fynance's "initial value cannot be
+      null" / "must be of the same sign");
+    * they **return ``inf`` / ``nan``** when a ratio's denominator is zero on an
+      otherwise valid curve — e.g. a *monotonically rising* curve has zero
+      drawdown, so Calmar (return / max-drawdown) and Sortino (excess /
+      downside-deviation) are ``inf``. With a strictly-positive
+      ``starting_capital`` (the config default) this is now the *common* shape
+      for a winning run, where the old ``v0 = 0`` curve would instead have made
+      fynance raise.
+
+    A read-only KPI view must stay 200 + JSON-numeric in both cases (a bare
+    ``inf`` / ``nan`` is not valid JSON and serializes to ``null``). So this
+    reports ``0.0`` for a raised *and* a non-finite ratio — the same "undefined
+    estimator → 0.0" convention the service uses for a too-short series.
     """
     try:
-        return compute()
+        value = compute()
     except (ValueError, ZeroDivisionError, ArithmeticError):
         return 0.0
+    return value if math.isfinite(value) else 0.0
 
 
 def _event_dict(event: Event) -> dict[str, Any]:

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -461,6 +461,12 @@ def status(
 # --- kpi ------------------------------------------------------------------- #
 
 
+#: Built-in fallback starting capital for ``kpi`` when neither ``--capital`` nor
+#: a config's ``starting_capital`` is available. Mirrors
+#: :attr:`AppConfig.starting_capital`'s own default.
+_KPI_DEFAULT_CAPITAL = 100_000.0
+
+
 @app.command()
 def kpi(
     db_path: pathlib.Path = typer.Option(
@@ -468,11 +474,19 @@ def kpi(
         "--db",
         help="SqliteStore database path to compute KPIs from.",
     ),
-    capital: float = typer.Option(
-        100_000.0,
+    capital: float | None = typer.Option(
+        None,
         "--capital",
         help="Starting account capital (quote units) anchoring the equity "
-        "curve the KPI ratios are computed over.",
+        "curve the KPI ratios are computed over. Overrides the config's "
+        "starting_capital; defaults to 100000 when neither is given.",
+    ),
+    config_path: pathlib.Path | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="YAML AppConfig path. When given, its starting_capital anchors the "
+        "equity curve unless --capital overrides it.",
     ),
 ) -> None:
     """Show realised PnL / fees / equity / KPI ratios from a stored fill history.
@@ -484,21 +498,49 @@ def kpi(
     Sortino / max-drawdown / Calmar ratios as floats.
 
     The KPI *ratios* are estimators over the equity curve ``capital + cumulative
-    realised PnL``; ``--capital`` anchors it to a realistic, strictly-positive
-    account value (the ratio math needs the curve not to cross zero). The
-    realised PnL / fees themselves are independent of ``--capital``.
+    realised PnL``; the anchor must be a realistic, strictly-positive account
+    value (the ratio math needs the curve not to cross zero). The realised PnL /
+    fees themselves are independent of the anchor.
+
+    Capital precedence
+    ------------------
+    The starting capital is resolved as **explicit ``--capital`` > config
+    ``starting_capital`` (when ``--config`` is given) > built-in default
+    (``100000``)**. So ``--capital`` always wins; absent it, a loaded config's
+    ``starting_capital`` is used; absent both, the built-in default applies.
     """
     from trading_bot.storage.sqlite_store import SqliteStore
 
     if not db_path.exists():
         raise typer.BadParameter(f"database not found: {db_path}")
 
+    resolved_capital = _resolve_kpi_capital(capital, config_path)
+
     store = SqliteStore(db_path)
-    perf = PerformanceService(v0=money(str(Decimal(str(capital)))))
+    perf = PerformanceService(v0=resolved_capital)
     for fill in store.fills():
         perf.apply(fill)
 
     _console.print(_render.kpi_table(perf))
+
+
+def _resolve_kpi_capital(
+    capital: float | None, config_path: pathlib.Path | None
+) -> Money:
+    """Resolve the KPI starting capital by the documented precedence.
+
+    Explicit ``--capital`` wins; absent it, a loaded config's
+    ``starting_capital`` is used (when ``--config`` was given); absent both, the
+    built-in default (:data:`_KPI_DEFAULT_CAPITAL`). The float ``--capital`` is
+    routed through ``str`` (``from_float`` semantics) so it never carries a
+    binary rounding error into the equity anchor; the config value is already an
+    exact :class:`~decimal.Decimal`.
+    """
+    if capital is not None:
+        return money(str(Decimal(str(capital))))
+    if config_path is not None:
+        return AppConfig.from_yaml(config_path).starting_capital
+    return money(str(Decimal(str(_KPI_DEFAULT_CAPITAL))))
 
 
 # --- serve ----------------------------------------------------------------- #

--- a/trading_bot/tests/application/test_config.py
+++ b/trading_bot/tests/application/test_config.py
@@ -61,6 +61,46 @@ def test_mode_defaults_to_paper() -> None:
     assert cfg.risk.max_position is None
 
 
+def test_starting_capital_defaults_to_100000() -> None:
+    """An unset ``starting_capital`` is the strictly-positive default 100000."""
+    cfg = AppConfig()
+    assert cfg.starting_capital == Decimal("100000")
+    assert isinstance(cfg.starting_capital, Decimal)
+
+
+def test_starting_capital_parses_exact_decimal_without_float_error() -> None:
+    """A YAML/JSON number for ``starting_capital`` keeps its exact meaning."""
+    cfg = AppConfig.model_validate({"starting_capital": 250000.5})
+    assert cfg.starting_capital == Decimal("250000.5")
+    assert isinstance(cfg.starting_capital, Decimal)
+
+
+def test_starting_capital_string_parses_exact() -> None:
+    """A string ``starting_capital`` parses to an exact Decimal."""
+    cfg = AppConfig.model_validate({"starting_capital": "1000000"})
+    assert cfg.starting_capital == Decimal("1000000")
+
+
+def test_zero_starting_capital_raises() -> None:
+    """A zero ``starting_capital`` is rejected (curve would sit at zero)."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate({"starting_capital": "0"})
+
+
+def test_negative_starting_capital_raises() -> None:
+    """A negative ``starting_capital`` is rejected."""
+    with pytest.raises(ValidationError):
+        AppConfig.model_validate({"starting_capital": "-1"})
+
+
+def test_starting_capital_round_trips_from_yaml(tmp_path) -> None:
+    """``starting_capital`` survives a YAML round-trip as an exact Decimal."""
+    path = tmp_path / "cap.yml"
+    path.write_text("starting_capital: \"500000\"\n")
+    cfg = AppConfig.from_yaml(path)
+    assert cfg.starting_capital == Decimal("500000")
+
+
 def test_model_validate_realistic_dict() -> None:
     """A realistic dict parses into fully-typed sub-models."""
     cfg = AppConfig.model_validate(REALISTIC)

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -371,6 +371,84 @@ def test_build_runners_bad_builtin_params_is_config_error() -> None:
         build_runners(config, engine, dccd_client=_FakeDccdClient({}))
 
 
+# --- same-instrument commingling: detect & reject -------------------------- #
+
+
+def _same_symbol_config(second_symbol: str = "BTC/USD") -> AppConfig:
+    """A 2-strategy config where both strategies trade the same instrument."""
+    return AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "strategies": [
+                {
+                    "name": "btc-fast",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                    "reference_qty": "1",
+                },
+                {
+                    "name": "btc-slow",
+                    "symbol": second_symbol,
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 4, "slow": 8}},
+                    "reference_qty": "1",
+                },
+            ],
+        }
+    )
+
+
+def test_build_runners_same_symbol_is_config_error() -> None:
+    """Two strategies on the same symbol → a clear :class:`ConfigError`.
+
+    The shared per-instrument tracker / performance view has no per-strategy
+    attribution, so two strategies on one instrument would commingle. The config
+    is rejected up front, naming the duplicated symbol and both strategies.
+    """
+    config = _same_symbol_config()
+    engine = build_engine(config, db_path=None)
+    with pytest.raises(ConfigError) as exc_info:
+        build_runners(config, engine, dccd_client=_FakeDccdClient({}))
+
+    msg = str(exc_info.value)
+    assert "BTC/USD" in msg
+    assert "btc-fast" in msg
+    assert "btc-slow" in msg
+    assert "commingle" in msg
+
+
+def test_build_runners_equivalent_symbol_spellings_commingle() -> None:
+    """Two spellings of the *same* instrument (BTC/USD vs XBT/USD) are caught.
+
+    Detection is by the normalised :class:`Symbol`, not the raw string, so a
+    Kraken-style ``XBT`` alias of ``BTC`` does not slip past the guard.
+    """
+    config = _same_symbol_config(second_symbol="XBT/USD")
+    engine = build_engine(config, db_path=None)
+    with pytest.raises(ConfigError, match="commingle"):
+        build_runners(config, engine, dccd_client=_FakeDccdClient({}))
+
+
+def test_run_app_same_symbol_rejected() -> None:
+    """`run_app` surfaces the same-symbol commingling as a :class:`ConfigError`."""
+    import asyncio
+
+    config = _same_symbol_config()
+    with pytest.raises(ConfigError, match="commingle"):
+        asyncio.run(run_app(config, dccd_client=_FakeDccdClient({})))
+
+
+def test_build_runners_distinct_symbols_build_fine() -> None:
+    """Distinct symbols build a runner each — the guard only rejects duplicates."""
+    config = _two_strategy_config()
+    engine = build_engine(config, db_path=None)
+    runners = build_runners(config, engine, dccd_client=_fake_client_for(config))
+    assert len(runners) == 2
+    instruments = {r.strategy.instrument for r in runners}
+    assert instruments == {BTC_USD, ETH_USD}
+
+
 def test_run_app_empty_config_runs_no_strategies() -> None:
     """A config with no strategies yields an empty, well-formed report."""
     import asyncio

--- a/trading_bot/tests/application/test_service_factory.py
+++ b/trading_bot/tests/application/test_service_factory.py
@@ -15,10 +15,12 @@ These prove the wiring contract:
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from trading_bot.application.config import AppConfig, BrokerConfig
-from trading_bot.application.events import EventBus
+from trading_bot.application.events import EventBus, FillEvent
 from trading_bot.application.order_router import OrderRouter
 from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
@@ -27,12 +29,37 @@ from trading_bot.application.service_factory import Engine, build_engine
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.paper import PaperBroker
 from trading_bot.domain.errors import BrokerError
+from trading_bot.domain.fill import Fill
 from trading_bot.domain.instrument import Instrument, Symbol
 from trading_bot.domain.money import money
 from trading_bot.domain.order import Order, OrderSide, OrderType
 from trading_bot.storage.sqlite_store import SqliteStore
 
 _BTCUSD = Instrument(Symbol("BTC", "USD"))
+
+
+def _fill_event(
+    fill_id: str,
+    side: OrderSide,
+    *,
+    qty: str,
+    price: str,
+    fee: str,
+    ts: int = 1,
+) -> FillEvent:
+    """A :class:`FillEvent` for ``_BTCUSD`` — drive the engine's read-side views."""
+    return FillEvent(
+        Fill(
+            fill_id=fill_id,
+            client_order_id="cid",
+            instrument=_BTCUSD,
+            side=side,
+            qty=money(qty),
+            price=money(price),
+            fee=money(fee),
+            ts=ts,
+        )
+    )
 
 
 def test_default_config_builds_paper_engine() -> None:
@@ -48,6 +75,53 @@ def test_default_config_builds_paper_engine() -> None:
     assert isinstance(engine.risk, RiskManager)
     # No db_path → no store.
     assert engine.store is None
+
+
+def test_starting_capital_anchors_perf_equity_curve() -> None:
+    """The config's ``starting_capital`` seeds the perf service's equity curve.
+
+    After one fill, the equity point is ``starting_capital + realised PnL`` — so
+    the curve no longer starts at zero (the gap-(a) closure: a meaningful anchor
+    for the KPI ratios).
+    """
+    cfg = AppConfig.model_validate({"mode": "paper", "starting_capital": "100000"})
+    engine = build_engine(cfg)
+
+    # A fee-free flat buy has zero realised PnL → the equity point is exactly v0.
+    engine.bus.emit(
+        _fill_event("F0", OrderSide.BUY, qty="1", price="100", fee="0")
+    )
+    curve = engine.perf.equity_curve()
+    assert len(curve) == 1
+    assert curve[0] == money("100000")
+
+
+def test_default_starting_capital_flows_to_perf() -> None:
+    """With no explicit ``starting_capital`` the perf anchor is the 100000 default."""
+    engine = build_engine(AppConfig())
+    engine.bus.emit(
+        _fill_event("F0", OrderSide.BUY, qty="1", price="100", fee="0")
+    )
+    assert engine.perf.equity_curve()[0] == money("100000")
+
+
+def test_winning_run_gives_finite_nonzero_sharpe() -> None:
+    """Verification on real data: a winning curve → a non-zero, finite Sharpe.
+
+    Closing gap (a): with the equity curve anchored at a positive
+    ``starting_capital`` it never sign-crosses, so a profitable round-trip yields
+    a *meaningful* Sharpe (non-zero and finite) — where a zero-anchored curve
+    would have made the estimator degenerate / return 0.0.
+    """
+    cfg = AppConfig.model_validate({"mode": "paper", "starting_capital": "100000"})
+    engine = build_engine(cfg)
+    # A profitable round-trip: buy @100, sell @110 → realised PnL +10.
+    engine.bus.emit(_fill_event("F1", OrderSide.BUY, qty="1", price="100", fee="0"))
+    engine.bus.emit(_fill_event("F2", OrderSide.SELL, qty="1", price="110", fee="0"))
+
+    sharpe = engine.perf.sharpe()
+    assert sharpe != 0.0
+    assert math.isfinite(sharpe)
 
 
 def test_paper_engine_shares_one_bus() -> None:

--- a/trading_bot/tests/brokers/test_kraken_rest.py
+++ b/trading_bot/tests/brokers/test_kraken_rest.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+import httpx
 import pytest
 
 from trading_bot.brokers import BrokerError, Capability, KrakenBroker
@@ -29,6 +30,7 @@ from trading_bot.domain import (
     Symbol,
     money,
 )
+from trading_bot.transport import AmbiguousRequestError, AsyncHTTPClient
 from trading_bot.transport.ratelimit import KrakenCallCounter
 
 BTC_USD = Instrument(Symbol("BTC", "USD"), price_precision=1, qty_precision=8)
@@ -66,15 +68,24 @@ def _fast_counter() -> KrakenCallCounter:
     )
 
 
-def _broker(monkeypatch: pytest.MonkeyPatch, *, creds: bool = True) -> KrakenBroker:
-    """Build a broker; with ``creds`` set dummy env credentials (signing runs)."""
+def _broker(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    creds: bool = True,
+    http: AsyncHTTPClient | None = None,
+) -> KrakenBroker:
+    """Build a broker; with ``creds`` set dummy env credentials (signing runs).
+
+    An optional ``http`` client is injected so a test can control retry timing
+    (a recording sleep) and assert how many attempts a call makes.
+    """
     if creds:
         monkeypatch.setenv("KRAKEN_API_KEY", "DUMMY-KEY")
         monkeypatch.setenv("KRAKEN_API_SECRET", _VECTOR_SECRET)
     else:
         monkeypatch.delenv("KRAKEN_API_KEY", raising=False)
         monkeypatch.delenv("KRAKEN_API_SECRET", raising=False)
-    return KrakenBroker(call_counter=_fast_counter())
+    return KrakenBroker(call_counter=_fast_counter(), http=http)
 
 
 # --- signing: the deterministic proof ------------------------------------- #
@@ -366,6 +377,99 @@ async def test_fills_since_ms_passes_start_seconds(
     body = httpx_mock.get_request().content.decode()
     # ms -> seconds for Kraken's ``start`` cursor.
     assert "start=1616492376.594" in body
+
+
+# --- venue-idempotency: AddOrder is sent at most once --------------------- #
+
+
+class _RecordingSleep:
+    """Async ``asyncio.sleep`` stand-in recording every requested backoff delay."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, delay: float) -> None:
+        self.calls.append(delay)
+
+
+async def test_place_order_does_not_retry_on_ambiguous_5xx(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 5xx on ``AddOrder`` is attempted **once** and raises an ambiguous error.
+
+    Closing gap (c): ``place_order`` posts with ``retry=False``, so a blind retry
+    can never double-submit the (non-idempotent) order. A single 5xx surfaces an
+    :class:`AmbiguousRequestError` telling the caller to reconcile — and exactly
+    one HTTP request is made (no retry, no backoff sleep).
+
+    Only **one** 503 is registered even though the client's ``max_retries`` is 3:
+    a retrying call would request a second (unregistered) response and error;
+    the single registered response being the sole request is itself the proof
+    that the order was attempted at most once.
+    """
+    httpx_mock.add_response(status_code=503, text="upstream down")
+    sleep = _RecordingSleep()
+    http = AsyncHTTPClient(exchange="kraken", max_retries=3, sleep=sleep)
+    broker = _broker(monkeypatch, http=http)
+    order = Order(
+        client_order_id="cid-ambiguous",
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        type=OrderType.MARKET,
+    )
+
+    with pytest.raises(AmbiguousRequestError, match="reconcile"):
+        await broker.place_order(order)
+
+    # AddOrder attempted at most once — no duplicate submission, no backoff.
+    assert len(httpx_mock.get_requests()) == 1
+    assert sleep.calls == []
+
+
+async def test_place_order_does_not_retry_on_transport_error(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dropped connection on ``AddOrder`` raises ambiguous, sent once."""
+    httpx_mock.add_exception(httpx.ConnectError("dropped"))
+    sleep = _RecordingSleep()
+    http = AsyncHTTPClient(exchange="kraken", max_retries=3, sleep=sleep)
+    broker = _broker(monkeypatch, http=http)
+    order = Order(
+        client_order_id="cid-drop",
+        instrument=BTC_USD,
+        side=OrderSide.SELL,
+        qty=money("1"),
+        type=OrderType.MARKET,
+    )
+
+    with pytest.raises(AmbiguousRequestError, match="reconcile"):
+        await broker.place_order(order)
+
+    assert len(httpx_mock.get_requests()) == 1
+    assert sleep.calls == []
+
+
+async def test_balances_still_retries_idempotent_read(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An idempotent private read (``Balance``) still retries a transient 5xx.
+
+    The retry opt-out is scoped to ``AddOrder``; the query endpoints keep their
+    bounded retry (a duplicate read is harmless).
+    """
+    httpx_mock.add_response(status_code=503, text="blip")
+    httpx_mock.add_response(json={"error": [], "result": {"ZUSD": "100.0"}})
+    sleep = _RecordingSleep()
+    http = AsyncHTTPClient(exchange="kraken", max_retries=3, sleep=sleep)
+    broker = _broker(monkeypatch, http=http)
+
+    balances = await broker.balances()
+
+    assert balances == {"USD": Decimal("100.0")}
+    # Two attempts (one retried 5xx) → one backoff sleep: the read path is intact.
+    assert len(httpx_mock.get_requests()) == 2
+    assert len(sleep.calls) == 1
 
 
 # --- ticker (public, mocked) ---------------------------------------------- #

--- a/trading_bot/tests/interfaces/test_cli_commands.py
+++ b/trading_bot/tests/interfaces/test_cli_commands.py
@@ -254,6 +254,68 @@ def test_kpi_renders_realised_pnl(tmp_path: pathlib.Path) -> None:
     assert "Sharpe" in result.output
 
 
+def test_kpi_default_capital_anchors_equity_endpoint(
+    tmp_path: pathlib.Path,
+) -> None:
+    """With no ``--capital`` / ``--config`` the built-in 100000 default anchors.
+
+    The realised PnL is 1000 (buy 2 @ 30000, sell 1 @ 31000), so the equity
+    endpoint is ``100000 + 1000 = 101000``.
+    """
+    db = tmp_path / "kpi.db"
+    _seed_store(db)
+
+    result = runner.invoke(app, ["kpi", "--db", str(db)])
+
+    assert result.exit_code == 0, result.output
+    assert "101000" in result.output  # 100000 default + 1000 realised
+
+
+def test_kpi_explicit_capital_overrides_default(tmp_path: pathlib.Path) -> None:
+    """`--capital` wins: equity endpoint anchors to the flag, not the default."""
+    db = tmp_path / "kpi.db"
+    _seed_store(db)
+
+    result = runner.invoke(app, ["kpi", "--db", str(db), "--capital", "5000"])
+
+    assert result.exit_code == 0, result.output
+    assert "6000" in result.output  # 5000 capital + 1000 realised
+    assert "101000" not in result.output  # not the default anchor
+
+
+def test_kpi_config_starting_capital_used_when_no_capital_flag(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A ``--config`` ``starting_capital`` anchors the curve absent ``--capital``."""
+    db = tmp_path / "kpi.db"
+    _seed_store(db)
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("starting_capital: \"200000\"\n")
+
+    result = runner.invoke(app, ["kpi", "--db", str(db), "--config", str(cfg)])
+
+    assert result.exit_code == 0, result.output
+    assert "201000" in result.output  # 200000 config + 1000 realised
+
+
+def test_kpi_capital_flag_beats_config_starting_capital(
+    tmp_path: pathlib.Path,
+) -> None:
+    """Precedence: explicit ``--capital`` > config ``starting_capital``."""
+    db = tmp_path / "kpi.db"
+    _seed_store(db)
+    cfg = tmp_path / "cfg.yml"
+    cfg.write_text("starting_capital: \"200000\"\n")
+
+    result = runner.invoke(
+        app, ["kpi", "--db", str(db), "--config", str(cfg), "--capital", "5000"]
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "6000" in result.output  # 5000 flag wins
+    assert "201000" not in result.output  # not the config anchor
+
+
 # --- _render helpers (no CLI) ---------------------------------------------- #
 
 

--- a/trading_bot/tests/transport/test_http.py
+++ b/trading_bot/tests/transport/test_http.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 import httpx
 import pytest
 
-from trading_bot.transport import AsyncHTTPClient, HTTPError
+from trading_bot.transport import (
+    AmbiguousRequestError,
+    AsyncHTTPClient,
+    HTTPError,
+)
 
 
 class RecordingSleep:
@@ -128,6 +132,140 @@ async def test_retries_on_transport_error(httpx_mock) -> None:
         result = await client.get("https://example.test/flaky")
 
     assert result == {"recovered": True}
+    assert sleep.calls == [pytest.approx(0.5)]
+
+
+# --- non-idempotent POST: retry=False (venue-idempotency guard) ------------ #
+
+
+async def test_post_no_retry_succeeds_at_most_once(httpx_mock) -> None:
+    """A ``retry=False`` POST that succeeds is sent exactly once, returns JSON."""
+    httpx_mock.add_response(status_code=200, json={"txid": ["OABC-1"]})
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(sleep=sleep) as client:
+        result = await client.post(
+            "https://example.test/AddOrder",
+            data={"pair": "XBTUSD"},
+            retry=False,
+        )
+
+    assert result == {"txid": ["OABC-1"]}
+    # Exactly one request was made; no backoff sleep.
+    assert len(httpx_mock.get_requests()) == 1
+    assert sleep.calls == []
+
+
+async def test_post_no_retry_5xx_raises_ambiguous_not_retried(httpx_mock) -> None:
+    """A 5xx on a ``retry=False`` POST → ``AmbiguousRequestError``, sent once.
+
+    The order may have landed at the venue before the 5xx; the client must NOT
+    retry (that could double-submit) and must signal the caller to reconcile.
+    """
+    httpx_mock.add_response(status_code=503, text="upstream down")
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(max_retries=3, sleep=sleep) as client:
+        with pytest.raises(AmbiguousRequestError) as exc_info:
+            await client.post(
+                "https://example.test/AddOrder",
+                data={"pair": "XBTUSD"},
+                retry=False,
+            )
+
+    # Exactly one attempt (no retry), no backoff sleep.
+    assert len(httpx_mock.get_requests()) == 1
+    assert sleep.calls == []
+    # The error tells the caller to reconcile, never blind-retry.
+    msg = str(exc_info.value)
+    assert "reconcile" in msg
+    assert "503" in msg
+
+
+async def test_post_no_retry_transport_error_raises_ambiguous(httpx_mock) -> None:
+    """A transport error on a ``retry=False`` POST → ``AmbiguousRequestError``.
+
+    A dropped connection after the request left is the canonical ambiguous case.
+    """
+    httpx_mock.add_exception(httpx.ConnectError("boom"))
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(max_retries=3, sleep=sleep) as client:
+        with pytest.raises(AmbiguousRequestError, match="reconcile"):
+            await client.post(
+                "https://example.test/AddOrder",
+                data={"pair": "XBTUSD"},
+                retry=False,
+            )
+
+    assert sleep.calls == []
+
+
+async def test_post_no_retry_429_raises_ambiguous(httpx_mock) -> None:
+    """A 429 on a ``retry=False`` POST → ``AmbiguousRequestError`` (not retried)."""
+    httpx_mock.add_response(status_code=429, headers={"Retry-After": "3"})
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(sleep=sleep) as client:
+        with pytest.raises(AmbiguousRequestError, match="reconcile"):
+            await client.post(
+                "https://example.test/AddOrder",
+                data={"pair": "XBTUSD"},
+                retry=False,
+            )
+
+    assert sleep.calls == []
+
+
+async def test_post_no_retry_4xx_raises_http_error_not_ambiguous(httpx_mock) -> None:
+    """A definite 4xx on a ``retry=False`` POST raises ``HTTPError`` (not ambiguous).
+
+    A 4xx rejection definitely did NOT take effect, so there is nothing to
+    reconcile: it is the ordinary non-retryable :class:`HTTPError`, same as the
+    retrying path.
+    """
+    httpx_mock.add_response(status_code=400, text="bad request")
+
+    async with AsyncHTTPClient() as client:
+        with pytest.raises(HTTPError) as exc_info:
+            await client.post(
+                "https://example.test/AddOrder",
+                data={"pair": "XBTUSD"},
+                retry=False,
+            )
+
+    assert exc_info.value.status == 400
+    assert not isinstance(exc_info.value, AmbiguousRequestError)
+
+
+async def test_post_default_retries_5xx_then_succeeds(httpx_mock) -> None:
+    """The default (``retry=True``) POST path is unchanged: 5xx is retried.
+
+    Proves the opt-out is opt-*in*: an idempotent POST still gets bounded retry.
+    """
+    httpx_mock.add_response(status_code=503)
+    httpx_mock.add_response(status_code=200, json={"ok": True})
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(backoff_base=0.5, sleep=sleep) as client:
+        result = await client.post(
+            "https://example.test/Balance", data={"nonce": "1"}
+        )
+
+    assert result == {"ok": True}
+    assert sleep.calls == [pytest.approx(0.5)]
+
+
+async def test_get_path_unchanged_by_retry_flag(httpx_mock) -> None:
+    """GET keeps retrying 5xx (the idempotent read path is never opted out)."""
+    httpx_mock.add_response(status_code=503)
+    httpx_mock.add_response(status_code=200, json={"ok": 1})
+    sleep = RecordingSleep()
+
+    async with AsyncHTTPClient(backoff_base=0.5, sleep=sleep) as client:
+        result = await client.get("https://example.test/data")
+
+    assert result == {"ok": 1}
     assert sleep.calls == [pytest.approx(0.5)]
 
 

--- a/trading_bot/transport/__init__.py
+++ b/trading_bot/transport/__init__.py
@@ -7,8 +7,11 @@ broker layer) and no domain business logic.
 Public surface:
 
 * :class:`~trading_bot.transport.http.AsyncHTTPClient` — async httpx wrapper with
-  retry/backoff, timeouts, and ``get`` / ``post``;
+  retry/backoff, timeouts, and ``get`` / ``post`` (the latter with an
+  opt-out-of-retries ``retry`` flag for non-idempotent POSTs);
 * :class:`~trading_bot.transport.http.HTTPError` — transport-local HTTP failure.
+* :class:`~trading_bot.transport.http.AmbiguousRequestError` — a non-retryable
+  request failed ambiguously (reconcile before retrying).
 * :class:`~trading_bot.transport.ws.WebSocketBase` — async WebSocket base with
   ``stream_raw`` and exponential reconnect.
 * :class:`~trading_bot.transport.ratelimit.RateLimiter` /
@@ -20,7 +23,11 @@ Public surface:
 
 from __future__ import annotations
 
-from trading_bot.transport.http import AsyncHTTPClient, HTTPError
+from trading_bot.transport.http import (
+    AmbiguousRequestError,
+    AsyncHTTPClient,
+    HTTPError,
+)
 from trading_bot.transport.ratelimit import (
     KrakenCallCounter,
     RateLimiter,
@@ -29,6 +36,7 @@ from trading_bot.transport.ratelimit import (
 from trading_bot.transport.ws import WebSocketBase
 
 __all__ = [
+    "AmbiguousRequestError",
     "AsyncHTTPClient",
     "HTTPError",
     "KrakenCallCounter",

--- a/trading_bot/transport/http.py
+++ b/trading_bot/transport/http.py
@@ -9,6 +9,19 @@ domain business logic — :class:`HTTPError` is a transport-local error type.
 Mirrors ``dccd.transport.http.AsyncHTTPClient``; adapted for execution by adding
 :meth:`AsyncHTTPClient.post` (order placement is a POST) and an injectable
 ``sleep`` seam so retry timing is testable without real waits.
+
+Idempotency of POST retries
+---------------------------
+A blind retry is safe only for an **idempotent** request — one a duplicate of
+which has no extra effect. GETs and idempotent POSTs (balance/open-orders/
+trade-history queries) retry freely. But a non-idempotent POST — placing an
+order — must **not** be blindly retried: after an *ambiguous* failure (the order
+landed at the venue but the response was lost to a 5xx or a dropped connection),
+a retry would submit a **second** order. :meth:`AsyncHTTPClient.post` therefore
+takes a ``retry`` flag; with ``retry=False`` the request is sent **at most
+once** and an ambiguous failure raises :class:`AmbiguousRequestError` telling the
+caller to *reconcile before retrying* — never to blind-retry. See
+:meth:`trading_bot.brokers.kraken.KrakenBroker.place_order`.
 """
 
 from __future__ import annotations
@@ -22,7 +35,7 @@ import httpx
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Mapping
 
-__all__ = ["AsyncHTTPClient", "HTTPError"]
+__all__ = ["AsyncHTTPClient", "AmbiguousRequestError", "HTTPError"]
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +65,36 @@ class HTTPError(Exception):
         self.url = url
         self.body = body
         super().__init__(f"HTTP {status} from {url}: {body[:200]}")
+
+
+class AmbiguousRequestError(Exception):
+    """A non-retryable request failed *ambiguously* — outcome unknown.
+
+    Raised by :meth:`AsyncHTTPClient.post` with ``retry=False`` when a single
+    attempt fails on a 5xx / 429 / transport error: the request may or may not
+    have taken effect at the server (e.g. an order that landed but whose response
+    was lost). Because the request is non-idempotent, the client refuses to
+    retry — a retry could duplicate the effect — and surfaces this error instead.
+    The caller must **reconcile** the server's actual state before deciding
+    whether to retry; it must **never** blind-retry.
+
+    Parameters
+    ----------
+    url : str
+        Target URL of the ambiguous request.
+    reason : str
+        Human-readable description of the failure that made the outcome
+        ambiguous (status code or transport error).
+    """
+
+    def __init__(self, url: str, reason: str) -> None:
+        self.url = url
+        self.reason = reason
+        super().__init__(
+            f"ambiguous non-idempotent request to {url}: {reason}; "
+            "the request may have taken effect — reconcile before retrying "
+            "(never blind-retry a non-idempotent request)"
+        )
 
 
 class _Limiter(Protocol):
@@ -185,8 +228,9 @@ class AsyncHTTPClient:
         data: Mapping[str, Any] | None = None,
         json: Any | None = None,
         headers: Mapping[str, str] | None = None,
+        retry: bool = True,
     ) -> Any:
-        """Perform a POST request with retry/backoff. Returns parsed JSON.
+        """Perform a POST request. Returns parsed JSON.
 
         Parameters
         ----------
@@ -198,6 +242,16 @@ class AsyncHTTPClient:
             JSON body (mutually exclusive with *data*, per httpx).
         headers : mapping, optional
             Per-request headers, merged over the client defaults.
+        retry : bool, default True
+            Whether transient failures (5xx / 429 / transport errors) may be
+            retried with backoff. ``True`` (the default) is for **idempotent**
+            POSTs (balance / open-orders / trade-history queries). Pass
+            ``False`` for a **non-idempotent** POST (placing an order): the
+            request is then sent **at most once** and an ambiguous transient
+            failure raises :class:`AmbiguousRequestError` rather than risking a
+            duplicate by retrying. A definite 4xx rejection still raises
+            :class:`HTTPError` either way (it did not take effect, nothing to
+            reconcile).
 
         Returns
         -------
@@ -207,10 +261,14 @@ class AsyncHTTPClient:
         Raises
         ------
         HTTPError
-            On a non-retryable 4xx, or once retries are exhausted.
+            On a non-retryable 4xx, or (when ``retry=True``) once retries are
+            exhausted.
+        AmbiguousRequestError
+            When ``retry=False`` and the single attempt fails on a 5xx / 429 /
+            transport error — the outcome is unknown; reconcile before retrying.
         """
         return await self._request(
-            "POST", url, data=data, json=json, headers=headers
+            "POST", url, data=data, json=json, headers=headers, retry=retry
         )
 
     async def _request(
@@ -222,16 +280,28 @@ class AsyncHTTPClient:
         data: Mapping[str, Any] | None = None,
         json: Any | None = None,
         headers: Mapping[str, str] | None = None,
+        retry: bool = True,
     ) -> Any:
-        """Shared retry/backoff loop for GET and POST."""
+        """Shared request loop for GET and POST.
+
+        With ``retry=True`` (the default) transient failures (5xx / 429 /
+        transport) are retried with backoff up to ``max_retries``. With
+        ``retry=False`` the request is attempted **once**; a transient failure
+        then raises :class:`AmbiguousRequestError` instead of retrying, so a
+        non-idempotent request is never duplicated.
+        """
         client = self._client
         if client is None:
             raise RuntimeError(
                 "AsyncHTTPClient must be used as an async context manager"
             )
 
+        # A non-retrying request is attempted exactly once; the retrying path
+        # keeps its bounded-retry budget unchanged.
+        max_attempts = self._max_retries if retry else 1
+
         last_exc: Exception | None = None
-        for attempt in range(self._max_retries):
+        for attempt in range(max_attempts):
             try:
                 # Proactive throttle: wait for a token before each outbound
                 # request so concurrent operations on the same exchange stay
@@ -250,6 +320,10 @@ class AsyncHTTPClient:
                 )
 
                 if resp.status_code == 429:
+                    if not retry:
+                        raise AmbiguousRequestError(
+                            url, f"HTTP 429 (rate-limited): {resp.text[:200]}"
+                        )
                     wait = self._retry_after(resp, attempt)
                     logger.warning(
                         "Rate-limited by %s, sleeping %.1fs", url, wait
@@ -259,6 +333,10 @@ class AsyncHTTPClient:
                     continue
 
                 if resp.status_code >= 500:
+                    if not retry:
+                        raise AmbiguousRequestError(
+                            url, f"HTTP {resp.status_code}: {resp.text[:200]}"
+                        )
                     wait = self._backoff(attempt)
                     logger.warning(
                         "HTTP %d from %s, retry in %.1fs",
@@ -276,6 +354,12 @@ class AsyncHTTPClient:
                 return resp.json()
 
             except httpx.TransportError as exc:
+                if not retry:
+                    # The request may have reached the server before the
+                    # connection dropped — outcome unknown. Refuse to retry.
+                    raise AmbiguousRequestError(
+                        url, f"transport error: {exc}"
+                    ) from exc
                 wait = self._backoff(attempt)
                 logger.warning(
                     "Transport error %s (attempt %d/%d), retry in %.1fs",


### PR DESCRIPTION
## Summary
- Second leaf of **E10**: closes the three recorded known gaps (offline; live still off).
  - **(a) KPI v0** — `AppConfig.starting_capital` (default 100000) wired into `PerformanceService(v0=)`; KPI ratios are now meaningful (Sharpe 15.97 vs 0.0). CLI `kpi --capital` overrides; the API `_safe_ratio` also coerces `inf`/`nan`→0.0.
  - **(b) same-instrument** — `build_runners` **rejects** two strategies on the same symbol (`ConfigError`, alias-aware: `XBT/USD`≡`BTC/USD`).
  - **(c) AddOrder retry** — `AsyncHTTPClient.post(retry=False)` → at-most-once + `AmbiguousRequestError`; `KrakenBroker.place_order` uses it (idempotent reads keep retrying), closing the blind-retry double-submit window.

## Why
- (a)/(b) make observability + orchestration honest; (c) closes the transport-level double-submit the router's in-memory dedup didn't cover. **Still deferred to a real-key sandbox**: venue-side dedup token surviving an engine crash. See `doc/dev/03-decisions.md`; `06-status` known-gaps updated (3 resolved).

## Changes
- `config.py` (+starting_capital), `service_factory.py` (v0), `run_app.py` (reject same-symbol), `cli/main.py` (kpi capital precedence), `transport/http.py` (`retry` flag + `AmbiguousRequestError`), `brokers/kraken.py` (AddOrder non-retry + docstrings), `api/app.py` (inf/nan→0.0); +27 tests.

## Test plan
- [x] `.venv/bin/python -m pytest` (559 passed, 0 unexpected skips)
- [x] verified myself: capital wired (Sharpe non-zero), same-symbol+alias rejected, AddOrder non-retryable
- [x] `ruff` + `mypy` clean