### PR TITLE
docs: plan binance-adapter (E11)

### DIFF
--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -15,6 +15,19 @@ The single source *index* of open work. Each unchecked item is a candidate for
 dashboard; paper-by-default, hardened under fault injection, live behind an explicit
 off-by-default opt-in. History in git + `CHANGELOG.md`; see `06-status.md`.
 
+## Active epics (post-0.2.0)
+
+- [ ] **E11 — Binance adapter (2nd live venue).** `BinanceBroker` REST behind the `Broker` port (HMAC-SHA256 signing vs Binance's vector; orders/balances/fills/ticker; `newClientOrderId` idempotency; testnet-capable), wired into `service_factory`. Public market data key-free; private path proven by mocks + an opt-in Binance **testnet** E2E. WS deferred.
+- [ ] **Multi-asset / portfolio strategy unit** (signalé par `fynance-research`). Today a
+  `SignalFn` is `(bars) -> Signal` for **one** instrument; the first validated research
+  strategy, **LS1**, is a **multi-asset long/short book** (a *vector* of target weights over
+  ~10 Binance USDT coins, gross-capped 2×). Add a portfolio-strategy abstraction that consumes
+  a weight vector in one shot (e.g. `fynance_research.strategies.ls1_live.target_weights()` →
+  `{pair: weight}`, fraction of capital, Σ\|w\|≤2) and emits N venue-neutral `Signal`s + the
+  per-coin order routing. **Interim**: deployable now as 10 single-instrument strategies each
+  calling `ls1_live.coin_exposure("<PAIR>")` (works, but recomputes the book 10×). Spec:
+  `fynance-research/DEPLOY_LS1.md`. Daily rebalance; reads bars from the dccd Binance store.
+
 ## Open / deferred (maintainer decisions)
 
 - [ ] **Final project name.** Kept `trading_bot` for now — choose and apply a final

--- a/doc/dev/plans/binance-adapter/00-plan.md
+++ b/doc/dev/plans/binance-adapter/00-plan.md
@@ -1,0 +1,70 @@
+---
+plan: binance-adapter
+kind: global
+status: planning
+roadmap: "- [ ] **E11 — Binance adapter (2nd live venue).** `BinanceBroker` REST behind the `Broker` port (HMAC-SHA256 signing vs Binance's vector; orders/balances/fills/ticker; `newClientOrderId` idempotency; testnet-capable), wired into `service_factory`. Public market data key-free; private path proven by mocks + an opt-in Binance **testnet** E2E. WS deferred."
+release_on_done: false
+---
+
+# E11 — Binance adapter (2nd live venue)
+
+## Goal
+
+Add **Binance** as the second live venue behind the existing venue-neutral
+`Broker` port — proving the multi-exchange design end-to-end (Kraken was the
+first; the port, registry, `PaperBroker` and the off-by-default live gate are all
+reused unchanged). `BinanceBroker` is a **REST adapter** mirroring `KrakenBroker`:
+domain-types-only surface, `transport` plumbing underneath, HMAC-**SHA256**
+signing verified against Binance's published vector.
+
+**Why now (the real use case):** the next epic, the multi-asset **LS1** long/short
+book, executes on ~10 **Binance USDT** pairs (daily rebalance). Its *bars* come
+from the **dccd** Binance store — so this broker only does **execution**
+(orders / balances / fills / ticker), not OHLC history.
+
+**Posture (decided with the maintainer):** Binance offers a real **spot testnet**
+(`testnet.binance.vision`) — unlike Kraken. So the adapter is **testnet-capable**
+(configurable base URL) and ships an **opt-in `network` E2E** that does a real
+place → query → cancel round-trip on the testnet with a free testnet key
+(paper money, isolated). Public market data works **key-free**; the private path
+is otherwise proven by **mocks + the signing vector**. Paper stays the default;
+Binance (mainnet *or* testnet) sits behind the same `live_enabled` opt-in gate —
+**no mainnet order is ever sent here**. WebSocket (public + user-data) is
+**deferred** to a follow-up (mirrors how Kraken split WS into its own leaf).
+
+## Decomposition
+
+1. **binance-symbol** — `domain/instrument.py`: `parse_binance_symbol` (concatenated,
+   separator-less pairs split on a known-quote table) + confirm `to_venue_symbol("binance")`.
+   Pure, no I/O.
+2. **binance-rest** — `BinanceBroker` REST adapter (signing vs vector, orders/balances/
+   fills/ticker, `newClientOrderId` idempotency, composite venue-order-id for symbol-scoped
+   cancel, testnet-capable) + mock tests + public smoke + opt-in testnet E2E; wired into
+   `service_factory`/registry/exports.
+
+## Leaf checklist
+
+- [ ] 01 binance-symbol — feat/binance-symbol — low (→ opus)
+- [ ] 02 binance-rest — feat/binance-rest — high (→ opus) (depends on 01)
+
+## Dependencies
+
+- 02 depends on 01 (`BinanceBroker` uses `parse_binance_symbol`). Serial.
+
+## Done criteria
+
+- `trading_bot/brokers/binance.py` exposes `BinanceBroker` behind the `Broker` port;
+  registered/wired in `service_factory` (`binance` ∈ live venues) and exported from
+  `brokers/__init__`.
+- Signing matches **Binance's published HMAC-SHA256 vector**; private endpoints are
+  **mock**-covered (request shaping incl. signed query + `X-MBX-APIKEY`, response parsing
+  to domain types); a real **public** ticker smoke (`-m network`) passes; the **testnet**
+  E2E (`-m network`) does a real place+cancel+balance round-trip when `BINANCE_API_KEY`/
+  `BINANCE_API_SECRET` (testnet) are present, and **skips** cleanly otherwise.
+- Binance's symbol-scoped `cancel`/`myTrades` are handled venue-neutrally (composite
+  `"<SYMBOL>:<orderId>"` venue-order-id; `fills()` over a configured symbol set) — both
+  documented in an ADR.
+- Paper stays the default; live (incl. testnet) is behind the existing off-by-default
+  `live_enabled` opt-in. Secrets only via `.env` (gitignored), never logged.
+- `ruff` + `mypy` + `pytest` green via `.venv`.
+- Last leaf (02) removes the E11 line from `07-roadmap.md` and updates `06-status.md`.

--- a/doc/dev/plans/binance-adapter/01-binance-symbol.md
+++ b/doc/dev/plans/binance-adapter/01-binance-symbol.md
@@ -1,0 +1,82 @@
+---
+plan: binance-adapter/01-binance-symbol
+kind: leaf
+status: planned
+complexity: low
+depends: []
+parallel: false
+branch: feat/binance-symbol
+pr: ""
+---
+
+# Binance symbol parsing (venue-neutral ↔ Binance pair codes)
+
+## Goal
+
+Teach the pure `domain/instrument.py` to translate Binance pair codes to/from the
+canonical `Symbol`. Binance concatenates **without a separator** (`BTCUSDT`,
+`ETHBTC`, `BNBUSDT`) using **canonical asset codes** (no Kraken-style `X`/`Z`
+prefixes, no `XBT` alias — Binance Bitcoin is `BTC`). So the existing generic
+`to_venue_symbol` path already renders Binance pairs correctly; the missing piece
+is the **inverse** parse, needed to rebuild `Order`s/`Fill`s from Binance
+responses.
+
+## Files to change
+
+- `trading_bot/domain/instrument.py` — add `parse_binance_symbol(pair) -> Symbol`
+  and a module-level `_BINANCE_QUOTES` table; export `parse_binance_symbol` in
+  `__all__`. (Do **not** change `to_venue_symbol` behaviour — just confirm/keep
+  the generic branch; optionally add an explicit `venue == "binance"` no-op branch
+  for clarity.)
+- `trading_bot/tests/domain/test_instrument.py` — add Binance cases.
+
+## Steps
+
+1. Add `_BINANCE_QUOTES`: an ordered tuple of Binance quote assets, **longest
+   first** so the suffix match is unambiguous:
+   `("FDUSD", "USDT", "USDC", "TUSD", "BUSD", "DAI", "BTC", "ETH", "BNB", "EUR",
+   "GBP", "TRY", "AUD", "BRL", "USD")`.
+2. `parse_binance_symbol(pair)`:
+   - honour an explicit separator first (`/`, `-`, `_`) → `Symbol(base, quote)`
+     (mirrors `parse_kraken_pair`);
+   - else upper-case and find the **first** quote in `_BINANCE_QUOTES` (longest
+     first) that the string **ends with** and leaves a non-empty base →
+     `Symbol(base, quote)`;
+   - else `raise ValueError(f"cannot parse Binance pair {pair!r}")`.
+   - `Symbol.__post_init__` already canonicalises both legs (`normalise` passes
+     Binance codes through unchanged), so no Binance-specific alias table is
+     needed.
+3. Confirm `Symbol("BTC", "USDT").to_venue_symbol("binance") == "BTCUSDT"` (the
+   generic `f"{base}{quote}"` branch). Add an explicit `binance` branch only if it
+   improves readability — behaviour must not change for any other venue.
+
+## Tests
+
+- `parse_binance_symbol("BTCUSDT") == Symbol("BTC", "USDT")`;
+  `"ETHBTC" == Symbol("ETH", "BTC")`; `"BNBUSDT" == Symbol("BNB", "USDT")`;
+  `"ETHFDUSD" == Symbol("ETH", "FDUSD")` (longest-quote-first wins over `USD`).
+- Round-trip for every LS1-style pair: for each base in
+  `{BTC, ETH, BNB, SOL, XRP, ADA, DOGE, …}`,
+  `parse_binance_symbol(Symbol(base, "USDT").to_venue_symbol("binance")) ==
+  Symbol(base, "USDT")`.
+- Separator forms: `parse_binance_symbol("BTC/USDT")`, `"BTC-USDT"`, `"btc_usdt"`
+  all equal `Symbol("BTC", "USDT")`.
+- `to_venue_symbol("binance")`: `BTC/USDT → "BTCUSDT"`, `ETH/BTC → "ETHBTC"`
+  (asserts **no** `XBT` aliasing leaks into Binance, unlike Kraken).
+- `pytest.raises(ValueError)` on an unparseable code (e.g. `"BTC"` alone, `"ZZZZ"`).
+
+## Verification on real data
+
+Not a data path on its own — but make the parse table **honest** against the live
+venue: in the `binance-rest` leaf's public smoke, assert that the symbols Binance
+returns from `GET /api/v3/exchangeInfo` for the configured pairs each round-trip
+through `parse_binance_symbol` ↔ `to_venue_symbol("binance")`. (Recorded here so
+the parse table is checked against reality, not just hand-picked cases.)
+
+## Closeout
+
+- CHANGELOG (Added): "`domain.instrument.parse_binance_symbol` — parse Binance
+  concatenated pair codes (`BTCUSDT`) into canonical `Symbol`s."
+- ADR: only if a non-trivial choice arises (e.g. quote-table ordering / ambiguity
+  policy). Otherwise none.
+- Status/roadmap: no change (deferred to leaf 02).

--- a/doc/dev/plans/binance-adapter/02-binance-rest.md
+++ b/doc/dev/plans/binance-adapter/02-binance-rest.md
@@ -1,0 +1,158 @@
+---
+plan: binance-adapter/02-binance-rest
+kind: leaf
+status: planned
+complexity: high
+depends: [01]
+parallel: false
+branch: feat/binance-rest
+pr: ""
+---
+
+# BinanceBroker — REST (signing, orders, balances, fills, ticker) + testnet E2E
+
+## Goal
+
+`BinanceBroker` implementing the `Broker` port over Binance's spot REST API:
+HMAC-**SHA256** request signing (verified vs Binance's published vector), public
+market data (ticker, instrument precision) and the private order/balance/fills
+calls, mapping domain `Order`/`Fill`/`Money`/`Instrument` to/from Binance
+payloads. Sits on `transport.AsyncHTTPClient` + a generic `RateLimiter`.
+**Testnet-capable** (configurable base URL) so an opt-in `network` E2E proves the
+real round-trip. **No key required to build or run the unit suite** (mirrors the
+Kraken posture); the testnet E2E skips without a key.
+
+## Files to change
+
+- `trading_bot/brokers/binance.py` — new; `BinanceBroker` (+ a pure `_sign` helper).
+- `trading_bot/brokers/__init__.py` — export `BinanceBroker`.
+- `trading_bot/application/service_factory.py` — add `"binance"` to `_LIVE_VENUES`,
+  a `_build_live_venue` branch constructing `BinanceBroker()`, and the import.
+- `trading_bot/tests/brokers/test_binance_rest.py` — new (mocks + signing vector +
+  public smoke + testnet E2E).
+- `.env.example` — add `BINANCE_API_KEY` / `BINANCE_API_SECRET` and the optional
+  `BINANCE_API_BASE` (testnet toggle), documenting the testnet URL.
+
+## Steps
+
+1. **Read first** for parity: `trading_bot/brokers/kraken.py` (the sibling adapter
+   — capability set, `_private_post`/`_public_get` shape, error mapping, money via
+   `money(str(...))`) and `domain/instrument.py` (`parse_binance_symbol` from leaf
+   01, `to_venue_symbol`, `normalise`).
+2. **Signing** (`_sign(query: str, secret: str) -> str`, pure, no I/O/clock):
+   `hmac.new(secret.encode(), query.encode(), hashlib.sha256).hexdigest()`, where
+   `query` is the **urlencoded** params including `timestamp` (ms) and
+   `recvWindow`. The signed request appends `&signature=<sig>` and sends the
+   `X-MBX-APIKEY: <key>` header. Credentials are env-sourced
+   (`BINANCE_API_KEY` / `BINANCE_API_SECRET`), never from code, never logged; the
+   broker is constructible without them (public-only / mocked).
+3. **Base URL / testnet**: constructor `base_url: str | None = None` →
+   defaults to `os.environ.get("BINANCE_API_BASE", "https://api.binance.com")`.
+   Testnet = `https://testnet.binance.vision`. Both speak the same `/api/v3/*`
+   paths. Expose `has_credentials` like Kraken.
+4. **Public** (key-free): `GET /api/v3/ticker/price?symbol=` → `ticker()`
+   (`money(str(price))`); `GET /api/v3/exchangeInfo?symbol=` → `instrument()`
+   (read `filters`: `PRICE_FILTER.tickSize` / `LOT_SIZE.stepSize` → derive
+   `price_precision` / `qty_precision` as decimal places, or fall back to
+   `baseAssetPrecision` / `quoteAssetPrecision`).
+5. **Private** (signed): `GET /api/v3/account` → `balances()` (parse the
+   `balances: [{asset, free, locked}]` array → `{normalise(asset): money(free)}`,
+   skip zero free); `POST /api/v3/order` → `place_order` (see step 6);
+   `DELETE /api/v3/order` → `cancel_order` (see step 7);
+   `GET /api/v3/openOrders` → `open_orders()` (account-wide; rebuild domain
+   `Order`s, `venue_order_id` = composite, step 7);
+   `GET /api/v3/myTrades?symbol=` → `fills()` (symbol-scoped, step 8).
+6. **`place_order`** — map domain `Order` → Binance params: `symbol`
+   (`to_venue_symbol("binance")`), `side` = `BUY`/`SELL` (upper-case of
+   `order.side.value`), `type` = `MARKET`/`LIMIT`/`STOP_LOSS_LIMIT` from
+   `OrderType`, `quantity` = `str(order.qty)`, `price` = `str(limit_price)` for
+   LIMIT (+ `timeInForce=GTC`), `stopPrice` for stop. **Idempotency:** forward
+   `order.client_order_id` as **`newClientOrderId`** *iff* it matches Binance's
+   constraint (≤36 chars, charset `[.A-Za-z0-9:/_-]`); the runner's
+   `f"{name}-{step}"` ids satisfy this. This gives **venue-level dedup** (Binance
+   rejects a duplicate `newClientOrderId` with `-2010`). Send the POST with
+   **`retry=False`** (at-most-once, like Kraken `AddOrder`): on an
+   `AmbiguousRequestError` the caller reconciles — never blind-retries. Return the
+   **composite** venue id (step 7). Raise `BrokerError` on a Binance error body
+   (`{"code": -xxxx, "msg": "..."}`).
+7. **Composite venue-order-id** — Binance `cancel`/`order`-status require a
+   **`symbol`**, but the port's `cancel_order(venue_order_id)` carries only an id.
+   Resolve this by making the adapter's venue id **`f"{SYMBOL}:{orderId}"`** (e.g.
+   `"BTCUSDT:123456"`). `place_order` and `open_orders` both produce this form;
+   `cancel_order` splits on the last `":"` → `DELETE /api/v3/order?symbol=&orderId=`.
+   The id stays opaque to the router/reconcile/store (text), so this is
+   self-contained. **ADR this.**
+8. **`fills(since_ms)`** — Binance has **no account-wide trade history**;
+   `myTrades` is **per-symbol**. Add a constructor arg `symbols: Iterable[Symbol] |
+   None = None`; `fills()` queries `myTrades?symbol=` for each (with `startTime` =
+   `since_ms`), concatenating results → domain `Fill`s (`money(str(...))` for
+   qty/price/`commission`→fee; `time` ms → `ts`; `isBuyer` → side; `id`/`orderId`).
+   If no symbols are configured **and** none can be derived, raise a clear
+   `BrokerError` explaining `fills()` needs the symbol set. **ADR this.**
+9. **Capabilities**: `{PLACE_ORDER, CANCEL, OPEN_ORDERS, BALANCES, FILLS, TICKER}`
+   (omit `PRIVATE_WS` — WS deferred).
+10. **Rate limit**: construct `AsyncHTTPClient(exchange="binance", limiter=
+    RateLimiter())` (Binance weight-budget specifics are future work; the generic
+    token bucket is enough here). Note this in the docstring.
+11. **Wire `service_factory`**: `_LIVE_VENUES = ("kraken", "binance")`;
+    `_build_live_venue` adds `if venue == "binance": return BinanceBroker()`;
+    import `BinanceBroker`. Confirm a `binance` live config without credentials
+    raises `BrokerError` (not a silent paper fallback) and that paper mode is
+    untouched.
+
+## Tests
+
+- **Signing vs Binance's published vector** (deterministic, no key): secret
+  `NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0`, query
+  `symbol=LTCBTC&side=BUY&type=LIMIT&timeInForce=GTC&quantity=1&price=0.1&recvWindow=5000&timestamp=1499827319559`
+  → `signature == c8db56825ae71d6d79447849e617115f4a920fa2acdcab2b053c4b2838bd6b71`.
+- **Mocks** (`pytest-httpx`) for every private call: assert the **request** (signed
+  `signature` present and correct, `X-MBX-APIKEY` header, expected params incl.
+  `newClientOrderId` forwarded) **and** the parsed domain objects (Decimal amounts,
+  instrument, order/fill fields). Cover: `place_order` (market/limit/stop), the
+  **composite id** returned and round-tripped through `cancel_order` (asserts the
+  `DELETE` carries the right `symbol`+`orderId`), `open_orders`, `balances`,
+  `fills` over a 2-symbol set.
+- Domain `Order` → Binance `/order` param mapping (market/limit/stop-loss).
+- A Binance error body (`{"code": -2010, "msg": "Account has insufficient
+  balance."}`) → `BrokerError`.
+- `newClientOrderId` is **omitted** when the id is incompatible (construct an order
+  with a 40-char id) — assert it falls back gracefully (no `newClientOrderId` sent).
+- `service_factory`: `mode=live`, `live_enabled=True`, `exchange=binance`, **no
+  creds** → `BrokerError`; paper mode still yields `PaperBroker`.
+
+## Verification on real data
+
+Network IS reachable. **Two** real checks (mandatory — a green mock suite is not
+enough for an execution adapter):
+
+1. **Public smoke** (`@pytest.mark.network`, **no key**): call
+   `GET /api/v3/ticker/price` and `GET /api/v3/exchangeInfo` for `BTC/USDT` live;
+   assert `ticker()` parses a price > 0 and `instrument()` returns sane precision;
+   assert the returned symbol round-trips `parse_binance_symbol` ↔
+   `to_venue_symbol("binance")`. **Run it.**
+2. **Testnet round-trip** (`@pytest.mark.network`, skips if `BINANCE_API_KEY`/
+   `BINANCE_API_SECRET` absent): point `base_url` at `https://testnet.binance.vision`,
+   then **place** a small LIMIT order far from market (won't fill), **read** it back
+   via `open_orders()`/`balances()`, **cancel** it via the composite id, and assert
+   the broker-reported state matches what was requested at every step (the order
+   appears with the right symbol/side/qty/price; the cancel removes it). This is
+   the **reconcile-against-broker-truth** check, on a real venue, paper money. If a
+   testnet key is available in `.env`, **run it and paste the evidence**; otherwise
+   report it as skipped and note the exact steps to run it.
+
+## Closeout
+
+- CHANGELOG (Added): "`brokers.BinanceBroker` — Binance spot REST adapter (HMAC-SHA256
+  signed orders/balances/fills/ticker, `newClientOrderId` idempotency, testnet-capable),
+  wired into `service_factory` as the 2nd live venue." (Changed: `service_factory`
+  `_LIVE_VENUES` now includes `binance`.)
+- ADR (PR #NN): (a) **composite venue-order-id** `"<SYMBOL>:<orderId>"` to satisfy
+  Binance's symbol-scoped cancel under the symbol-free port; (b) **`fills()`
+  symbol-scoping** via a configured symbol set (no account-wide trade history on
+  Binance); (c) `newClientOrderId` venue-level idempotency (improves on Kraken) kept
+  alongside the reconcile-on-ambiguous `retry=False` policy; (d) testnet-capable
+  base URL + the testnet-E2E posture.
+- Status: `06-status.md` — record Binance as the 2nd live venue (public key-free;
+  private mock+vector+testnet-E2E; mainnet real-key still deferred behind the opt-in).
+- Roadmap: **last leaf** — remove the E11 line from `07-roadmap.md`.


### PR DESCRIPTION
## Goal

Add **Binance** as the 2nd live venue behind the existing `Broker` port — proving
the multi-exchange design end-to-end (Kraken was the first; port, registry,
`PaperBroker` and the off-by-default live gate are reused unchanged).
`BinanceBroker` is a REST adapter mirroring `KrakenBroker` (domain-types-only
surface, `transport` plumbing, HMAC-**SHA256** signing vs Binance's published
vector).

**Why now:** the next epic — the multi-asset **LS1** long/short book — executes on
~10 **Binance USDT** pairs; its bars come from the **dccd** Binance store, so this
broker only does execution (orders/balances/fills/ticker).

**Posture:** Binance has a real **spot testnet** (`testnet.binance.vision`), so the
adapter is **testnet-capable** and ships an opt-in `network` E2E doing a real
place→query→cancel round-trip (paper money). Public data is key-free; the private
path is otherwise proven by mocks + the signing vector. Paper stays default; live
(mainnet *or* testnet) sits behind the same `live_enabled` opt-in — **no mainnet
order is ever sent**. WS deferred (mirrors Kraken).

## Leaf checklist

- [ ] 01 binance-symbol — `feat/binance-symbol` — low (→ opus) — `parse_binance_symbol`
- [ ] 02 binance-rest — `feat/binance-rest` — high (→ opus) — `BinanceBroker` REST + testnet E2E + wiring (depends on 01)

## Key design decisions (detailed in the leaves)

- **Composite venue-order-id** `"<SYMBOL>:<orderId>"` so Binance's symbol-scoped
  `cancel` works under the symbol-free port.
- **`fills()` symbol-scoping** (Binance has no account-wide trade history).
- **`newClientOrderId`** forwarded for venue-level idempotency (improves on Kraken),
  alongside the reconcile-on-ambiguous `retry=False` policy.

## Also in this PR (transparent)

Restores the **multi-asset / LS1** roadmap item that was sitting **uncommitted on
the release branch** (wrong home) — it lands on `develop` under a new *Active
epics* section, next to E11. That epic is scheduled **after** Binance.

## Test plan

- [ ] Plan tree reviewed; merge, then `/execute-leaf binance-adapter next`.