### PR TITLE
feat: go-live runbook + LiveTradingNotEnabled opt-in (closes E10; rewrite complete)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   under **fault injection** (a `FaultyBroker` over `PaperBroker`): reconciliation
   converges after a simulated disconnect (no order duplicated/lost), idempotent submit
   survives retries/ambiguous failures, and the kill-switch cancels + halts mid-run.
+- Go-live runbook (`doc/dev/09-go-live.md`) + a `LiveTradingNotEnabled` opt-in guard:
+  live trading is **off by default** — `mode: live` alone is refused; it requires
+  `AppConfig.live_enabled` **and** credentials. The live adapter is only constructed,
+  never called — **no real order is ever sent**. Completes the **E10 go-live
+  hardening** (the final project name stays deferred).
 - `AppConfig.starting_capital` (default 100000) — wired into `PerformanceService(v0=)`
   so the KPI ratios (Sharpe/Sortino/max-drawdown/Calmar) are **meaningful** (the equity
   curve no longer starts at zero and sign-crosses); CLI `kpi --capital` overrides it.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,29 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-28 Go-live is an off-by-default opt-in; rewrite feature-complete
+
+**Decision.** Going live is an explicit, documented, **off-by-default** opt-in:
+`mode: live` alone is insufficient — `AppConfig.live_enabled` (default `False`) is a
+second gate that `build_engine` checks **before** credentials, raising
+`LiveTradingNotEnabled` (pointing at `doc/dev/09-go-live.md`) when not set; the CLI
+`run --live` mirrors it (interactive ack **and** `live_enabled`, else a clear refusal
+that places nothing). Even when enabled with credentials, the live `KrakenBroker` is
+only *constructed*, never called — **no real order is ever sent from this repo**. The
+runbook documents the deliberate enable steps, the pre-trade safety checklist, and a
+proven-vs-pending table. This closes **E10** and the E1–E10 rewrite: a feature-complete
+hexagonal engine (paper-validated, hardened under fault injection) conducting the
+triptych via CLI + web UI.
+
+**Why.** Paper-by-default + a second explicit opt-in makes "no live by accident"
+structural at every layer (config, factory, CLI). The one remaining live prerequisite —
+**validating private endpoints + venue-level idempotency against a real-key sandbox** —
+is intentionally out of the repo (needs a real key, maintainer decision). **Still
+deferred:** the **final project name** (kept `trading_bot`) and real-key live
+enablement; both stay open in the roadmap.
+
+---
+
 ### 2026-06-28 Close known gaps: KPI capital, reject same-symbol, AddOrder non-retry
 
 **Decision.** Three recorded gaps closed (offline; live still off):

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -1,14 +1,37 @@
 # 06 — Status
 
-_Last updated: 2026-06-20_
+_Last updated: 2026-06-28_
 
 ## Where things stand
 
-**Phase 0 (bootstrap) — done / in this branch.** The repo now has the dccd/fynance
-developer standard: `pyproject.toml`, ruff/mypy/pytest/interrogate, pre-commit,
-GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
-`.claude/` workflow + hooks, and this `doc/dev/` pack. The package imports and a
-smoke test passes.
+**The E1–E10 rewrite is complete — the engine is feature-complete and hardened.**
+Phase 0 (tooling) plus all ten epics shipped: `domain/` (pure, mypy-strict),
+`transport/` (http/ws/ratelimit), `brokers/` (`Broker` port + `KrakenBroker` REST+WS +
+port-pure `PaperBroker`), `storage/` (`SqliteStore`, money as TEXT), `application/`
+(declarative `AppConfig`+`EventBus`, idempotent risk-gated `OrderRouter`,
+`PositionTracker`, `reconcile`, `Strategy`+safe loader, causal `DataFeed`+`feed_for`,
+`StrategyRunner`, `PerformanceService`, `RiskManager`+kill-switch, `Orchestrator`,
+`run_app`, `service_factory`), and `interfaces/` (Typer `trading-bot` CLI +
+read-only FastAPI `api`/Jinja2 `ui`). One `AppConfig` conducts the triptych — dccd
+data (library import) + fynance signals + brokers — and `trading-bot run <config>`
+runs the whole declared multi-strategy system (paper by default); `trading-bot serve`
+exposes the read-only dashboard. The money-safety invariants (reconcile convergence,
+idempotency, kill-switch) are **proven under fault injection** (`tests/hardening/`).
+**Live trading is off by default** behind an explicit `live_enabled` opt-in +
+credentials + the go-live runbook (`doc/dev/09-go-live.md`) — **no real order is ever
+sent from the repo**. ~570 tests green via the project `.venv`; ruff + mypy clean
+across the whole package.
+
+**Remaining (maintainer decisions, see `07-roadmap.md`):** the **final project name**
+(kept `trading_bot`), and **real-key live enablement** (validate Kraken private
+endpoints + venue-level idempotency against a real-key sandbox, then flip
+`live_enabled`).
+
+### Bootstrap (Phase 0, historical)
+
+The dccd/fynance developer standard: `pyproject.toml`, ruff/mypy/pytest/interrogate,
+pre-commit, GitHub Actions CI (3.11–3.13), Git Flow (`develop`/`master`), `CLAUDE.md`,
+`.claude/` workflow + hooks, and this `doc/dev/` pack.
 
 **E1–E9 are complete — only go-live hardening (E10) remains.** Trading_Bot conducts
 the triptych: one `AppConfig` declares data (dccd) + strategies (fynance) + brokers +

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -10,8 +10,15 @@ The single source *index* of open work. Each unchecked item is a candidate for
 > **Full decomposition** — every epic broken into its leaves, branches,
 > complexity and dependencies: [`08-program-plan.md`](08-program-plan.md).
 
-## Later
+**The E1–E10 rewrite is complete.** The hexagonal engine conducts the triptych
+(dccd data + fynance signals + brokers) via the `trading-bot` CLI and a read-only web
+dashboard; paper-by-default, hardened under fault injection, live behind an explicit
+off-by-default opt-in. History in git + `CHANGELOG.md`; see `06-status.md`.
 
-- [ ] **E10 — Go-live hardening & final name.** Live-trading checklist
-  (reconciliation, kill-switch, idempotency proven under fault injection); choose
-  and apply the final project name. _(depends on E8)_
+## Open / deferred (maintainer decisions)
+
+- [ ] **Final project name.** Kept `trading_bot` for now — choose and apply a final
+  name when ready (touches the package/repo/docs).
+- [ ] **Real-key live enablement.** Validate Kraken private endpoints + venue-level
+  order idempotency against a **real-key sandbox**, then flip `live_enabled` — the one
+  remaining prerequisite before real-money trading. See `doc/dev/09-go-live.md`.

--- a/doc/dev/09-go-live.md
+++ b/doc/dev/09-go-live.md
@@ -1,0 +1,134 @@
+# Go-live runbook
+
+> **Live trading is OFF by default and gated.** Paper trading is the default and
+> is fully working; trading real money is a deliberate, multi-step opt-in. Nothing
+> in this repository sends a real order on its own — the live venue adapter is not
+> even constructed until you have explicitly opted in. **Never risk money you
+> cannot afford to lose.**
+
+This runbook is the single source of truth for *how* to go live, *what is proven*
+offline, and *what still needs a real-key sandbox* before any real order. Read it
+in full before flipping any switch.
+
+---
+
+## Status
+
+- **Paper-trading is the default and fully working.** A fresh `AppConfig` is
+  `mode: paper`, `live_enabled: false`; the engine wires a
+  [`PaperBroker`](../../trading_bot/brokers/paper.py) — no venue, no key, no
+  network. A fresh config can never trade real money by accident.
+- **Live is off by default and gated by two independent opt-ins** plus
+  credentials (see below).
+- The hardening suite (`trading_bot/tests/hardening/`) proves the safety-critical
+  paths **offline** against the `PaperBroker` and fault-injecting fakes. What it
+  cannot prove without a real key is listed in *Proven vs pending*.
+
+---
+
+## The opt-in gates (all required to go live)
+
+Going live requires **all** of the following — each is an independent gate, and
+missing any one refuses with a non-zero exit / a raised
+`LiveTradingNotEnabled` (or `BrokerError`) and **places no order**:
+
+1. **`mode: live`** in the config (`AppConfig.mode`). Default `paper`.
+2. **`live_enabled: true`** in the config (`AppConfig.live_enabled`). Default
+   `false`. This is the explicit "I have read the runbook" opt-in — flipping
+   `mode` alone is not enough. The factory
+   ([`build_engine`](../../trading_bot/application/service_factory.py)) raises
+   `LiveTradingNotEnabled` (pointing here) when `mode == "live"` and this is
+   `false`, **before it ever looks at credentials**.
+3. **Credentials** — `KRAKEN_API_KEY` / `KRAKEN_API_SECRET` in the environment
+   (via a gitignored `.env`, never committed). With `live_enabled: true` but no
+   credentials the factory raises `BrokerError`.
+4. **CLI acknowledgement** — `trading-bot run --live` additionally requires
+   `--yes-i-understand` (or an interactive confirmation) *and* re-checks
+   `live_enabled`. Missing either, the command refuses and points here.
+
+---
+
+## To enable live trading — the deliberate steps
+
+1. **Read this runbook.** (You are here.)
+2. **Provide credentials.** Put your Kraken keys in a gitignored `.env`:
+
+   ```
+   KRAKEN_API_KEY=...
+   KRAKEN_API_SECRET=...        # base64, as Kraken issues it
+   ```
+
+   `.env` is gitignored — **never commit secrets**, never log keys (the broker
+   redacts them).
+3. **Opt in, in the config.** Set both flags in your `AppConfig` YAML:
+
+   ```yaml
+   mode: live
+   live_enabled: true
+   ```
+4. **Run the hardening suite** and the full test suite — both must be green:
+
+   ```bash
+   .venv/bin/python -m pytest -q
+   .venv/bin/ruff check trading_bot/
+   .venv/bin/mypy trading_bot/
+   ```
+5. **Validate against a real-key sandbox.** This is the one remaining
+   prerequisite and is **not done in-repo**: before any real order, exercise the
+   private endpoints (AddOrder / OpenOrders / balances / fills) against a real
+   Kraken key (ideally a low-limit, throwaway key) and confirm the
+   venue-reported state matches what the engine requested — see *Proven vs
+   pending*. **Do not skip this.**
+
+Only after all five does a live `run` proceed to wire the live adapter.
+
+---
+
+## Pre-trade safety checklist
+
+Before the first live order, confirm every item:
+
+- [ ] **Risk limits set** in `RiskConfig`: `max_order` (largest single order),
+      `max_position` (largest net exposure), `max_daily_loss` (the halt
+      threshold). An unset limit is *unconstrained* — set them deliberately.
+- [ ] **Kill-switch tested** — confirm the `RiskManager` kill-switch cancels open
+      orders and halts new ones (covered offline by the hardening suite).
+- [ ] **Reconcile-on-startup** — on start and after any disconnect the engine
+      refetches open orders + balances + fills and reconciles local state;
+      confirm it converges (proven offline).
+- [ ] **Strategy paper-validated** — the exact strategy you intend to run has
+      been validated in `mode: paper` over representative data and behaves as
+      expected.
+- [ ] **`starting_capital` set** to your real account value (anchors the KPI
+      equity curve).
+- [ ] **Credentials present and correct**, scoped to the minimum permissions
+      needed, and a small position/order size for the first live run.
+
+---
+
+## Proven vs pending
+
+| Concern | Proven offline (`tests/hardening/`) | Pending — needs a real-key sandbox |
+|---|---|---|
+| Reconciliation | Reconcile converges local state to broker-reported open orders / balances / fills after a disconnect | Real private-endpoint reads (OpenOrders / balances / fills) against a live key |
+| Idempotency | **Engine-side** idempotency: a retried submit with the same client-order-id never double-submits locally | **Venue-level** idempotency token: Kraken honouring the client-order-id so a retry never creates a duplicate *at the venue* |
+| Ambiguous failures | Ambiguous submit failures (timeout / unknown outcome) are surfaced, not silently assumed filled or failed | Real network-edge behaviour against the live API |
+| Kill-switch | Kill-switch cancels open orders + halts new ones | Real cancel against the venue |
+| Order placement | Full order lifecycle against the `PaperBroker` | **A real AddOrder has never been sent from this repo** |
+
+The left column is what the offline suite demonstrates today. The right column is
+the one remaining bridge to live — it requires a real key and is **out of scope
+for this repository's automated tests** (which never hit a real venue).
+
+---
+
+## Disclaimers
+
+- **Paper is the default.** Live is off by default and must be opted into
+  deliberately, per the gates above.
+- **No real order is ever sent by this repository's code paths or tests.** The
+  live adapter is constructed only after every opt-in passes, and constructing it
+  sends nothing.
+- **Never risk money you cannot afford to lose.** Live trading uses real money;
+  the authors provide no warranty. You are responsible for your keys, your risk
+  limits, and your trades.

--- a/doc/dev/plans/go-live-hardening/00-plan.md
+++ b/doc/dev/plans/go-live-hardening/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: go-live-hardening
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E10 — Go-live hardening & final name.** Live-trading checklist (reconciliation, kill-switch, idempotency proven under fault injection); choose and apply the final project name."
 release_on_done: false
 ---
@@ -33,7 +33,7 @@ explicitly turned on, with a real-key sandbox the only thing left to do later).
 
 - [x] 01 fault-injection — test/go-live-hardening — high
 - [x] 02 close-known-gaps — feat/close-known-gaps — high
-- [ ] 03 go-live-runbook — feat/go-live-opt-in — medium (depends on 01, 02)
+- [x] 03 go-live-runbook — feat/go-live-opt-in — medium (depends on 01, 02)
 
 ## Dependencies
 

--- a/doc/dev/plans/go-live-hardening/03-go-live-runbook.md
+++ b/doc/dev/plans/go-live-hardening/03-go-live-runbook.md
@@ -1,7 +1,7 @@
 ---
 plan: go-live-hardening/03-go-live-runbook
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: [01, 02]
 parallel: false

--- a/doc/dev/plans/go-live-hardening/03-go-live-runbook.md
+++ b/doc/dev/plans/go-live-hardening/03-go-live-runbook.md
@@ -6,7 +6,7 @@ complexity: medium
 depends: [01, 02]
 parallel: false
 branch: feat/go-live-opt-in
-pr: ""
+pr: "#55"
 ---
 
 # Go-live runbook + explicit opt-in guard (live OFF by default)

--- a/examples/config.example.yaml
+++ b/examples/config.example.yaml
@@ -9,6 +9,12 @@
 
 mode: paper
 
+# Live trading is OFF by default. Beyond `mode: live`, going live also requires
+# this explicit opt-in (and credentials + reading the runbook doc/dev/09-go-live.md).
+# Flipping `mode` alone is not enough: the engine raises LiveTradingNotEnabled
+# until `live_enabled: true` is set. Leave it false for paper.
+live_enabled: false
+
 # Starting account capital (quote units) that anchors the equity curve the KPI
 # ratios (Sharpe/Sortino/Calmar) are computed over: equity = starting_capital +
 # cumulative realised PnL. Must be strictly positive (keeps the curve off zero so

--- a/trading_bot/application/config.py
+++ b/trading_bot/application/config.py
@@ -12,6 +12,12 @@ Design choices (carried into the ADR):
   trades real money by accident. Switching to ``"live"`` is always an explicit,
   deliberate edit. ``mode`` is a ``Literal["paper", "live"]`` so any other value
   is rejected at validation time.
+* **Live is off by default — a second opt-in gate.** Beyond ``mode``, going live
+  also requires ``live_enabled: true`` (default ``False``). The factory raises
+  :class:`~trading_bot.domain.errors.LiveTradingNotEnabled` for ``mode == "live"``
+  while ``live_enabled`` is ``False``, so flipping ``mode`` alone never reaches a
+  real venue. Enabling live is a documented, deliberate choice — read the go-live
+  runbook (``doc/dev/09-go-live.md``) and provide credentials.
 * **Money stays exact.** Risk limits (:class:`RiskConfig`) and the
   ``starting_capital`` are :class:`~decimal.Decimal`, parsed from ``str``/``int``
   without ever touching ``float`` — pydantic builds a ``Decimal`` directly from
@@ -291,6 +297,14 @@ class AppConfig(BaseModel):
         Execution mode. Defaults to ``"paper"`` so a fresh config never trades
         real money by accident; ``"live"`` must be set deliberately. Any other
         value is rejected.
+    live_enabled : bool, optional
+        The explicit, off-by-default opt-in for live trading. Defaults to
+        ``False``: even with ``mode == "live"`` and credentials present,
+        :func:`~trading_bot.application.service_factory.build_engine` raises
+        :class:`~trading_bot.domain.errors.LiveTradingNotEnabled` until this is
+        set ``True``. Set it ``True`` *and* provide credentials *and* read the
+        go-live runbook (``doc/dev/09-go-live.md``) to trade real money. Paper
+        mode ignores it entirely.
     starting_capital : Decimal, optional
         Initial account capital (quote units) that anchors the equity curve the
         KPI ratios are computed over (``equity = starting_capital + cumulative
@@ -326,6 +340,7 @@ class AppConfig(BaseModel):
     """
 
     mode: Literal["paper", "live"] = "paper"
+    live_enabled: bool = False
     starting_capital: Decimal = Field(default_factory=lambda: money("100000"))
     brokers: list[BrokerConfig] = Field(default_factory=list)
     strategies: list[StrategyConfig] = Field(default_factory=list)

--- a/trading_bot/application/service_factory.py
+++ b/trading_bot/application/service_factory.py
@@ -29,11 +29,17 @@ The **paper-by-default** invariant lives here. The broker is chosen by
 * ``mode == "paper"`` (the :class:`AppConfig` default) → always a
   :class:`~trading_bot.brokers.paper.PaperBroker`. No venue, no key, no network
   — a fresh config can never trade real money.
-* ``mode == "live"`` → the configured venue's adapter is built **only if it has
-  credentials**. The first :class:`~trading_bot.application.config.BrokerConfig`
-  selects the venue (``exchange``); a known live venue (``"kraken"``) without
-  credentials, an unknown venue, or no broker configured at all each raise a
-  clear :class:`~trading_bot.domain.errors.BrokerError` — the factory **never**
+* ``mode == "live"`` → live is **off by default**. The factory first checks the
+  explicit opt-in :attr:`~trading_bot.application.config.AppConfig.live_enabled`:
+  while it is ``False`` (the default), live raises
+  :class:`~trading_bot.domain.errors.LiveTradingNotEnabled` (pointing at the
+  go-live runbook, ``doc/dev/09-go-live.md``) — so flipping ``mode`` alone never
+  reaches a real venue. Only when ``live_enabled`` is ``True`` does the venue's
+  adapter get built, and then **only if it has credentials**. The first
+  :class:`~trading_bot.application.config.BrokerConfig` selects the venue
+  (``exchange``); a known live venue (``"kraken"``) without credentials, an
+  unknown venue, or no broker configured at all each raise a clear
+  :class:`~trading_bot.domain.errors.BrokerError` — the factory **never**
   silently falls back to paper and **never** trades live by accident.
 
 A ``"paper"`` exchange entry is also honoured under either mode, so a config can
@@ -54,7 +60,7 @@ from trading_bot.application.risk import RiskManager
 from trading_bot.brokers.base import Broker
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.paper import PaperBroker
-from trading_bot.domain.errors import BrokerError
+from trading_bot.domain.errors import BrokerError, LiveTradingNotEnabled
 from trading_bot.storage.sqlite_store import SqliteStore
 
 __all__ = ["Engine", "build_engine"]
@@ -63,6 +69,8 @@ __all__ = ["Engine", "build_engine"]
 _LIVE_VENUES = ("kraken",)
 #: The venue key for the in-process simulator.
 _PAPER_VENUE = "paper"
+#: The go-live runbook the live-opt-in refusals point users at.
+_RUNBOOK = "doc/dev/09-go-live.md"
 
 
 @dataclass(frozen=True, slots=True)
@@ -142,9 +150,16 @@ def build_engine(
 
     Raises
     ------
+    LiveTradingNotEnabled
+        In live mode when the explicit opt-in
+        :attr:`~trading_bot.application.config.AppConfig.live_enabled` is
+        ``False`` (the default) — live is off by default; the message points at
+        the go-live runbook. Checked *before* credentials, so it fires
+        regardless of whether keys are present.
     BrokerError
-        In live mode, if the configured venue lacks credentials, is unknown, or
-        no broker is configured at all. The factory never falls back to paper.
+        In live mode (with ``live_enabled`` set), if the configured venue lacks
+        credentials, is unknown, or no broker is configured at all. The factory
+        never falls back to paper.
 
     """
     bus = EventBus()
@@ -180,9 +195,14 @@ def _build_broker(config: AppConfig, bus: EventBus) -> Broker:
     """Select and construct the broker for ``config`` — paper-by-default.
 
     In paper mode (the default), always a bus-wired
-    :class:`~trading_bot.brokers.paper.PaperBroker`. In live mode, the configured
-    venue's adapter, built only when it has credentials; an explicit ``"paper"``
-    venue entry yields the simulator under either mode. Refuses (raises
+    :class:`~trading_bot.brokers.paper.PaperBroker`. In live mode, live is **off
+    by default**: unless :attr:`~trading_bot.application.config.AppConfig.
+    live_enabled` is ``True`` the live path raises
+    :class:`~trading_bot.domain.errors.LiveTradingNotEnabled` (the opt-in gate,
+    checked before credentials); only then is the configured venue's adapter
+    built, and only when it has credentials. An explicit ``"paper"`` venue entry
+    yields the simulator under either mode (no opt-in needed — it cannot trade
+    real money). Refuses (raises
     :class:`~trading_bot.domain.errors.BrokerError`) rather than falling back to
     paper for a live venue that cannot trade.
     """
@@ -192,8 +212,20 @@ def _build_broker(config: AppConfig, bus: EventBus) -> Broker:
         # Paper-by-default: the simulator, wired to the bus so its fills fan out.
         return PaperBroker(event_bus=bus)
 
-    # mode == "live" with a non-paper venue: build the real adapter, but only if
-    # it can actually trade. Never silently downgrade to paper.
+    # mode == "live" with a non-paper venue. Live is OFF by default: require the
+    # explicit opt-in *before* even looking at credentials, so flipping `mode`
+    # alone (or a stray --live) can never reach a real venue. No order is sent
+    # by constructing the adapter; this only gates whether it is built at all.
+    if not config.live_enabled:
+        raise LiveTradingNotEnabled(
+            "live trading is not enabled (live_enabled is False): set "
+            "live_enabled: true in the config (and provide credentials) after "
+            f"reading the go-live runbook at {_RUNBOOK}. Paper is the default; "
+            "live is off by default. No order placed."
+        )
+
+    # Opt-in is set: build the real adapter, but only if it can actually trade.
+    # Never silently downgrade to paper.
     if venue in _LIVE_VENUES:
         broker = _build_live_venue(venue)
         if not broker.has_credentials:

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -32,6 +32,7 @@ from trading_bot.domain.errors import (
     ConfigError,
     InstrumentMismatch,
     InsufficientFunds,
+    LiveTradingNotEnabled,
     MissingOrder,
     NoCapability,
     OrderError,
@@ -134,4 +135,5 @@ __all__ = [
     "BrokerError",
     "SignalError",
     "ConfigError",
+    "LiveTradingNotEnabled",
 ]

--- a/trading_bot/domain/errors.py
+++ b/trading_bot/domain/errors.py
@@ -27,6 +27,7 @@ __all__ = [
     "BrokerError",
     "SignalError",
     "ConfigError",
+    "LiveTradingNotEnabled",
 ]
 
 
@@ -218,6 +219,39 @@ class ConfigError(TradingBotError):
 
     def __init__(self, msg: str) -> None:
         super().__init__(msg)
+
+
+class LiveTradingNotEnabled(TradingBotError):
+    """Live trading was requested but the explicit opt-in is not set.
+
+    The off-by-default guard for going live. The engine refuses to wire a live
+    venue adapter for ``mode == "live"`` unless ``AppConfig.live_enabled`` is
+    explicitly ``True`` — so a config that merely flips ``mode`` to ``"live"``
+    (or a stray ``--live`` flag) can never reach a real venue by accident. Going
+    live is a deliberate, documented choice: read the runbook
+    (``doc/dev/09-go-live.md``), provide credentials and set ``live_enabled:
+    true``. Distinct from :class:`BrokerError` (which gates on *credentials*
+    once live is enabled): this gates on the *opt-in itself*.
+
+    Parameters
+    ----------
+    msg : str, optional
+        Human-readable detail. When omitted a default message naming the opt-in
+        flag (``live_enabled``) and the runbook (``doc/dev/09-go-live.md``) is
+        built.
+
+    """
+
+    #: The default refusal — names the opt-in flag and the runbook to read.
+    _DEFAULT = (
+        "live trading is not enabled: set live_enabled: true in the config "
+        "(and provide credentials) after reading the go-live runbook at "
+        "doc/dev/09-go-live.md. Paper trading is the default; live is "
+        "off by default and must be opted into deliberately. No order placed."
+    )
+
+    def __init__(self, msg: str | None = None) -> None:
+        super().__init__(msg if msg is not None else self._DEFAULT)
 
 
 class NoCapability(TradingBotError):

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -21,12 +21,16 @@ hand the resulting state to the pure rendering helpers in
 Paper-by-default (the invariant)
 --------------------------------
 A ``run`` defaults to **paper** trading — no venue, no key, no network. Going
-``--live`` requires *both* an explicit acknowledgement (``--yes-i-understand``,
-or an interactive confirmation) *and* venue credentials; absent either, ``run``
-**refuses with a non-zero exit and never places an order**. The factory
+``--live`` requires *all* of: an explicit acknowledgement (``--yes-i-understand``,
+or an interactive confirmation), the config's off-by-default opt-in
+(``live_enabled: true``), *and* venue credentials; absent any of them, ``run``
+**refuses with a non-zero exit and never places an order**, pointing the user at
+the go-live runbook (``doc/dev/09-go-live.md``). The factory
 (:func:`~trading_bot.application.service_factory.build_engine`) enforces the same
-on its side (it never silently falls back to paper for a credential-less live
-venue), so a missing key cannot trade real money by accident.
+on its side (it raises :class:`~trading_bot.domain.errors.LiveTradingNotEnabled`
+unless ``live_enabled`` is set, and never silently falls back to paper for a
+credential-less live venue), so neither a missing opt-in nor a missing key can
+trade real money by accident.
 
 Offline-testable bars source
 -----------------------------
@@ -85,6 +89,9 @@ _console = Console()
 #: Default synthetic-feed length (bars) when no ``--bars`` file is given — long
 #: enough for the default 10/30 MA windows to warm up and cross at least once.
 _SYNTHETIC_BARS = 80
+
+#: The go-live runbook the ``--live`` refusals point the user at.
+_RUNBOOK = "doc/dev/09-go-live.md"
 
 
 @app.callback()
@@ -247,8 +254,9 @@ def run(
     live: bool = typer.Option(
         False,
         "--live",
-        help="Trade LIVE (real money). Requires --yes-i-understand AND "
-        "credentials; refuses otherwise.",
+        help="Trade LIVE (real money). Requires --yes-i-understand AND the "
+        "config's live_enabled: true AND credentials; refuses otherwise "
+        "(see doc/dev/09-go-live.md).",
     ),
     yes_i_understand: bool = typer.Option(
         False,
@@ -274,10 +282,12 @@ def run(
       synthetic feed, exactly as before, so ``trading-bot run`` does something
       meaningful out of the box.
 
-    **Going live is guarded.** ``--live`` demands both ``--yes-i-understand`` and
-    venue credentials; missing either, the command refuses with a non-zero exit
-    and **never places an order** (the broker is never even built down the live
-    path until both checks pass).
+    **Going live is guarded.** ``--live`` demands ``--yes-i-understand``, the
+    config's off-by-default opt-in (``live_enabled: true``) *and* venue
+    credentials; missing any of them, the command refuses with a non-zero exit,
+    points at the go-live runbook (``doc/dev/09-go-live.md``) and **never places
+    an order** (the broker is never even built down the live path until every
+    check passes).
     """
     config = (
         AppConfig.from_yaml(config_path)
@@ -386,13 +396,16 @@ def _resolve_mode(
 ) -> str:
     """Resolve the effective run mode, guarding the live path.
 
-    Paper unless ``--live`` is set. ``--live`` requires the explicit
-    ``--yes-i-understand`` acknowledgement (or an interactive confirmation);
-    without it the command refuses with a non-zero exit and never proceeds to
-    build a broker. (Credential presence is enforced one layer down by
-    :func:`~trading_bot.application.service_factory.build_engine`, which refuses a
-    credential-less live venue — so the two gates together mean a live order is
-    impossible without *both* an acknowledgement and a key.)
+    Paper unless ``--live`` is set. ``--live`` requires *both* the explicit
+    ``--yes-i-understand`` acknowledgement (or an interactive confirmation) *and*
+    the config's off-by-default opt-in (``live_enabled: true``); missing either,
+    the command refuses with a non-zero exit, points at the go-live runbook
+    (``doc/dev/09-go-live.md``) and never proceeds to build a broker. (Credential
+    presence is enforced one layer down by
+    :func:`~trading_bot.application.service_factory.build_engine`, which also
+    re-checks the opt-in and refuses a credential-less live venue — so the gates
+    together mean a live order is impossible without an acknowledgement, the
+    config opt-in, *and* a key.)
     """
     if not live:
         return "paper"
@@ -408,7 +421,18 @@ def _resolve_mode(
     if not acknowledged:
         _console.print(
             "[red]refusing to trade live[/red] without explicit confirmation; "
-            "pass --yes-i-understand (no order was placed)."
+            f"pass --yes-i-understand (no order was placed). See {_RUNBOOK}."
+        )
+        raise typer.Exit(code=1)
+
+    # Second, off-by-default gate: the config must opt into live explicitly.
+    # Mirrors the factory's LiveTradingNotEnabled — refuse here so no engine is
+    # ever built and no order can be placed.
+    if not config.live_enabled:
+        _console.print(
+            "[red]refusing to trade live[/red]: live is off by default. Set "
+            f"live_enabled: true in the config and read {_RUNBOOK} first "
+            "(no order was placed)."
         )
         raise typer.Exit(code=1)
 

--- a/trading_bot/tests/application/test_config.py
+++ b/trading_bot/tests/application/test_config.py
@@ -61,6 +61,31 @@ def test_mode_defaults_to_paper() -> None:
     assert cfg.risk.max_position is None
 
 
+def test_live_enabled_defaults_to_false() -> None:
+    """``live_enabled`` is off by default — live is an explicit opt-in."""
+    cfg = AppConfig()
+    assert cfg.live_enabled is False
+
+
+def test_live_enabled_round_trips_from_yaml(tmp_path: pathlib.Path) -> None:
+    """``live_enabled: true`` survives a YAML round-trip as a bool."""
+    path = tmp_path / "live.yml"
+    path.write_text("mode: live\nlive_enabled: true\n")
+    cfg = AppConfig.from_yaml(path)
+    assert cfg.mode == "live"
+    assert cfg.live_enabled is True
+
+
+def test_live_enabled_omitted_in_yaml_defaults_false(
+    tmp_path: pathlib.Path,
+) -> None:
+    """A YAML config that omits ``live_enabled`` parses it as ``False``."""
+    path = tmp_path / "paper.yml"
+    path.write_text("mode: live\n")
+    cfg = AppConfig.from_yaml(path)
+    assert cfg.live_enabled is False
+
+
 def test_starting_capital_defaults_to_100000() -> None:
     """An unset ``starting_capital`` is the strictly-positive default 100000."""
     cfg = AppConfig()

--- a/trading_bot/tests/application/test_service_factory.py
+++ b/trading_bot/tests/application/test_service_factory.py
@@ -28,7 +28,7 @@ from trading_bot.application.risk import RiskManager
 from trading_bot.application.service_factory import Engine, build_engine
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.paper import PaperBroker
-from trading_bot.domain.errors import BrokerError
+from trading_bot.domain.errors import BrokerError, LiveTradingNotEnabled
 from trading_bot.domain.fill import Fill
 from trading_bot.domain.instrument import Instrument, Symbol
 from trading_bot.domain.money import money
@@ -174,15 +174,51 @@ def test_db_path_attaches_sqlite_store(tmp_path) -> None:
     assert engine.store.get_order("cid-store") is not None
 
 
-def test_live_mode_without_credentials_refuses() -> None:
-    """A live-mode config whose venue lacks credentials raises — no broker back.
+def test_live_mode_not_enabled_refuses_regardless_of_credentials(
+    monkeypatch,
+) -> None:
+    """Live OFF by default: ``mode="live"`` + ``live_enabled=False`` always raises.
 
-    The paper-by-default invariant: live trading is opt-in *and* gated on
-    credentials. Without them the factory must refuse, never silently fall back
-    to paper and never return a live broker that cannot trade.
+    The opt-in gate fires *before* the credential check, so it refuses even when
+    credentials are present — flipping ``mode`` alone (without ``live_enabled``)
+    can never reach a real venue. The message points at the go-live runbook.
+    """
+    # Even with credentials present, the opt-in gate refuses first.
+    monkeypatch.setenv("KRAKEN_API_KEY", "k")
+    monkeypatch.setenv("KRAKEN_API_SECRET", "c2VjcmV0")  # base64("secret")
+    cfg = AppConfig(
+        mode="live",
+        live_enabled=False,
+        brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
+    )
+
+    with pytest.raises(LiveTradingNotEnabled) as exc:
+        build_engine(cfg)
+    # The refusal names the runbook so the user knows the deliberate next step.
+    assert "doc/dev/09-go-live.md" in str(exc.value)
+
+
+def test_live_mode_not_enabled_default_refuses_no_credentials() -> None:
+    """``live_enabled`` defaults to False → live refuses even with no credentials."""
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
+    )
+    assert cfg.live_enabled is False
+    with pytest.raises(LiveTradingNotEnabled):
+        build_engine(cfg)
+
+
+def test_live_enabled_without_credentials_refuses() -> None:
+    """Opt-in set but no credentials → the credential gate still raises BrokerError.
+
+    With ``live_enabled=True`` the opt-in gate passes; the factory then enforces
+    credentials and refuses a credential-less live venue (never falls back to
+    paper). The two gates are independent: opt-in *and* a key are both required.
     """
     cfg = AppConfig(
         mode="live",
+        live_enabled=True,
         brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
     )
 
@@ -194,24 +230,37 @@ def test_live_mode_without_credentials_refuses() -> None:
         build_engine(cfg)
 
 
-def test_live_mode_with_credentials_builds_live_broker(monkeypatch) -> None:
-    """Live mode + credentials present → the live venue adapter is built."""
+def test_live_enabled_with_credentials_builds_live_broker_no_order(
+    monkeypatch,
+) -> None:
+    """Opt-in + credentials → the live adapter is *constructed* (no order sent).
+
+    With both gates satisfied the factory builds the live ``KrakenBroker``
+    object. Construction is pure (no network, no order) — the test only asserts
+    the broker's *type* and that it reports credentials; it never calls it. This
+    is the whole point of the off-by-default opt-in: enabling it constructs the
+    adapter without trading.
+    """
     monkeypatch.setenv("KRAKEN_API_KEY", "k")
     monkeypatch.setenv("KRAKEN_API_SECRET", "c2VjcmV0")  # base64("secret")
     cfg = AppConfig(
         mode="live",
+        live_enabled=True,
         brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
     )
 
     engine = build_engine(cfg)
+    # The adapter object exists and is the live venue — but is never invoked,
+    # so no order / no network call was ever made.
     assert isinstance(engine.broker, KrakenBroker)
     assert engine.broker.has_credentials
 
 
 def test_live_mode_unknown_venue_refuses() -> None:
-    """Live mode with an unknown venue raises clearly (no silent fallback)."""
+    """Live mode (opted in) with an unknown venue raises clearly (no fallback)."""
     cfg = AppConfig(
         mode="live",
+        live_enabled=True,
         brokers=[BrokerConfig(name="x", exchange="not-a-venue")],
     )
     with pytest.raises(BrokerError):
@@ -220,7 +269,7 @@ def test_live_mode_unknown_venue_refuses() -> None:
 
 def test_live_mode_no_broker_configured_refuses() -> None:
     """Live mode with no configured broker raises — never trade without a venue."""
-    cfg = AppConfig(mode="live")
+    cfg = AppConfig(mode="live", live_enabled=True)
     with pytest.raises(BrokerError):
         build_engine(cfg)
 

--- a/trading_bot/tests/interfaces/test_cli_commands.py
+++ b/trading_bot/tests/interfaces/test_cli_commands.py
@@ -142,14 +142,40 @@ def test_run_live_without_confirmation_refuses_no_order() -> None:
     assert "run complete" not in result.output
 
 
-def test_run_live_acknowledged_without_credentials_refuses(
+def test_run_live_without_opt_in_refuses_no_order(
+    tmp_path: pathlib.Path,
+) -> None:
+    """`run --live --yes-i-understand` without ``live_enabled`` refuses, no order.
+
+    The acknowledgement passes the first CLI gate, but the config's off-by-default
+    ``live_enabled`` is unset, so the CLI refuses *before building anything*: a
+    non-zero exit, a message pointing at the runbook, and no order placed.
+    """
+    cfg = tmp_path / "live.yaml"
+    # mode flipped to live by --live, but live_enabled omitted (defaults False).
+    cfg.write_text(
+        "mode: paper\nbrokers:\n  - name: k\n    exchange: kraken\n"
+    )
+
+    result = runner.invoke(
+        app,
+        ["run", "--live", "--yes-i-understand", "-c", str(cfg)],
+    )
+
+    assert result.exit_code != 0
+    assert "refusing to trade live" in result.output
+    assert "09-go-live.md" in result.output
+    assert "run complete" not in result.output
+
+
+def test_run_live_acknowledged_opted_in_without_credentials_refuses(
     tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """`run --live --yes-i-understand` without creds refuses, places no order.
+    """`run --live` opted-in but without creds refuses, places no order.
 
-    The acknowledgement passes the CLI gate, but ``build_engine`` refuses a
-    credential-less live Kraken venue (paper-by-default invariant): a non-zero
-    exit, a clear message, no order placed.
+    The acknowledgement *and* ``live_enabled: true`` pass the CLI gates, but
+    ``build_engine`` refuses a credential-less live Kraken venue
+    (paper-by-default invariant): a non-zero exit, a clear message, no order.
     """
     # Ensure no Kraken credentials are visible.
     monkeypatch.delenv("KRAKEN_API_KEY", raising=False)
@@ -157,7 +183,8 @@ def test_run_live_acknowledged_without_credentials_refuses(
 
     cfg = tmp_path / "live.yaml"
     cfg.write_text(
-        "mode: paper\nbrokers:\n  - name: k\n    exchange: kraken\n"
+        "mode: live\nlive_enabled: true\n"
+        "brokers:\n  - name: k\n    exchange: kraken\n"
     )
 
     result = runner.invoke(

--- a/trading_bot/tests/interfaces/test_cli_run_config.py
+++ b/trading_bot/tests/interfaces/test_cli_run_config.py
@@ -154,10 +154,10 @@ def test_run_config_live_without_creds_refuses_no_order(
 ) -> None:
     """`run -c <live-config> --live --yes-i-understand` without creds refuses.
 
-    A config declaring a strategy + a credential-less Kraken venue, run ``--live``
-    with the acknowledgement: the CLI gate passes, but ``build_engine`` (inside
-    ``run_app``) refuses the credential-less live venue — a non-zero exit, a clear
-    message, and no order placed.
+    A config declaring a strategy + a credential-less Kraken venue, opted into
+    live (``live_enabled: true``), run ``--live`` with the acknowledgement: both
+    CLI gates pass, but ``build_engine`` (inside ``run_app``) refuses the
+    credential-less live venue — a non-zero exit, a clear message, no order.
     """
     monkeypatch.delenv("KRAKEN_API_KEY", raising=False)
     monkeypatch.delenv("KRAKEN_API_SECRET", raising=False)
@@ -168,8 +168,11 @@ def test_run_config_live_without_creds_refuses_no_order(
     monkeypatch.setattr(run_app_module, "feed_for", _fake_feed_for_factory())
 
     cfg = tmp_path / "live.yaml"
+    # Opt in (live_enabled) so the CLI's opt-in gate passes and the refusal comes
+    # from the credential check inside build_engine.
     cfg.write_text(
-        "mode: paper\n"
+        "mode: live\n"
+        "live_enabled: true\n"
         "brokers:\n"
         "  - name: k\n"
         "    exchange: kraken\n"


### PR DESCRIPTION
## Summary
- **Final leaf of E10 — and of the whole E1–E10 rewrite.** Going live is now an explicit, documented, **off-by-default** opt-in: `AppConfig.live_enabled` (default `False`) is a second gate `build_engine` checks **before** credentials — `mode: live` alone raises `LiveTradingNotEnabled` pointing at the runbook; the CLI `--live` mirrors it. The live `KrakenBroker` is only **constructed**, never called — **no real order is ever sent from the repo**.
- New go-live runbook `doc/dev/09-go-live.md` (enable steps, pre-trade checklist, proven-vs-pending table). Closes E10; `07-roadmap.md` E10 line removed.

## Why
- Paper-by-default + a second explicit opt-in makes "no live by accident" structural at every layer (config/factory/CLI). The one remaining live prerequisite — validate private endpoints + venue-level idempotency against a **real-key sandbox** — is intentionally out of the repo. See `doc/dev/03-decisions.md`.

## Still deferred (maintainer decisions)
- **Final project name** (kept `trading_bot`); **real-key live enablement** — both kept open in `07-roadmap.md`.

## Changes
- `domain/errors.py` (`LiveTradingNotEnabled`), `config.py` (`live_enabled`), `service_factory.py` (opt-in gate), `cli/main.py` (refusal flow), `doc/dev/09-go-live.md`; tests.

## Changelog
Added: go-live runbook + `LiveTradingNotEnabled` opt-in guard (live off by default).

## Test plan
- [x] `.venv/bin/python -m pytest` (565 passed, 0 unexpected skips; paper path unaffected)
- [x] verified myself: live OFF by default refuses even with creds; paper builds `PaperBroker`; enabled+dummy-creds constructs the adapter with no order sent
- [x] `ruff` + `mypy` clean