### PR TITLE
chore: declare polars core dep + lazy fynance so CI is green

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,10 +32,11 @@ _README.md
 *.log
 *.db
 *.dat
-*.html
 *.ipynb_checkpoints
 logs/
 errors/
+# (no blanket *.html ignore — the web UI ships Jinja2 templates under
+#  trading_bot/interfaces/ui/templates/ that MUST be tracked.)
 
 # Sphinx generated
 doc/source/generated/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,12 @@ dependencies = [
     "websockets>=12.0",
     "pydantic>=2.0",
     "numpy>=1.26",
+    # polars is the OHLC bars-frame type used across the application layer
+    # (data_feed/data_provider/strategy) and the CLI — a hard runtime dep.
+    "polars>=0.20",
+    # pyyaml backs AppConfig.from_yaml (imported at module level in
+    # application/config.py), so it is a core runtime dep, not just dev/daemon.
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]

--- a/trading_bot/application/strategy.py
+++ b/trading_bot/application/strategy.py
@@ -38,8 +38,13 @@ sink. Here only an *already-importable* dotted module can be named; nothing is
 executed from a loose file.
 
 This module lives in the application layer: it may import the pure domain and
-depends on :mod:`polars` (the bars frame type) and, for the example signal,
-:mod:`fynance`. It performs no I/O of its own.
+depends on :mod:`polars` (the bars frame type). The built-in
+:func:`ma_crossover_signal` additionally needs :mod:`fynance`, but that is an
+**optional** ``[triptych]`` dependency: it is imported *lazily*, inside the
+signal callable, so importing this module never requires fynance — only
+*calling* the built-in MA-crossover signal does (mirroring how
+:mod:`trading_bot.domain.performance` defers its KPI imports). This module
+performs no I/O of its own.
 """
 
 from __future__ import annotations
@@ -49,7 +54,6 @@ import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
 
-import fynance as fy
 import numpy as np
 import polars as pl
 
@@ -317,6 +321,11 @@ def ma_crossover_signal(
     ------
     ValueError
         If the windows are not ``1 <= fast < slow``.
+    ImportError
+        Raised by the returned callable (not here) when it is *evaluated* in an
+        environment without the optional ``fynance`` dependency. fynance is
+        imported lazily inside the callable, so building the ``SignalFn`` — and
+        importing this module — never requires it; only running the signal does.
 
     """
     if fast < 1 or slow <= fast:
@@ -325,6 +334,12 @@ def ma_crossover_signal(
         )
 
     def _signal(bars: pl.DataFrame) -> Signal:
+        # fynance is an optional [triptych] dependency: import it here, when the
+        # signal is actually evaluated, so importing this module stays free of it
+        # (mirrors domain.performance's lazy KPI imports). A missing fynance
+        # surfaces as a clear ImportError at evaluation time, not at import time.
+        import fynance as fy
+
         ts = _bar_ts_ms(bars)
         if bars.height == 0 or _CLOSE_COL not in bars.columns:
             return Signal.exposure(instrument, money("0"), ts=ts)

--- a/trading_bot/interfaces/ui/templates/dashboard.html
+++ b/trading_bot/interfaces/ui/templates/dashboard.html
@@ -1,0 +1,88 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>trading_bot — dashboard</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <!-- Header: brand + version + mode badge. The only server-rendered values are
+       the version and the mode; all engine state is fetched client-side by
+       app.js from /api/* (the UI is a pure HTTP client of the API). -->
+  <header class="topbar">
+    <div class="brand-group">
+      <span class="brand">trading_bot</span>
+      <span class="ver">v{{ version }}</span>
+    </div>
+    <span class="mode-badge mode-{{ mode }}">{{ mode }}</span>
+    <span id="conn" class="conn"><span class="dot"></span>connecting…</span>
+  </header>
+
+  <main>
+    <!-- Positions ------------------------------------------------------------ -->
+    <section class="card">
+      <h2>Positions</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Instrument</th>
+              <th class="num">Net qty</th>
+              <th class="num">Avg entry</th>
+              <th class="num">Realised PnL</th>
+              <th class="num">Fees</th>
+            </tr>
+          </thead>
+          <tbody id="positions-body">
+            <tr class="empty"><td colspan="5">Loading…</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- Open orders ---------------------------------------------------------- -->
+    <section class="card">
+      <h2>Open orders</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Client id</th>
+              <th>Instrument</th>
+              <th>Side</th>
+              <th>Type</th>
+              <th class="num">Qty</th>
+              <th class="num">Limit</th>
+              <th class="num">Filled</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody id="orders-body">
+            <tr class="empty"><td colspan="8">Loading…</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- PnL / KPI ------------------------------------------------------------ -->
+    <section class="card">
+      <h2>PnL / KPI</h2>
+      <div class="table-wrap">
+        <table>
+          <tbody id="kpi-body">
+            <tr class="empty"><td colspan="2">Loading…</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    trading_bot v{{ version }} — read-only dashboard.
+    <a href="https://github.com/ArthurBernard/Trading_Bot">GitHub</a>
+  </footer>
+
+  <script src="/static/app.js"></script>
+</body>
+</html>

--- a/trading_bot/tests/application/test_orchestrator.py
+++ b/trading_bot/tests/application/test_orchestrator.py
@@ -141,6 +141,7 @@ async def test_two_runners_run_concurrently_and_independently() -> None:
     result maps each runner to its order count, and each tracker reflects only
     its own strategy's fills (independent books).
     """
+    pytest.importorskip("fynance")  # ma_crossover signal evaluates fynance.sma
     up = [float(100 + i) for i in range(20)]
     down = [float(120 - i) for i in range(1, 21)]
 
@@ -281,6 +282,7 @@ async def test_one_runner_raising_does_not_hang_siblings() -> None:
     runs to completion, and the orchestrator re-raises the lone failure (not a
     group error). The sibling is never left hung.
     """
+    pytest.importorskip("fynance")  # the good runner's ma_crossover evaluates fynance.sma
 
     class _BoomFeed:
         def __iter__(self) -> Iterator[pl.DataFrame]:
@@ -437,6 +439,7 @@ async def test_install_signal_handlers_falls_back_when_unsupported() -> None:
 
 async def test_orchestrator_emits_lifecycle_log_events() -> None:
     """With an event bus, the orchestrator emits start/finish LogEvents."""
+    pytest.importorskip("fynance")  # ma_crossover signal evaluates fynance.sma
     logs: list[LogEvent] = []
     bus = EventBus()
     bus.subscribe(lambda e: logs.append(e) if isinstance(e, LogEvent) else None)

--- a/trading_bot/tests/application/test_performance_service.py
+++ b/trading_bot/tests/application/test_performance_service.py
@@ -25,6 +25,8 @@ from __future__ import annotations
 
 from decimal import Decimal
 
+import pytest
+
 from trading_bot.application import (
     EventBus,
     FillEvent,
@@ -218,6 +220,7 @@ def test_kpis_equal_domain_performance_over_equity_curve() -> None:
     A monotonic-up equity curve gives a finite, strictly-positive Sharpe and a
     zero max drawdown — concrete assertions that prove the wrappers ran fynance.
     """
+    pytest.importorskip("fynance")  # KPI ratios delegate to fynance
     # A win, a win, a bigger win across one instrument (all closes from flat).
     fills = [
         _fill(fill_id="F1", side=OrderSide.BUY, qty="1", price="100", fee="0"),
@@ -259,6 +262,7 @@ def test_kpis_equal_domain_performance_over_equity_curve() -> None:
 
 def test_max_drawdown_nonzero_on_dip() -> None:
     """A curve that dips has a positive fractional max drawdown matching domain."""
+    pytest.importorskip("fynance")  # max_drawdown delegates to fynance
     fills = [
         # +10 (peak), then -30 (dip), then +50 (recover).
         _fill(fill_id="F1", side=OrderSide.BUY, qty="1", price="100", fee="0"),
@@ -312,6 +316,7 @@ async def test_end_to_end_router_paperbroker_drives_performance() -> None:
     * KPIs == ``domain.performance`` over the service's equity curve (they run —
       fynance present).
     """
+    pytest.importorskip("fynance")  # KPI ratios delegate to fynance
     bus = EventBus()
     svc = PerformanceService(v0=money("1000000"), event_bus=bus)
     broker = PaperBroker(

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -175,6 +175,7 @@ async def test_run_app_two_strategies_independent_positions_and_pnl() -> None:
     broker's own fills (``Position.from_fills`` per instrument) and must agree
     exactly — fills are the PnL source of truth.
     """
+    pytest.importorskip("fynance")  # ma_crossover signals evaluate fynance.sma
     config = _two_strategy_config()
     client = _fake_client_for(config)
 
@@ -211,6 +212,7 @@ async def test_run_app_positions_match_independent_fill_computation() -> None:
     reported per-strategy position to an independent fold of exactly that
     instrument's broker fills.
     """
+    pytest.importorskip("fynance")  # ma_crossover signals evaluate fynance.sma
     config = _two_strategy_config()
     client = _fake_client_for(config)
 

--- a/trading_bot/tests/application/test_service_factory.py
+++ b/trading_bot/tests/application/test_service_factory.py
@@ -113,6 +113,7 @@ def test_winning_run_gives_finite_nonzero_sharpe() -> None:
     a *meaningful* Sharpe (non-zero and finite) — where a zero-anchored curve
     would have made the estimator degenerate / return 0.0.
     """
+    pytest.importorskip("fynance")  # engine.perf.sharpe() delegates to fynance
     cfg = AppConfig.model_validate({"mode": "paper", "starting_capital": "100000"})
     engine = build_engine(cfg)
     # A profitable round-trip: buy @100, sell @110 → realised PnL +10.

--- a/trading_bot/tests/application/test_strategy.py
+++ b/trading_bot/tests/application/test_strategy.py
@@ -118,6 +118,7 @@ def test_warmup_returns_flat_below_lookback() -> None:
 
 
 def test_warmup_calls_fn_at_lookback() -> None:
+    pytest.importorskip("fynance")  # evaluate() at lookback invokes ma_crossover (fynance.sma)
     strat = Strategy(
         name="s",
         instrument=BTC_USD,
@@ -140,6 +141,7 @@ def test_ma_crossover_rejects_bad_windows() -> None:
 
 
 def test_ma_crossover_long_then_short() -> None:
+    pytest.importorskip("fynance")  # ma_crossover signal evaluates fynance.sma
     fn = ma_crossover_signal(BTC_USD, fast=2, slow=4)
 
     # A clear up-trend: fast MA rises above slow MA -> long.
@@ -155,6 +157,7 @@ def test_ma_crossover_long_then_short() -> None:
 
 
 def test_ma_crossover_flips_at_crossover() -> None:
+    pytest.importorskip("fynance")  # ma_crossover signal evaluates fynance.sma
     fn = ma_crossover_signal(BTC_USD, fast=2, slow=4)
     # up then down: collect the exposure at each step (using only bars <= t).
     closes = [10.0, 11.0, 13.0, 16.0, 20.0, 25.0, 22.0, 17.0, 12.0, 9.0, 7.0]
@@ -168,6 +171,7 @@ def test_ma_crossover_flips_at_crossover() -> None:
 
 def test_ma_crossover_is_causal() -> None:
     """The signal at bar t must not depend on any bar > t (no lookahead)."""
+    pytest.importorskip("fynance")  # ma_crossover signal evaluates fynance.sma
     fn = ma_crossover_signal(BTC_USD, fast=3, slow=5)
     closes = [10.0, 12.0, 11.0, 14.0, 18.0, 22.0, 19.0, 15.0, 11.0, 8.0]
 
@@ -184,6 +188,7 @@ def test_ma_crossover_is_causal() -> None:
 
 
 def test_ma_crossover_ts_from_latest_bar() -> None:
+    pytest.importorskip("fynance")  # ma_crossover signal evaluates fynance.sma
     fn = ma_crossover_signal(BTC_USD, fast=2, slow=4)
     bars = _bars([10.0, 11.0, 13.0, 16.0], start_ts=1_700_000_000)
     sig = fn(bars)
@@ -246,6 +251,7 @@ def test_load_strategy_non_callable_attr_raises() -> None:
 
 def test_verify_on_realistic_series() -> None:
     """Trend up then down: exposure flips at the crossovers; fully causal."""
+    pytest.importorskip("fynance")  # ma_crossover signal evaluates fynance.sma
     rng = np.random.default_rng(42)
     up = np.linspace(100.0, 200.0, 60)
     down = np.linspace(200.0, 100.0, 60)

--- a/trading_bot/tests/application/test_strategy_runner.py
+++ b/trading_bot/tests/application/test_strategy_runner.py
@@ -27,6 +27,7 @@ from collections.abc import Iterator
 from decimal import Decimal
 
 import polars as pl
+import pytest
 
 from trading_bot.application import (
     EventBus,
@@ -109,6 +110,7 @@ async def test_end_to_end_position_follows_signal() -> None:
     2 and ``-1`` targets short 2. We assert the tracked net_qty is long after the
     up-leg and short after the down-leg, with exact ``Decimal`` money.
     """
+    pytest.importorskip("fynance")  # ma_crossover_signal evaluates fynance.sma
     # 20 up then 20 down — comfortably past a fast=3/slow=6 crossover each way.
     up = [float(100 + i) for i in range(20)]
     down = [float(120 - i) for i in range(1, 21)]
@@ -153,6 +155,7 @@ async def test_position_goes_long_then_short_across_the_cross() -> None:
     long *before* the down-cross — proving the track follows the signal at the
     crossover, not just at the end.
     """
+    pytest.importorskip("fynance")  # ma_crossover_signal evaluates fynance.sma
     up = [float(100 + i) for i in range(20)]
     frame_up = _bars(up)
     strat = Strategy(
@@ -368,6 +371,7 @@ async def test_idempotent_rerun_does_not_double_submit() -> None:
     router deduped every id. This is the runner-half (stable ids) meeting the
     router-half (one id → one venue order) of the E4 idempotency contract.
     """
+    pytest.importorskip("fynance")  # ma_crossover_signal evaluates fynance.sma
     up = [float(100 + i) for i in range(20)]
     down = [float(120 - i) for i in range(1, 21)]
     frame = _bars(up + down)
@@ -434,6 +438,7 @@ async def test_client_order_ids_are_deterministic_and_per_step() -> None:
     of per-step ids — determinism — and every id matches ``f"{name}-{step}"``
     with the step index aligned to the bar it traded on.
     """
+    pytest.importorskip("fynance")  # ma_crossover_signal evaluates fynance.sma
     up = [float(100 + i) for i in range(12)]
     frame = _bars(up)
 
@@ -522,6 +527,7 @@ async def test_order_factory_and_log_events() -> None:
     overrides its client-order-id with the deterministic per-step id. A LogEvent
     is emitted per submitted order on the bus.
     """
+    pytest.importorskip("fynance")  # ma_crossover_signal evaluates fynance.sma
     logs: list[LogEvent] = []
 
     closes = [float(100 + i) for i in range(12)]

--- a/trading_bot/tests/interfaces/test_api.py
+++ b/trading_bot/tests/interfaces/test_api.py
@@ -239,6 +239,7 @@ def test_kpi_realised_pnl_string_matches_engine_and_has_ratios(
     client: TestClient, engine: Engine
 ) -> None:
     """``/api/kpi`` realised PnL (string) equals the perf service; ratios present."""
+    pytest.importorskip("fynance")  # the seeded curve makes /api/kpi compute fynance ratios
     resp = client.get("/api/kpi")
     assert resp.status_code == 200
     body = resp.json()
@@ -428,6 +429,7 @@ def test_kpi_endpoint_stays_robust_over_a_profitable_curve() -> None:
     whichever fynance can compute on this curve, and ``0.0`` (via ``_safe_ratio``)
     for any it rejects. The point is the read-only KPI view is always 200 + numeric.
     """
+    pytest.importorskip("fynance")  # the profitable curve makes /api/kpi compute fynance ratios
     engine = build_engine(AppConfig.model_validate({"mode": "paper"}))
     perf = engine.perf
     perf.apply(

--- a/trading_bot/tests/interfaces/test_cli_commands.py
+++ b/trading_bot/tests/interfaces/test_cli_commands.py
@@ -77,6 +77,7 @@ def test_run_over_fixture_paper_moves_position(tmp_path: pathlib.Path) -> None:
     recomputed *independently* from the broker's fills (read back from the
     persisted store) and must agree exactly — fills are the source of truth.
     """
+    pytest.importorskip("fynance")  # the ma_crossover run evaluates fynance.sma
     bars = tmp_path / "bars.csv"
     _ohlc_fixture(bars)
     db = tmp_path / "run.db"
@@ -117,6 +118,7 @@ def test_run_over_fixture_paper_moves_position(tmp_path: pathlib.Path) -> None:
 
 def test_run_synthetic_feed_default(tmp_path: pathlib.Path) -> None:
     """`run` with no --bars uses the built-in synthetic feed and exits 0."""
+    pytest.importorskip("fynance")  # the synthetic demo uses the ma_crossover signal
     result = runner.invoke(app, ["run"])
 
     assert result.exit_code == 0, result.output
@@ -270,6 +272,7 @@ def test_kpi_renders_realised_pnl(tmp_path: pathlib.Path) -> None:
     A known two-fill sequence (buy 2 @ 30000, sell 1 @ 31000, no fees) realises
     exactly 1000 on the closed unit; the table must show that figure.
     """
+    pytest.importorskip("fynance")  # the KPI table computes fynance ratios over the curve
     db = tmp_path / "kpi.db"
     _seed_store(db)
 
@@ -289,6 +292,7 @@ def test_kpi_default_capital_anchors_equity_endpoint(
     The realised PnL is 1000 (buy 2 @ 30000, sell 1 @ 31000), so the equity
     endpoint is ``100000 + 1000 = 101000``.
     """
+    pytest.importorskip("fynance")  # the KPI table computes fynance ratios over the curve
     db = tmp_path / "kpi.db"
     _seed_store(db)
 
@@ -300,6 +304,7 @@ def test_kpi_default_capital_anchors_equity_endpoint(
 
 def test_kpi_explicit_capital_overrides_default(tmp_path: pathlib.Path) -> None:
     """`--capital` wins: equity endpoint anchors to the flag, not the default."""
+    pytest.importorskip("fynance")  # the KPI table computes fynance ratios over the curve
     db = tmp_path / "kpi.db"
     _seed_store(db)
 
@@ -314,6 +319,7 @@ def test_kpi_config_starting_capital_used_when_no_capital_flag(
     tmp_path: pathlib.Path,
 ) -> None:
     """A ``--config`` ``starting_capital`` anchors the curve absent ``--capital``."""
+    pytest.importorskip("fynance")  # the KPI table computes fynance ratios over the curve
     db = tmp_path / "kpi.db"
     _seed_store(db)
     cfg = tmp_path / "cfg.yml"
@@ -329,6 +335,7 @@ def test_kpi_capital_flag_beats_config_starting_capital(
     tmp_path: pathlib.Path,
 ) -> None:
     """Precedence: explicit ``--capital`` > config ``starting_capital``."""
+    pytest.importorskip("fynance")  # the KPI table computes fynance ratios over the curve
     db = tmp_path / "kpi.db"
     _seed_store(db)
     cfg = tmp_path / "cfg.yml"
@@ -365,6 +372,7 @@ def test_positions_table_contains_formatted_values() -> None:
 
 def test_kpi_table_contains_realised_pnl_and_ratios() -> None:
     """`kpi_table` shows realised PnL + the named ratios for a known fill set."""
+    pytest.importorskip("fynance")  # kpi_table computes fynance ratios over the curve
     perf = PerformanceService(v0=money("100000"))
     perf.apply(
         Fill("F1", "c-0", _BTC_USD, OrderSide.BUY, money("2"),

--- a/trading_bot/tests/interfaces/test_cli_run_config.py
+++ b/trading_bot/tests/interfaces/test_cli_run_config.py
@@ -114,6 +114,7 @@ def test_run_config_two_strategies_prints_multistrategy_summary(
     The dccd feed is replaced by a fake (InMemoryFeed over canned bars) so the
     whole command is offline; the paper broker is the engine's real data path.
     """
+    pytest.importorskip("fynance")  # ma_crossover strategies + KPI summary evaluate fynance
     # Replace the feed seam the entrypoint uses with the offline fake.
     import importlib
 
@@ -139,6 +140,7 @@ def test_run_config_two_strategies_prints_multistrategy_summary(
 
 def test_run_config_synthetic_path_still_works() -> None:
     """Backward-compat: `run` with no config still runs the synthetic demo."""
+    pytest.importorskip("fynance")  # the synthetic demo uses the ma_crossover signal
     result = runner.invoke(app, ["run"])
 
     assert result.exit_code == 0, result.output

--- a/trading_bot/tests/interfaces/test_ui.py
+++ b/trading_bot/tests/interfaces/test_ui.py
@@ -192,6 +192,7 @@ def test_api_endpoints_back_the_dashboard_with_real_state(
     positions/KPI endpoints report it as exact Decimal strings — the verbatim
     money the JS renders.
     """
+    pytest.importorskip("fynance")  # the seeded curve makes /api/kpi compute fynance ratios
     positions = client.get("/api/positions").json()
     assert positions, "engine should hold a position"
     btc = next(p for p in positions if p["instrument"] == "BTC/USD")


### PR DESCRIPTION
## Summary
- **Fixes red CI.** The rewrite grew runtime deps `pyproject.toml` never declared, so CI (`pip install -e ".[dev]"` then `pytest`) failed at collection with `ModuleNotFoundError: No module named 'polars'`.
- `polars>=0.20` + `pyyaml>=6.0` added to **core** `dependencies` (both are module-level runtime imports — the OHLC bars frame type and `AppConfig.from_yaml`).
- `application/strategy.py`: **fynance is now lazily imported** (inside the MA-crossover signal fn), so the whole `application` layer imports without the optional `triptych` extra — matching the documented design ("without fynance the KPI tests skip"). 33 fynance-dependent tests across 10 files get a surgical `pytest.importorskip("fynance")` so they **skip cleanly** when fynance is absent (mirroring the existing `domain/performance` KPI tests). dccd was already lazy; its real tests are `@network`.

## Verified
- **CI-like clean venv** (`[dev]` only, no fynance/dccd): app imports OK; `pytest` → **526 passed, 39 skipped, 0 failed/errors**; ruff + mypy clean.
- **Full `.venv`** (with fynance/dccd): **565 passed, 0 skipped**; ruff + mypy clean.

## Test plan
- [x] reproduced the CI scenario in a throwaway venv — green with skips
- [x] full local suite still 565 passed
- [ ] CI green on this PR