### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [0.2.0] - 2026-06-28
+
+### Added
+
 - `brokers.BinanceBroker` — Binance spot REST adapter behind the `Broker` port
   (HMAC-SHA256 signed orders/balances/fills/ticker; public market data key-free),
   the **2nd live venue**. `newClientOrderId` carries the client-order-id for

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trading_bot"
-version = "0.2.0.dev0"
-description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first. [in progress]"
+version = "0.2.0"
+description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first."
 readme = "README.md"
 license = { text = "MIT" }
 authors = [{ name = "Arthur Bernard", email = "arthur.bernard.92@gmail.com" }]

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -10,6 +10,6 @@ package). See ``doc/dev/07-roadmap.md`` for the rewrite roadmap.
 """
 from __future__ import annotations
 
-__version__ = "0.2.0.dev0"
+__version__ = "0.2.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
## Release v0.2.0 — the multi-exchange execution engine

First tagged release. Freezes `[Unreleased]` → `## [0.2.0] - 2026-06-28` and bumps
the version sources (`pyproject.toml` + `trading_bot/__init__.py`) to `0.2.0`.

**Scope = the E1–E10 hexagonal rewrite + E11 (Binance):**
- Hexagonal engine (domain / transport / brokers / storage / application / interfaces),
  async-first, all money `Decimal`. Paper-by-default; live behind an off-by-default
  `live_enabled` opt-in — no order is ever sent without explicit opt-in + credentials.
- Two live venues behind one `Broker` port: **`KrakenBroker`** (REST+WS) and
  **`BinanceBroker`** (REST, testnet-capable) + the in-process `PaperBroker`.
- Idempotent risk-gated `OrderRouter`, `reconcile`, `PositionTracker`,
  `PerformanceService` (KPIs via fynance), `RiskManager`+kill-switch, `Orchestrator`,
  declarative `AppConfig`, Typer CLI + read-only FastAPI/Jinja2 dashboard.
- Money-safety invariants **proven under fault injection** (`tests/hardening/`).

Full detail: the `## [0.2.0]` section of `CHANGELOG.md`. ~617 tests green; ruff + mypy clean.

**Next (0.3.0):** the multi-asset / LS1 portfolio-strategy unit.

## Test plan
- [x] CI green on `develop`
- [x] version sources agree (`0.2.0`) and import at runtime