### PR TITLE
feat: parse Binance pair symbols (parse_binance_symbol)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `domain.instrument.parse_binance_symbol` — parse Binance separator-less pair codes
+  (`BTCUSDT` → `BTC/USDT`) into canonical `Symbol`s via a longest-first quote-suffix
+  table; groundwork for the Binance adapter (E11). (#60)
 - Hardening test suite (`tests/hardening/`) — proves the money-safety invariants
   under **fault injection** (a `FaultyBroker` over `PaperBroker`): reconciliation
   converges after a simulated disconnect (no order duplicated/lost), idempotent submit

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,26 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-28 Binance symbol parsing — longest-first quote-suffix table (PR #60)
+
+**Decision.** `domain.instrument.parse_binance_symbol` splits Binance's
+separator-less pair codes (`BTCUSDT`) by matching the **longest** known quote
+asset as a suffix, from a module `_BINANCE_QUOTES` table (`FDUSD/USDT/USDC/…/USD`,
+ordered longest-first), leaving the remainder as the base; an explicit separator
+(`/`, `-`, `_`) short-circuits first. Mirrors `parse_kraken_pair`. Binance uses
+canonical asset codes (no Kraken `X`/`Z` prefixes, no `XBT` alias), so `normalise`
+passes them through and `to_venue_symbol`'s generic `f"{base}{quote}"` branch
+already renders Binance pairs — only the inverse parse was missing.
+
+**Why.** A Binance symbol carries no separator and no embedded base/quote split,
+so the quote must be inferred. A longest-first suffix table disambiguates
+`USDT`/`USD` and `FDUSD`/`USD` deterministically and keeps the domain **pure**
+(no network). **Rejected:** resolving base/quote via a `/exchangeInfo` call
+(impure — couples the domain to I/O); a regex (less explicit, same ambiguity
+risk).
+
+---
+
 ### 2026-06-28 Go-live is an off-by-default opt-in; rewrite feature-complete
 
 **Decision.** Going live is an explicit, documented, **off-by-default** opt-in:

--- a/doc/dev/plans/binance-adapter/00-plan.md
+++ b/doc/dev/plans/binance-adapter/00-plan.md
@@ -44,7 +44,7 @@ Binance (mainnet *or* testnet) sits behind the same `live_enabled` opt-in gate �
 
 ## Leaf checklist
 
-- [ ] 01 binance-symbol — feat/binance-symbol — low (→ opus)
+- [x] 01 binance-symbol — feat/binance-symbol — low (→ opus)
 - [ ] 02 binance-rest — feat/binance-rest — high (→ opus) (depends on 01)
 
 ## Dependencies

--- a/doc/dev/plans/binance-adapter/01-binance-symbol.md
+++ b/doc/dev/plans/binance-adapter/01-binance-symbol.md
@@ -1,12 +1,12 @@
 ---
 plan: binance-adapter/01-binance-symbol
 kind: leaf
-status: planned
+status: done
 complexity: low
 depends: []
 parallel: false
 branch: feat/binance-symbol
-pr: ""
+pr: "#60"
 ---
 
 # Binance symbol parsing (venue-neutral ↔ Binance pair codes)

--- a/trading_bot/domain/instrument.py
+++ b/trading_bot/domain/instrument.py
@@ -14,6 +14,11 @@ particular has two layers of weirdness:
 :func:`parse_kraken_pair` turns a Kraken pair string into a :class:`Symbol`, and
 :meth:`Symbol.to_venue_symbol` renders a canonical symbol back to a venue's code.
 
+Binance is simpler: it concatenates canonical asset codes with no separator
+(``BTCUSDT``, ``ETHBTC``) and uses no X/Z prefixes and no ``XBT`` alias.
+:func:`parse_binance_symbol` is the inverse that rebuilds a :class:`Symbol` from
+a Binance pair string.
+
 The alias table (``XBT→BTC``, ``XDG→DOGE``) is the one used by the **dccd**
 Kraken adapter (``dccd/sources/kraken.py`` ``_KRAKEN_ALIASES`` and
 ``dccd/domain/symbol.py`` ``_ALIASES``); the X/Z legacy-prefix rule is Kraken's
@@ -30,6 +35,7 @@ __all__ = [
     "Instrument",
     "normalise",
     "parse_kraken_pair",
+    "parse_binance_symbol",
 ]
 
 # --- Kraken asset normalisation -------------------------------------------- #
@@ -50,6 +56,31 @@ _CANONICAL_TO_KRAKEN: dict[str, str] = {
 # legacy 4-char form. Used to split a concatenated legacy pair on the boundary.
 _FIAT: frozenset[str] = frozenset(
     {"USD", "EUR", "GBP", "JPY", "CAD", "AUD", "CHF"}
+)
+
+# --- Binance pair parsing -------------------------------------------------- #
+
+# Binance concatenates legs with no separator (``BTCUSDT``, ``ETHBTC``) using
+# canonical asset codes (no X/Z prefixes, no XBT alias — Binance Bitcoin is
+# ``BTC``). To split a concatenated pair we match a trailing quote asset; the
+# tuple is ordered **longest first** so the suffix match is unambiguous (e.g.
+# ``FDUSD`` is tried before ``USD``, ``USDT`` before ``USD``).
+_BINANCE_QUOTES: tuple[str, ...] = (
+    "FDUSD",
+    "USDT",
+    "USDC",
+    "TUSD",
+    "BUSD",
+    "DAI",
+    "BTC",
+    "ETH",
+    "BNB",
+    "EUR",
+    "GBP",
+    "TRY",
+    "AUD",
+    "BRL",
+    "USD",
 )
 
 
@@ -152,8 +183,8 @@ class Symbol:
         ----------
         venue : str
             The venue name. Only ``"kraken"`` (case-insensitive) has a bespoke
-            rendering today (altname form, ``XBTUSD`` / ``ETHXBT``); any other
-            venue gets the concatenated canonical legs.
+            rendering today (altname form, ``XBTUSD`` / ``ETHXBT``); ``"binance"``
+            and any other venue get the concatenated canonical legs (``BTCUSDT``).
 
         Returns
         -------
@@ -166,10 +197,14 @@ class Symbol:
         'XBTUSD'
         >>> Symbol("ETH", "BTC").to_venue_symbol("kraken")
         'ETHXBT'
+        >>> Symbol("BTC", "USDT").to_venue_symbol("binance")
+        'BTCUSDT'
 
         """
         if venue.lower() == "kraken":
             return f"{_to_kraken_asset(self.base)}{_to_kraken_asset(self.quote)}"
+        # Binance (and any other venue) use the bare concatenated canonical legs;
+        # the explicit branch keeps the no-alias guarantee visible.
         return f"{self.base}{self.quote}"
 
 
@@ -235,6 +270,63 @@ def parse_kraken_pair(pair: str) -> Symbol:
                 return Symbol(base_raw, quote_raw)
 
     raise ValueError(f"cannot parse Kraken pair {pair!r}")
+
+
+def parse_binance_symbol(pair: str) -> Symbol:
+    """Parse a Binance pair string into a canonical :class:`Symbol`.
+
+    Binance concatenates the legs with no separator and uses canonical asset
+    codes (``BTCUSDT``, ``ETHBTC``, ``BNBUSDT``) — no Kraken-style ``X``/``Z``
+    prefixes and no ``XBT`` alias (Binance Bitcoin is ``BTC``).
+
+    The split strategy:
+
+    * a separator (``/``, ``-``, ``_``) is honoured if present;
+    * otherwise the first quote in :data:`_BINANCE_QUOTES` (longest first) that
+      the upper-cased string **ends with**, leaving a non-empty base, wins.
+
+    :meth:`Symbol.__post_init__` canonicalises both legs, but :func:`normalise`
+    passes Binance codes through unchanged, so no Binance alias table is needed.
+
+    Parameters
+    ----------
+    pair : str
+        A Binance pair string (``"BTCUSDT"``, ``"ETHBTC"``, ``"BTC/USDT"``).
+
+    Returns
+    -------
+    Symbol
+        The canonical symbol.
+
+    Raises
+    ------
+    ValueError
+        If the pair cannot be split into a base and a quote.
+
+    Examples
+    --------
+    >>> str(parse_binance_symbol("BTCUSDT"))
+    'BTC/USDT'
+    >>> str(parse_binance_symbol("ETHBTC"))
+    'ETH/BTC'
+    >>> str(parse_binance_symbol("ETHFDUSD"))
+    'ETH/FDUSD'
+
+    """
+    raw = pair.strip()
+    # Explicit separator wins.
+    for sep in ("/", "-", "_"):
+        if sep in raw:
+            base, quote = raw.split(sep, 1)
+            return Symbol(base, quote)
+
+    code = raw.upper()
+    # Longest-first suffix match so e.g. ``FDUSD`` wins over ``USD``.
+    for quote in _BINANCE_QUOTES:
+        if code.endswith(quote) and len(code) > len(quote):
+            return Symbol(code[: -len(quote)], quote)
+
+    raise ValueError(f"cannot parse Binance pair {pair!r}")
 
 
 @dataclass(frozen=True, slots=True)

--- a/trading_bot/tests/domain/test_instrument.py
+++ b/trading_bot/tests/domain/test_instrument.py
@@ -8,6 +8,7 @@ from trading_bot.domain.instrument import (
     Instrument,
     Symbol,
     normalise,
+    parse_binance_symbol,
     parse_kraken_pair,
 )
 
@@ -71,6 +72,57 @@ class TestParseKrakenPair:
     def test_unparseable_raises(self) -> None:
         with pytest.raises(ValueError):
             parse_kraken_pair("ZZ")
+
+
+# Representative real Binance pair strings (canonical codes, no separator).
+REAL_BINANCE_PAIRS = [
+    "BTCUSDT",
+    "ETHUSDT",
+    "BNBUSDT",
+    "SOLUSDT",
+    "XRPUSDT",
+    "ADAUSDT",
+    "DOGEUSDT",
+    "ETHBTC",
+]
+
+
+class TestParseBinanceSymbol:
+    def test_concatenated_form(self) -> None:
+        assert parse_binance_symbol("BTCUSDT") == Symbol("BTC", "USDT")
+        assert parse_binance_symbol("ETHBTC") == Symbol("ETH", "BTC")
+        assert parse_binance_symbol("BNBUSDT") == Symbol("BNB", "USDT")
+
+    def test_longest_quote_wins(self) -> None:
+        # FDUSD must win over the shorter USD suffix.
+        assert parse_binance_symbol("ETHFDUSD") == Symbol("ETH", "FDUSD")
+
+    @pytest.mark.parametrize("base", ["BTC", "ETH", "BNB", "SOL", "XRP", "ADA", "DOGE"])
+    def test_round_trip_from_symbol(self, base: str) -> None:
+        sym = Symbol(base, "USDT")
+        rendered = sym.to_venue_symbol("binance")
+        assert parse_binance_symbol(rendered) == sym
+
+    def test_explicit_separator(self) -> None:
+        assert parse_binance_symbol("BTC/USDT") == Symbol("BTC", "USDT")
+        assert parse_binance_symbol("BTC-USDT") == Symbol("BTC", "USDT")
+        assert parse_binance_symbol("btc_usdt") == Symbol("BTC", "USDT")
+
+    def test_no_xbt_aliasing_on_render(self) -> None:
+        # Unlike Kraken, Binance never aliases BTC to XBT.
+        assert Symbol("BTC", "USDT").to_venue_symbol("binance") == "BTCUSDT"
+        assert Symbol("ETH", "BTC").to_venue_symbol("binance") == "ETHBTC"
+
+    def test_unparseable_raises(self) -> None:
+        with pytest.raises(ValueError):
+            parse_binance_symbol("BTC")  # bare base, no quote suffix left
+        with pytest.raises(ValueError):
+            parse_binance_symbol("ZZZZ")  # no known quote suffix
+
+    @pytest.mark.parametrize("pair", REAL_BINANCE_PAIRS)
+    def test_real_pairs_round_trip(self, pair: str) -> None:
+        # Honesty check: the parse table matches the codes Binance actually uses.
+        assert parse_binance_symbol(pair).to_venue_symbol("binance") == pair
 
 
 class TestSymbol:


### PR DESCRIPTION
## Summary
- Add `domain.instrument.parse_binance_symbol(pair) -> Symbol` — the inverse of `to_venue_symbol("binance")`, splitting Binance's separator-less pair codes (`BTCUSDT`) into a canonical `Symbol` via a longest-first quote-suffix table (`_BINANCE_QUOTES`).
- Pure domain change (no I/O, no float); mirrors `parse_kraken_pair`.

## Why
- Binance concatenates pairs without a separator and uses canonical asset codes (no Kraken `X`/`Z` prefixes, no `XBT` alias), so `to_venue_symbol`'s generic branch already renders Binance pairs — only the inverse parse was missing (needed by the upcoming `BinanceBroker` to rebuild `Order`s/`Fill`s).
- A longest-first quote table disambiguates `USDT`/`USD`, `FDUSD`/`USD` deterministically and keeps the domain pure (no `exchangeInfo` call). See ADR (PR).

## Changes
- `trading_bot/domain/instrument.py` — `_BINANCE_QUOTES` + `parse_binance_symbol`; `__all__` export; docstring updates. `to_venue_symbol` behaviour unchanged for every venue.
- `trading_bot/tests/domain/test_instrument.py` — concatenated/separator/longest-first/round-trip/`ValueError` cases + a real-pairs honesty round-trip.

## Changelog
Added under [Unreleased]:
- `domain.instrument.parse_binance_symbol` — parse Binance pair codes into canonical `Symbol`s (E11 groundwork).

## Test plan
- [x] `.venv/bin/python -m pytest` — 585 passed, 5 deselected (network)
- [x] `.venv/bin/ruff check trading_bot/` — clean
- [x] `.venv/bin/mypy trading_bot/` — clean (domain strict)
- [ ] CI green

First leaf of the **E11 — Binance adapter** plan tree (`doc/dev/plans/binance-adapter/`). Leaf 02 (`BinanceBroker` REST) depends on this.