### PR TITLE
feat: BinanceBroker spot REST adapter — 2nd live venue (E11)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,30 @@
 # Example environment for trading_bot — copy to `.env` and fill in real values.
 #
-# `.env` is gitignored: NEVER commit real key material. The KrakenBroker reads
-# these two variables from the environment and signs private REST requests with
-# them. They are optional — the broker is constructible without them and serves
+# `.env` is gitignored: NEVER commit real key material. Each broker reads its
+# credentials from the environment and signs private REST requests with them.
+# They are optional — every broker is constructible without them and serves
 # public market data (ticker, instrument metadata) key-free; private calls
-# (balances, place/cancel/open orders, fills) require both to be set.
+# (balances, place/cancel/open orders, fills) require both key + secret to be set.
+
+# --- Kraken (HMAC-SHA512) ---------------------------------------------------
 
 # Kraken API key (the public identifier of your API credential).
 KRAKEN_API_KEY=
 
 # Kraken API secret (base64-encoded; used for HMAC-SHA512 request signing).
 KRAKEN_API_SECRET=
+
+# --- Binance (HMAC-SHA256) --------------------------------------------------
+
+# Binance API key (sent as the X-MBX-APIKEY header on signed requests).
+BINANCE_API_KEY=
+
+# Binance API secret (used for HMAC-SHA256 request signing).
+BINANCE_API_SECRET=
+
+# Optional Binance REST base URL — the testnet toggle. Leave empty to use
+# mainnet (https://api.binance.com). Set to the spot testnet to exercise the
+# signed round-trip without real funds:
+#   BINANCE_API_BASE=https://testnet.binance.vision
+# (Get a testnet key/secret at https://testnet.binance.vision.)
+BINANCE_API_BASE=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `brokers.BinanceBroker` — Binance spot REST adapter behind the `Broker` port
+  (HMAC-SHA256 signed orders/balances/fills/ticker; public market data key-free),
+  the **2nd live venue**. `newClientOrderId` carries the client-order-id for
+  venue-level idempotency; the non-idempotent order POST stays `retry=False`
+  (reconcile-on-ambiguous). Composite venue-order-id `"<SYMBOL>:<orderId>"` lets
+  the symbol-free port drive Binance's symbol-scoped cancel; `fills()` queries
+  `myTrades` over a configured symbol set. **Testnet-capable** (configurable base
+  URL) with an opt-in `network` E2E doing a real place→read→cancel round-trip on
+  `testnet.binance.vision`. Wired into `service_factory` (`binance` ∈ live venues);
+  paper stays the default, live behind the existing off-by-default opt-in. Completes
+  **E11**. (#61)
 - `domain.instrument.parse_binance_symbol` — parse Binance separator-less pair codes
   (`BTCUSDT` → `BTC/USDT`) into canonical `Symbol`s via a longest-first quote-suffix
   table; groundwork for the Binance adapter (E11). (#60)
@@ -26,6 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `service_factory` recognises `binance` as a live venue (`_LIVE_VENUES`); a `binance`
+  live config without credentials raises `BrokerError` (never a silent paper fallback).
+- `transport.AsyncHTTPClient.request(method, …)` — a thin public seam over the shared
+  request loop for arbitrary verbs (Binance signs `DELETE /api/v3/order` for cancels),
+  with the same `retry`/`AmbiguousRequestError` semantics as `post`. (#61)
 - `run_app`/`build_runners` now **reject** two strategies declaring the same instrument
   (a `ConfigError`, catching aliases like `XBT/USD`≡`BTC/USD`) — the shared per-instrument
   tracker has no per-strategy attribution, so commingling is refused up front.

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,49 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-28 BinanceBroker — 2nd live venue; composite id, fills scoping, newClientOrderId, testnet (PR #61)
+
+**Decision.** `BinanceBroker` (spot REST) is the second adapter behind the
+venue-neutral `Broker` port, proving the multi-exchange design end-to-end. Four
+Binance-specific choices were made to fit the symbol-free, Kraken-shaped port:
+- **Composite venue-order-id `"<SYMBOL>:<orderId>"`.** Binance's `cancel`/order
+  endpoints require the **symbol**, but `Broker.cancel_order(venue_order_id)`
+  carries only an id. The adapter therefore makes its venue id the composite
+  `symbol:orderId` (produced identically by `place_order` *and* `open_orders`, split
+  on the **last** `:`), so reconcile→cancel works. The id stays opaque text to the
+  router/store.
+- **`fills()` over a configured symbol set.** Binance has no account-wide trade
+  history; `myTrades` is per-symbol. `BinanceBroker(symbols=…)` queries each; with no
+  symbols it raises a clear `BrokerError` rather than silently returning `[]`.
+- **`newClientOrderId` venue-level idempotency.** The domain `client_order_id`
+  (`f"{name}-{step}"`) is forwarded as `newClientOrderId` when it fits Binance's
+  `[.A-Za-z0-9:/_-]{1,36}` constraint — a real venue-side dedup (Binance rejects a
+  duplicate with `-2010`), kept **alongside** the `retry=False` reconcile-on-ambiguous
+  policy (defence in depth; improves on Kraken, which has no usable client id).
+- **Testnet-capable base URL.** `base_url` (env `BINANCE_API_BASE`) toggles
+  `testnet.binance.vision`, enabling an opt-in `network` E2E real round-trip in paper
+  money — Binance offers a real spot testnet (Kraken did not), so this is the cheapest
+  path to real-venue order verification.
+
+Two supporting changes: a small public `transport.AsyncHTTPClient.request(method, …)`
+seam (Binance signs `DELETE` for cancels — GET/POST-only was insufficient), same
+retry/ambiguity semantics; and `STOP_LOSS` maps to Binance `STOP_LOSS_LIMIT` resting
+at the stop price (Binance has no symbol-free stop-market that fits the domain shape).
+Posture unchanged: public data key-free, private path proven by mocks + the signing
+vector + a key-gated testnet E2E; **no mainnet order is ever sent**; paper stays the
+default behind the `live_enabled` opt-in.
+
+**Why.** A second venue is the real test of the port abstraction. Binance breaks two
+of Kraken's conveniences (symbol-free cancel, account-wide trade history); solving both
+inside the adapter (composite id, configured symbol set) keeps the port and the engine
+unchanged — the abstraction holds. `newClientOrderId` is a genuine idempotency upgrade
+worth taking even though live is still off. **Rejected:** widening the `Broker` port to
+pass a symbol into `cancel_order`/`fills` (would leak a venue quirk into every adapter
+and the engine); a per-call DELETE hack in the adapter instead of the transport seam
+(bypasses the shared retry loop).
+
+---
+
 ### 2026-06-28 Binance symbol parsing — longest-first quote-suffix table (PR #60)
 
 **Decision.** `domain.instrument.parse_binance_symbol` splits Binance's

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -7,7 +7,7 @@ _Last updated: 2026-06-28_
 **The E1–E10 rewrite is complete — the engine is feature-complete and hardened.**
 Phase 0 (tooling) plus all ten epics shipped: `domain/` (pure, mypy-strict),
 `transport/` (http/ws/ratelimit), `brokers/` (`Broker` port + `KrakenBroker` REST+WS +
-port-pure `PaperBroker`), `storage/` (`SqliteStore`, money as TEXT), `application/`
+`BinanceBroker` REST + port-pure `PaperBroker`), `storage/` (`SqliteStore`, money as TEXT), `application/`
 (declarative `AppConfig`+`EventBus`, idempotent risk-gated `OrderRouter`,
 `PositionTracker`, `reconcile`, `Strategy`+safe loader, causal `DataFeed`+`feed_for`,
 `StrategyRunner`, `PerformanceService`, `RiskManager`+kill-switch, `Orchestrator`,
@@ -19,8 +19,16 @@ exposes the read-only dashboard. The money-safety invariants (reconcile converge
 idempotency, kill-switch) are **proven under fault injection** (`tests/hardening/`).
 **Live trading is off by default** behind an explicit `live_enabled` opt-in +
 credentials + the go-live runbook (`doc/dev/09-go-live.md`) — **no real order is ever
-sent from the repo**. ~570 tests green via the project `.venv`; ruff + mypy clean
+sent from the repo**. ~617 tests green via the project `.venv`; ruff + mypy clean
 across the whole package.
+
+**Post-0.2.0 — E11 (Binance) shipped:** `BinanceBroker` (spot REST) is the **2nd live
+venue** behind the `Broker` port (HMAC-SHA256 signing vs Binance's vector; composite
+venue-id for symbol-scoped cancel; `newClientOrderId` idempotency; **testnet-capable**
+with an opt-in real round-trip E2E on `testnet.binance.vision`). Public market data is
+key-free; the private path is mock+vector+testnet-E2E proven. This is the execution
+venue for the upcoming **multi-asset / LS1** epic (next). Mainnet real-key enablement
+stays deferred behind the opt-in.
 
 **Remaining (maintainer decisions, see `07-roadmap.md`):** the **final project name**
 (kept `trading_bot`), and **real-key live enablement** (validate Kraken private

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -17,7 +17,6 @@ off-by-default opt-in. History in git + `CHANGELOG.md`; see `06-status.md`.
 
 ## Active epics (post-0.2.0)
 
-- [ ] **E11 — Binance adapter (2nd live venue).** `BinanceBroker` REST behind the `Broker` port (HMAC-SHA256 signing vs Binance's vector; orders/balances/fills/ticker; `newClientOrderId` idempotency; testnet-capable), wired into `service_factory`. Public market data key-free; private path proven by mocks + an opt-in Binance **testnet** E2E. WS deferred.
 - [ ] **Multi-asset / portfolio strategy unit** (signalé par `fynance-research`). Today a
   `SignalFn` is `(bars) -> Signal` for **one** instrument; the first validated research
   strategy, **LS1**, is a **multi-asset long/short book** (a *vector* of target weights over

--- a/doc/dev/plans/binance-adapter/00-plan.md
+++ b/doc/dev/plans/binance-adapter/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: binance-adapter
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **E11 — Binance adapter (2nd live venue).** `BinanceBroker` REST behind the `Broker` port (HMAC-SHA256 signing vs Binance's vector; orders/balances/fills/ticker; `newClientOrderId` idempotency; testnet-capable), wired into `service_factory`. Public market data key-free; private path proven by mocks + an opt-in Binance **testnet** E2E. WS deferred."
 release_on_done: false
 ---
@@ -45,7 +45,7 @@ Binance (mainnet *or* testnet) sits behind the same `live_enabled` opt-in gate �
 ## Leaf checklist
 
 - [x] 01 binance-symbol — feat/binance-symbol — low (→ opus)
-- [ ] 02 binance-rest — feat/binance-rest — high (→ opus) (depends on 01)
+- [x] 02 binance-rest — feat/binance-rest — high (→ opus) (depends on 01)
 
 ## Dependencies
 

--- a/doc/dev/plans/binance-adapter/02-binance-rest.md
+++ b/doc/dev/plans/binance-adapter/02-binance-rest.md
@@ -1,12 +1,12 @@
 ---
 plan: binance-adapter/02-binance-rest
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01]
 parallel: false
 branch: feat/binance-rest
-pr: ""
+pr: "#61"
 ---
 
 # BinanceBroker — REST (signing, orders, balances, fills, ticker) + testnet E2E
@@ -147,7 +147,7 @@ enough for an execution adapter):
   signed orders/balances/fills/ticker, `newClientOrderId` idempotency, testnet-capable),
   wired into `service_factory` as the 2nd live venue." (Changed: `service_factory`
   `_LIVE_VENUES` now includes `binance`.)
-- ADR (PR #NN): (a) **composite venue-order-id** `"<SYMBOL>:<orderId>"` to satisfy
+- ADR (PR #61): (a) **composite venue-order-id** `"<SYMBOL>:<orderId>"` to satisfy
   Binance's symbol-scoped cancel under the symbol-free port; (b) **`fills()`
   symbol-scoping** via a configured symbol set (no account-wide trade history on
   Binance); (c) `newClientOrderId` venue-level idempotency (improves on Kraken) kept

--- a/trading_bot/application/service_factory.py
+++ b/trading_bot/application/service_factory.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 
 import pathlib
 from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
 
 from trading_bot.application.config import AppConfig, BrokerConfig
 from trading_bot.application.events import EventBus
@@ -58,6 +59,7 @@ from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.risk import RiskManager
 from trading_bot.brokers.base import Broker
+from trading_bot.brokers.binance import BinanceBroker
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.paper import PaperBroker
 from trading_bot.domain.errors import BrokerError, LiveTradingNotEnabled
@@ -66,11 +68,30 @@ from trading_bot.storage.sqlite_store import SqliteStore
 __all__ = ["Engine", "build_engine"]
 
 #: Venue keys recognised as live (non-simulated) adapters.
-_LIVE_VENUES = ("kraken",)
+_LIVE_VENUES = ("kraken", "binance")
 #: The venue key for the in-process simulator.
 _PAPER_VENUE = "paper"
 #: The go-live runbook the live-opt-in refusals point users at.
 _RUNBOOK = "doc/dev/09-go-live.md"
+
+
+@runtime_checkable
+class _LiveBroker(Broker, Protocol):
+    """A live venue adapter: a :class:`Broker` that also reports credentials.
+
+    The credential gate in :func:`_build_broker` consults ``has_credentials``,
+    which is *not* part of the venue-neutral :class:`Broker` port (the simulator
+    has no credentials concept). Every live adapter
+    (:class:`~trading_bot.brokers.kraken.KrakenBroker`,
+    :class:`~trading_bot.brokers.binance.BinanceBroker`) exposes it, so this
+    narrow structural extension of the port lets the factory check it (and return
+    a value still assignable to :class:`Broker`) without widening the port itself.
+    """
+
+    @property
+    def has_credentials(self) -> bool:
+        """Whether the adapter holds both API key and secret."""
+        ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -260,11 +281,16 @@ def _selected_venue(config: AppConfig) -> str:
     return first.exchange.lower()
 
 
-def _build_live_venue(venue: str) -> KrakenBroker:
+def _build_live_venue(venue: str) -> _LiveBroker:
     """Construct the live adapter for ``venue`` (reads credentials from env)."""
     if venue == "kraken":
         # KrakenBroker reads KRAKEN_API_KEY / KRAKEN_API_SECRET from the
         # environment; ``has_credentials`` reports whether both are present.
         return KrakenBroker()
+    if venue == "binance":
+        # BinanceBroker reads BINANCE_API_KEY / BINANCE_API_SECRET (and the
+        # optional BINANCE_API_BASE testnet toggle) from the environment;
+        # ``has_credentials`` reports whether both key + secret are present.
+        return BinanceBroker()
     # Unreachable: callers gate on ``_LIVE_VENUES`` first. Defensive only.
     raise BrokerError(f"no live adapter for venue {venue!r}")

--- a/trading_bot/brokers/__init__.py
+++ b/trading_bot/brokers/__init__.py
@@ -27,6 +27,9 @@ Public surface:
   failure (re-exported for convenience);
 * :class:`~trading_bot.brokers.kraken.KrakenBroker` — the concrete Kraken REST
   adapter (signed orders/balances/fills + public market data);
+* :class:`~trading_bot.brokers.binance.BinanceBroker` — the concrete Binance spot
+  REST adapter (HMAC-SHA256-signed orders/balances/fills + public market data,
+  testnet-capable);
 * :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS` — the Kraken v2 private
   WebSocket adapter streaming ``executions`` (own trades / order updates) into
   domain :class:`~trading_bot.domain.fill.Fill`s (auth-token flow; live private
@@ -38,6 +41,7 @@ Public surface:
 from __future__ import annotations
 
 from trading_bot.brokers.base import Broker, BrokerError, Capability, require
+from trading_bot.brokers.binance import BinanceBroker
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.kraken_ws import KrakenPrivateWS
 from trading_bot.brokers.paper import PaperBroker
@@ -49,6 +53,7 @@ __all__ = [
     "require",
     "BrokerError",
     "BrokerRegistry",
+    "BinanceBroker",
     "KrakenBroker",
     "KrakenPrivateWS",
     "PaperBroker",

--- a/trading_bot/brokers/binance.py
+++ b/trading_bot/brokers/binance.py
@@ -1,0 +1,764 @@
+"""The :class:`BinanceBroker` — Binance spot REST adapter behind the :class:`Broker` port.
+
+This is the concrete Binance implementation of the venue-neutral
+:class:`~trading_bot.brokers.base.Broker` port — the sibling of
+:class:`~trading_bot.brokers.kraken.KrakenBroker`. It speaks **domain types only**
+(:class:`~trading_bot.domain.order.Order`,
+:class:`~trading_bot.domain.fill.Fill`,
+:class:`~trading_bot.domain.instrument.Instrument`,
+:class:`~trading_bot.domain.money.Money`) on its surface and translates them to
+and from Binance's spot REST payloads underneath, using the
+:mod:`trading_bot.transport` plumbing for I/O, retry/backoff and rate limiting.
+
+Signing
+-------
+Private endpoints are authenticated with Binance's HMAC-SHA256 scheme, factored
+into the module-level :func:`_sign` helper:
+
+* ``query`` is the urlencoded params **including** ``timestamp`` (ms) and
+  ``recvWindow``;
+* ``signature = hmac_sha256(secret, query).hexdigest()``;
+* the signed request appends ``&signature=<sig>`` and sends the
+  ``X-MBX-APIKEY: <key>`` header.
+
+:func:`_sign` is a pure function (no I/O, no clock) so it can be checked against
+Binance's published vector deterministically — that vector is the *only* proof of
+signing correctness exercised in the unit suite; the real round-trip is proven on
+Binance's **testnet** (opt-in, key-gated).
+
+Credentials & posture
+---------------------
+Credentials come from the environment (``BINANCE_API_KEY`` /
+``BINANCE_API_SECRET``) and **never** from code. The broker is constructible
+*without* them — public market-data calls (:meth:`BinanceBroker.ticker`, the
+:class:`Instrument` builder) work key-free — and any private call attempted
+without credentials raises a clear :class:`~trading_bot.domain.errors.BrokerError`
+*before* a request goes out. Key material is never logged. Add a
+:attr:`has_credentials` property (mirrors Kraken).
+
+Base URL / testnet
+------------------
+The constructor's ``base_url`` defaults to ``$BINANCE_API_BASE`` or
+``https://api.binance.com``. Point it at ``https://testnet.binance.vision`` to
+exercise the signed round-trip against Binance's spot testnet — both speak the
+same ``/api/v3/*`` paths.
+
+Composite venue-order-id
+------------------------
+Binance ``cancel`` / order-status require a **symbol** alongside the order id,
+but the port's :meth:`cancel_order` carries only an id. The adapter therefore
+makes its venue id the **composite** ``"{SYMBOL}:{orderId}"`` (e.g.
+``"BTCUSDT:123456"``): :meth:`place_order` and :meth:`open_orders` both produce
+this form and :meth:`cancel_order` splits it back. The id stays opaque text to
+the router / reconcile / store, so this is self-contained.
+
+Rate limit
+----------
+Construction wires an :class:`~trading_bot.transport.http.AsyncHTTPClient` for the
+``"binance"`` exchange with a generic
+:class:`~trading_bot.transport.ratelimit.RateLimiter` token bucket. Binance's
+finer-grained *weight*-budget accounting is future work; the generic per-second
+token bucket is enough for this adapter.
+
+Money
+-----
+Every amount Binance reports is a decimal string; it is parsed with
+``money(str(...))`` so prices, volumes and fees stay exact :class:`~decimal.
+Decimal` and never round-trip through ``float``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import re
+import time
+import urllib.parse
+from typing import TYPE_CHECKING, Any
+
+from trading_bot.brokers.base import Broker, Capability
+from trading_bot.domain.errors import BrokerError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import (
+    Instrument,
+    Symbol,
+    normalise,
+    parse_binance_symbol,
+)
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.transport.http import AsyncHTTPClient
+from trading_bot.transport.ratelimit import RateLimiter
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+__all__ = ["BinanceBroker"]
+
+_DEFAULT_API_BASE = "https://api.binance.com"
+#: Binance spot testnet base URL (same ``/api/v3/*`` paths as mainnet).
+TESTNET_API_BASE = "https://testnet.binance.vision"
+_API_PREFIX = "/api/v3"
+#: Default ``recvWindow`` (ms): how long a signed request stays valid server-side.
+_RECV_WINDOW = 5000
+#: Separator between the symbol and the numeric order id in the composite venue id.
+_VENUE_ID_SEP = ":"
+
+# Domain OrderType -> Binance ``type`` string. BEST_LIMIT renders as a plain
+# LIMIT (its price is discovered by the caller before submission, so by the time
+# it reaches the broker it carries a concrete ``limit_price``).
+_ORDERTYPE_TO_BINANCE: dict[OrderType, str] = {
+    OrderType.MARKET: "MARKET",
+    OrderType.LIMIT: "LIMIT",
+    OrderType.STOP_LOSS: "STOP_LOSS_LIMIT",
+    OrderType.BEST_LIMIT: "LIMIT",
+}
+
+# Binance ``type`` string -> domain OrderType (for rebuilding open orders).
+_BINANCE_TO_ORDERTYPE: dict[str, OrderType] = {
+    "MARKET": OrderType.MARKET,
+    "LIMIT": OrderType.LIMIT,
+    "LIMIT_MAKER": OrderType.LIMIT,
+    "STOP_LOSS_LIMIT": OrderType.STOP_LOSS,
+    "STOP_LOSS": OrderType.STOP_LOSS,
+}
+
+# Binance's ``newClientOrderId`` constraint: at most 36 chars from the charset
+# [.A-Za-z0-9:/_-]. The runner's ``f"{name}-{step}"`` ids satisfy this; an
+# arbitrary domain client_order_id may not, in which case it is simply not
+# forwarded (engine-side dedup still guards re-submission of the same logical
+# order; see :meth:`BinanceBroker.place_order`).
+_CLIENT_ORDER_ID_RE = re.compile(r"^[.A-Za-z0-9:/_-]{1,36}$")
+
+
+def _sign(query: str, secret: str) -> str:
+    """Compute Binance's HMAC-SHA256 ``signature`` for a signed request.
+
+    Pure function (no I/O, no clock): given the urlencoded ``query`` string
+    (which must already carry ``timestamp`` and ``recvWindow``) and the API
+    ``secret``, returns the hex ``signature`` to append as ``&signature=<sig>``.
+    Matched against Binance's published test vector.
+
+    The algorithm is simply
+    ``hmac.new(secret, query, sha256).hexdigest()``.
+
+    Parameters
+    ----------
+    query : str
+        The urlencoded request parameters, e.g.
+        ``"symbol=LTCBTC&side=BUY&...&recvWindow=5000&timestamp=1499827319559"``.
+    secret : str
+        The Binance API secret.
+
+    Returns
+    -------
+    str
+        The hex-encoded HMAC-SHA256 signature.
+
+    """
+    return hmac.new(
+        secret.encode(), query.encode(), hashlib.sha256
+    ).hexdigest()
+
+
+def _is_valid_new_client_order_id(client_order_id: str) -> bool:
+    """Whether ``client_order_id`` fits Binance's ``newClientOrderId`` constraint."""
+    return bool(_CLIENT_ORDER_ID_RE.match(client_order_id))
+
+
+def _precision_from_step(step: str | None) -> int | None:
+    """Derive a decimal-place count from a Binance ``tickSize`` / ``stepSize``.
+
+    Binance expresses precision as a step string (``"0.01000000"``,
+    ``"0.00001000"``); the number of decimal places is the position of the last
+    non-zero digit. ``"1.00000000"`` (whole-unit step) → ``0``. Returns ``None``
+    when no step is given.
+    """
+    if step is None:
+        return None
+    text = step.strip()
+    if "." not in text:
+        return 0
+    fractional = text.split(".", 1)[1].rstrip("0")
+    return len(fractional)
+
+
+class BinanceBroker(Broker):
+    """Binance spot REST adapter implementing the venue-neutral :class:`Broker` port.
+
+    Public market data (ticker, instrument metadata) needs no credentials;
+    private order/balance/fill calls read ``BINANCE_API_KEY`` /
+    ``BINANCE_API_SECRET`` from the environment and sign each request with
+    :func:`_sign`. A private call attempted without credentials raises
+    :class:`~trading_bot.domain.errors.BrokerError` before any I/O.
+
+    Retry policy — idempotency-aware
+    --------------------------------
+    The transport retries transient failures (5xx / 429 / dropped connections)
+    with backoff — safe for the **idempotent** endpoints (the read/query calls
+    :meth:`balances`, :meth:`open_orders`, :meth:`fills`, and :meth:`cancel_order`,
+    cancelling an already-cancelled order being a no-op). It is **not** safe for
+    :meth:`place_order` (``POST /api/v3/order``): a blind retry after an *ambiguous*
+    failure (the order landed but the response was lost) could place a **second**
+    order. :meth:`place_order` therefore opts out of retries (``retry=False``); on
+    an ambiguous failure the transport raises
+    :class:`~trading_bot.transport.http.AmbiguousRequestError` and the caller must
+    reconcile (:func:`~trading_bot.application.reconcile.reconcile`) — never
+    blind-retry. (Binance's own ``newClientOrderId`` dedup is a second guard: a
+    duplicate id is rejected with ``-2010``.)
+
+    Parameters
+    ----------
+    api_key : str, optional
+        Binance API key. Defaults to ``$BINANCE_API_KEY``. ``None``/empty leaves
+        the broker public-only.
+    api_secret : str, optional
+        Binance API secret. Defaults to ``$BINANCE_API_SECRET``.
+    base_url : str, optional
+        REST base URL. Defaults to ``$BINANCE_API_BASE`` or
+        ``https://api.binance.com``. Point it at
+        :data:`TESTNET_API_BASE` (``https://testnet.binance.vision``) for the
+        testnet round-trip.
+    symbols : iterable of Symbol, optional
+        The instruments :meth:`fills` should query (Binance has no account-wide
+        trade history; ``myTrades`` is per-symbol). Without it, :meth:`fills`
+        raises a clear :class:`~trading_bot.domain.errors.BrokerError`.
+    http : AsyncHTTPClient, optional
+        Transport client. Defaults to one wired for the ``"binance"`` exchange
+        with a shared :class:`~trading_bot.transport.ratelimit.RateLimiter`.
+    recv_window : int, default 5000
+        Binance ``recvWindow`` (ms) carried on every signed request.
+
+    Attributes
+    ----------
+    name : str
+        The venue key, ``"binance"`` (the registry key for this adapter).
+
+    """
+
+    name = "binance"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        api_secret: str | None = None,
+        base_url: str | None = None,
+        symbols: Iterable[Symbol] | None = None,
+        http: AsyncHTTPClient | None = None,
+        recv_window: int = _RECV_WINDOW,
+    ) -> None:
+        # Credentials are env-sourced by default and never logged. An empty
+        # string is treated as "absent" so a blank env var stays public-only.
+        self._api_key = (
+            api_key if api_key is not None else os.environ.get("BINANCE_API_KEY", "")
+        )
+        self._api_secret = (
+            api_secret
+            if api_secret is not None
+            else os.environ.get("BINANCE_API_SECRET", "")
+        )
+        self._base_url = (
+            base_url
+            if base_url is not None
+            else os.environ.get("BINANCE_API_BASE", _DEFAULT_API_BASE)
+        ).rstrip("/")
+        self._symbols = tuple(symbols) if symbols is not None else ()
+        self._http = http or AsyncHTTPClient(
+            exchange=self.name, limiter=RateLimiter()
+        )
+        self._recv_window = recv_window
+
+    # --- capability declaration -------------------------------------------- #
+
+    def capabilities(self) -> set[Capability]:
+        """The :class:`Capability` set this adapter serves.
+
+        All six REST operations are implemented (place/cancel/open-orders,
+        balances, fills, ticker). The private/authenticated WebSocket feed
+        (:data:`~trading_bot.brokers.base.Capability.PRIVATE_WS`) is **not** part
+        of this REST adapter (WS is deferred), so it is omitted.
+        """
+        return {
+            Capability.PLACE_ORDER,
+            Capability.CANCEL,
+            Capability.OPEN_ORDERS,
+            Capability.BALANCES,
+            Capability.FILLS,
+            Capability.TICKER,
+        }
+
+    # --- credentials ------------------------------------------------------- #
+
+    @property
+    def has_credentials(self) -> bool:
+        """Whether both API key and secret are present (private calls possible)."""
+        return bool(self._api_key) and bool(self._api_secret)
+
+    def _require_credentials(self) -> None:
+        """Raise :class:`BrokerError` if a private call lacks credentials."""
+        if not self.has_credentials:
+            raise BrokerError(
+                "Binance private endpoint requires credentials; set "
+                "BINANCE_API_KEY and BINANCE_API_SECRET in the environment"
+            )
+
+    @staticmethod
+    def _timestamp_ms() -> int:
+        """The current Unix time in milliseconds (Binance ``timestamp``)."""
+        return int(time.time() * 1000)
+
+    # --- request plumbing -------------------------------------------------- #
+
+    @staticmethod
+    def _raise_on_error(payload: Any, *, context: str) -> Any:
+        """Return ``payload`` or raise :class:`BrokerError` on a Binance error body.
+
+        Binance signals a rejection with a JSON object
+        ``{"code": -xxxx, "msg": "..."}``. The ``msg`` is a plain venue
+        diagnostic (never key material), so it is safe to surface. A successful
+        payload is a list or an object without a ``code`` field.
+        """
+        if isinstance(payload, dict) and "code" in payload and "msg" in payload:
+            raise BrokerError(
+                f"Binance {context}: {payload['msg']} (code {payload['code']})"
+            )
+        return payload
+
+    async def _public_get(
+        self, endpoint: str, params: Mapping[str, Any]
+    ) -> Any:
+        """GET a public endpoint and return its parsed JSON (or raise)."""
+        url = f"{self._base_url}{_API_PREFIX}/{endpoint}"
+        async with self._http as client:
+            payload = await client.get(url, params=dict(params))
+        return self._raise_on_error(payload, context=endpoint)
+
+    async def _signed_request(
+        self,
+        method: str,
+        endpoint: str,
+        params: Mapping[str, Any],
+        *,
+        retry: bool = True,
+    ) -> Any:
+        """Sign and send a private request, returning its parsed JSON (or raise).
+
+        Builds the canonical query (caller params + ``recvWindow`` + ``timestamp``),
+        signs it with :func:`_sign`, appends ``&signature=<sig>`` and sends the
+        ``X-MBX-APIKEY`` header. Binance accepts signed params on the query string
+        for every verb (GET / POST / DELETE), so the body stays empty. Requires
+        credentials.
+
+        Parameters
+        ----------
+        method : str
+            ``"GET"``, ``"POST"`` or ``"DELETE"``.
+        endpoint : str
+            The endpoint path under ``/api/v3`` (e.g. ``"order"``, ``"account"``).
+        params : mapping
+            The request parameters (``recvWindow`` / ``timestamp`` are appended).
+        retry : bool, default True
+            Forwarded to the transport. ``True`` for **idempotent** endpoints
+            (queries / cancel); ``False`` for the **non-idempotent** order POST so
+            a blind retry can never double-submit (see :meth:`place_order`).
+        """
+        self._require_credentials()
+        # Binance signs the full query (caller params + recvWindow + timestamp)
+        # and carries it on the query string for every verb (GET / POST / DELETE),
+        # with an empty body and the API key in the X-MBX-APIKEY header.
+        signed = {
+            **params,
+            "recvWindow": self._recv_window,
+            "timestamp": self._timestamp_ms(),
+        }
+        query = urllib.parse.urlencode(signed)
+        signature = _sign(query, self._api_secret)
+        url = (
+            f"{self._base_url}{_API_PREFIX}/{endpoint}"
+            f"?{query}&signature={signature}"
+        )
+        headers = {"X-MBX-APIKEY": self._api_key}
+
+        async with self._http as client:
+            payload = await client.request(
+                method, url, headers=headers, retry=retry
+            )
+        return self._raise_on_error(payload, context=endpoint)
+
+    # --- public endpoints -------------------------------------------------- #
+
+    async def instrument(self, symbol: Symbol) -> Instrument:
+        """Build an :class:`Instrument` for ``symbol`` from ``exchangeInfo``.
+
+        Reads the symbol's ``filters`` — ``PRICE_FILTER.tickSize`` /
+        ``LOT_SIZE.stepSize`` → price/quantity precision (decimal places). Falls
+        back to ``baseAssetPrecision`` / ``quoteAssetPrecision`` when a filter is
+        absent.
+
+        Parameters
+        ----------
+        symbol : Symbol
+            The canonical pair to describe.
+
+        Returns
+        -------
+        Instrument
+            The instrument with venue price/qty precision filled in.
+
+        Raises
+        ------
+        BrokerError
+            If Binance returns an error or no entry for the symbol.
+
+        """
+        venue_symbol = symbol.to_venue_symbol(self.name)
+        payload = await self._public_get(
+            "exchangeInfo", {"symbol": venue_symbol}
+        )
+        symbols = payload.get("symbols") if isinstance(payload, dict) else None
+        if not symbols:
+            raise BrokerError(
+                f"Binance exchangeInfo: no entry for {venue_symbol!r}"
+            )
+        entry = symbols[0]
+        filters = {
+            f.get("filterType"): f for f in entry.get("filters", [])
+        }
+        price_step = filters.get("PRICE_FILTER", {}).get("tickSize")
+        qty_step = filters.get("LOT_SIZE", {}).get("stepSize")
+        price_precision = _precision_from_step(price_step)
+        qty_precision = _precision_from_step(qty_step)
+        if price_precision is None:
+            quote_prec = entry.get("quoteAssetPrecision")
+            price_precision = int(quote_prec) if quote_prec is not None else None
+        if qty_precision is None:
+            base_prec = entry.get("baseAssetPrecision")
+            qty_precision = int(base_prec) if base_prec is not None else None
+        return Instrument(
+            symbol=symbol,
+            price_precision=price_precision,
+            qty_precision=qty_precision,
+        )
+
+    async def ticker(self, instrument: Instrument) -> Money:
+        """Return the public last price for ``instrument`` as a ``Decimal``.
+
+        Parameters
+        ----------
+        instrument : Instrument
+            The instrument to price.
+
+        Returns
+        -------
+        Decimal
+            The last trade price (``GET /api/v3/ticker/price`` field ``price``),
+            exact.
+
+        Raises
+        ------
+        BrokerError
+            If Binance errors or the ticker payload lacks a price.
+
+        """
+        venue_symbol = instrument.symbol.to_venue_symbol(self.name)
+        payload = await self._public_get(
+            "ticker/price", {"symbol": venue_symbol}
+        )
+        price = payload.get("price") if isinstance(payload, dict) else None
+        if price is None:
+            raise BrokerError(
+                f"Binance ticker/price: no price for {venue_symbol!r}"
+            )
+        return money(str(price))
+
+    # --- private endpoints ------------------------------------------------- #
+
+    async def balances(self) -> dict[str, Money]:
+        """Return free balances keyed by canonical asset code (``GET /account``).
+
+        Parses ``balances: [{asset, free, locked}]``, normalises each asset code
+        and keeps the **free** amount, skipping zero-free assets.
+
+        Returns
+        -------
+        dict of str to Decimal
+            Canonical asset code (``"USDT"``, ``"BTC"``, ...) to its free balance
+            as an exact :class:`~decimal.Decimal`.
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, or on a Binance error.
+
+        """
+        payload = await self._signed_request("GET", "account", {})
+        result: dict[str, Money] = {}
+        for entry in payload.get("balances", []):
+            free = money(str(entry.get("free", "0")))
+            if free > 0:
+                result[normalise(str(entry.get("asset", "")))] = free
+        return result
+
+    async def place_order(self, order: Order) -> str:
+        """Submit ``order`` via ``POST /api/v3/order``; return the composite venue id.
+
+        Maps the domain order to Binance's ``/order`` parameters:
+        ``symbol`` from the instrument, ``side``=BUY/SELL from :class:`OrderSide`,
+        ``type``=MARKET/LIMIT/STOP_LOSS_LIMIT from :class:`OrderType`,
+        ``quantity``=qty, ``price`` (+ ``timeInForce=GTC``) for LIMIT, and
+        ``stopPrice`` for stop orders (see :meth:`_order_params`).
+
+        Venue-idempotency
+        -----------------
+        The domain ``client_order_id`` is forwarded as Binance's
+        ``newClientOrderId`` **iff** it fits the venue constraint (≤36 chars,
+        charset ``[.A-Za-z0-9:/_-]``); the runner's ``f"{name}-{step}"`` ids do.
+        Binance then dedups venue-side — a duplicate id is rejected with ``-2010``.
+
+        ``/order`` is **non-idempotent** — a second submission places a second
+        order — so this call is sent **at most once** (``retry=False``): the
+        transport will not blindly retry it on an ambiguous transient failure (a
+        5xx / dropped connection after the order may already have landed). Instead
+        it raises :class:`~trading_bot.transport.http.AmbiguousRequestError`,
+        signalling the caller to reconcile
+        (:func:`~trading_bot.application.reconcile.reconcile`) and decide from the
+        venue's actual state — **never** to blind-retry.
+
+        Parameters
+        ----------
+        order : Order
+            The domain order to submit.
+
+        Returns
+        -------
+        str
+            The **composite** venue order id ``"{SYMBOL}:{orderId}"`` — opaque to
+            the caller, round-tripped by :meth:`cancel_order` / :meth:`open_orders`.
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, on a Binance error, or if no order id is returned.
+        AmbiguousRequestError
+            On an ambiguous transient failure — the order may have landed;
+            reconcile before any retry.
+
+        """
+        params = self._order_params(order)
+        payload = await self._signed_request(
+            "POST", "order", params, retry=False
+        )
+        order_id = payload.get("orderId")
+        if order_id is None:
+            raise BrokerError(
+                f"Binance order: no orderId returned for {order.client_order_id}"
+            )
+        symbol = str(payload.get("symbol") or params["symbol"])
+        return self._compose_venue_id(symbol, order_id)
+
+    def _order_params(self, order: Order) -> dict[str, str]:
+        """Render a domain :class:`Order` to Binance ``/order`` parameters.
+
+        Pure (no I/O), so the order-to-payload mapping is unit-testable on its
+        own. ``price`` + ``timeInForce=GTC`` are set for limit orders;
+        ``stopPrice`` (and ``price``) for stop-loss-limit orders. The
+        ``newClientOrderId`` is forwarded only when the domain
+        ``client_order_id`` fits Binance's constraint.
+        """
+        params: dict[str, str] = {
+            "symbol": order.instrument.symbol.to_venue_symbol(self.name),
+            "side": order.side.value.upper(),  # "BUY" / "SELL"
+            "type": _ORDERTYPE_TO_BINANCE[order.type],
+            "quantity": str(order.qty),
+        }
+        if order.type is OrderType.STOP_LOSS:
+            # STOP_LOSS maps to a STOP_LOSS_LIMIT: the trigger is ``stopPrice``;
+            # Binance also wants a working ``price`` + ``timeInForce`` for the
+            # resting limit. With no explicit limit, rest at the stop price.
+            params["stopPrice"] = str(order.stop_price)
+            params["price"] = str(order.limit_price or order.stop_price)
+            params["timeInForce"] = "GTC"
+        elif order.type in (OrderType.LIMIT, OrderType.BEST_LIMIT):
+            if order.limit_price is not None:
+                params["price"] = str(order.limit_price)
+                params["timeInForce"] = "GTC"
+        # Forward the idempotency key venue-side when it fits Binance's charset/
+        # length; otherwise omit it (engine-side dedup + retry=False still guard
+        # against duplicates).
+        if _is_valid_new_client_order_id(order.client_order_id):
+            params["newClientOrderId"] = order.client_order_id
+        return params
+
+    async def cancel_order(self, venue_order_id: str) -> None:
+        """Cancel the live order identified by ``venue_order_id`` (``DELETE /order``).
+
+        ``venue_order_id`` is the **composite** ``"{SYMBOL}:{orderId}"`` returned
+        by :meth:`place_order` / :meth:`open_orders`; it is split back into the
+        ``symbol`` + ``orderId`` Binance's cancel requires.
+
+        Parameters
+        ----------
+        venue_order_id : str
+            The composite venue id (``"BTCUSDT:123456"``).
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, on a malformed composite id, or on a Binance error.
+
+        """
+        symbol, order_id = self._split_venue_id(venue_order_id)
+        await self._signed_request(
+            "DELETE", "order", {"symbol": symbol, "orderId": order_id}
+        )
+
+    async def open_orders(self) -> list[Order]:
+        """Return account-wide open orders as domain :class:`Order`s (``GET /openOrders``).
+
+        Each Binance open order is reconstructed into a domain order driven
+        through ``submit`` → ``open`` (and ``apply_fill`` if partially executed)
+        so the status matches Binance's view, with ``venue_order_id`` set to the
+        **composite** ``"{SYMBOL}:{orderId}"`` — reproduced identically so a later
+        :meth:`cancel_order` works.
+
+        Returns
+        -------
+        list of Order
+            The open orders as domain objects.
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, or on a Binance error.
+
+        """
+        payload = await self._signed_request("GET", "openOrders", {})
+        return [self._rebuild_order(info) for info in payload]
+
+    def _rebuild_order(self, info: Mapping[str, Any]) -> Order:
+        """Rebuild a domain :class:`Order` from a Binance open-order entry."""
+        venue_symbol = str(info.get("symbol", ""))
+        symbol = parse_binance_symbol(venue_symbol)
+        side = OrderSide(str(info.get("side", "BUY")).lower())
+        otype = _BINANCE_TO_ORDERTYPE.get(
+            str(info.get("type", "")), OrderType.LIMIT
+        )
+        qty = money(str(info.get("origQty", "0")))
+        price = info.get("price")
+        limit_price = (
+            money(str(price))
+            if otype in (OrderType.LIMIT, OrderType.BEST_LIMIT)
+            and price
+            and money(str(price)) > 0
+            else None
+        )
+        stop_price = (
+            money(str(info.get("stopPrice")))
+            if otype is OrderType.STOP_LOSS and info.get("stopPrice")
+            else None
+        )
+        # A STOP_LOSS_LIMIT on Binance also carries a resting ``price``; the
+        # domain STOP_LOSS forbids a limit_price, so drop it on rebuild.
+        client_id = str(info.get("clientOrderId") or info.get("orderId"))
+        composite = self._compose_venue_id(venue_symbol, info.get("orderId"))
+        order = Order(
+            client_order_id=client_id,
+            instrument=Instrument(symbol),
+            side=side,
+            qty=qty,
+            type=otype,
+            limit_price=limit_price,
+            stop_price=stop_price,
+        )
+        order.submit()
+        order.open(composite)
+        # Reflect any already-executed volume so the status matches Binance's.
+        executed = money(str(info.get("executedQty", "0")))
+        if executed > 0:
+            avg_price = limit_price or stop_price
+            if avg_price is not None and avg_price > 0:
+                order.apply_fill(executed, avg_price)
+        return order
+
+    async def fills(self, since_ms: int | None = None) -> list[Fill]:
+        """Return executions as domain :class:`Fill`s (``GET /myTrades`` per symbol).
+
+        Binance has **no account-wide** trade history; ``myTrades`` is per-symbol.
+        This queries ``myTrades`` for each configured symbol (see the ``symbols``
+        constructor arg), concatenating the results.
+
+        Parameters
+        ----------
+        since_ms : int, optional
+            Lower time bound as **milliseconds since the Unix epoch (UTC)**,
+            forwarded as Binance's ``startTime``. ``None`` returns each symbol's
+            default recent window.
+
+        Returns
+        -------
+        list of Fill
+            The executions as immutable domain fills (exact Decimal qty/price/fee).
+
+        Raises
+        ------
+        BrokerError
+            Without credentials, on a Binance error, or if no symbols are
+            configured (Binance has no account-wide trade history, so ``fills()``
+            needs an explicit symbol set).
+
+        """
+        if not self._symbols:
+            raise BrokerError(
+                "Binance fills() needs a symbol set: Binance has no "
+                "account-wide trade history (myTrades is per-symbol). Pass "
+                "symbols=[...] to BinanceBroker."
+            )
+        fills: list[Fill] = []
+        for symbol in self._symbols:
+            venue_symbol = symbol.to_venue_symbol(self.name)
+            params: dict[str, Any] = {"symbol": venue_symbol}
+            if since_ms is not None:
+                params["startTime"] = since_ms
+            payload = await self._signed_request("GET", "myTrades", params)
+            for trade in payload:
+                fills.append(self._build_fill(symbol, trade))
+        return fills
+
+    @staticmethod
+    def _build_fill(symbol: Symbol, info: Mapping[str, Any]) -> Fill:
+        """Build a domain :class:`Fill` from a Binance ``myTrades`` entry."""
+        side = OrderSide.BUY if info.get("isBuyer") else OrderSide.SELL
+        return Fill(
+            fill_id=str(info.get("id")),
+            client_order_id=str(info.get("orderId")),
+            instrument=Instrument(symbol),
+            side=side,
+            qty=money(str(info.get("qty", "0"))),
+            price=money(str(info.get("price", "0"))),
+            fee=money(str(info.get("commission", "0"))),
+            ts=int(info.get("time", 0)),
+        )
+
+    # --- composite venue id ------------------------------------------------- #
+
+    @staticmethod
+    def _compose_venue_id(symbol: str, order_id: Any) -> str:
+        """Compose the opaque venue id ``"{SYMBOL}:{orderId}"``."""
+        return f"{symbol}{_VENUE_ID_SEP}{order_id}"
+
+    @staticmethod
+    def _split_venue_id(venue_order_id: str) -> tuple[str, str]:
+        """Split the composite venue id back into ``(symbol, orderId)``.
+
+        Splits on the **last** ``":"`` so a symbol can never be mistaken for the
+        id boundary (Binance symbols carry no colon, but split-on-last is robust).
+        """
+        symbol, sep, order_id = venue_order_id.rpartition(_VENUE_ID_SEP)
+        if not sep or not symbol or not order_id:
+            raise BrokerError(
+                f"Binance cancel: malformed composite venue id "
+                f"{venue_order_id!r}; expected '<SYMBOL>:<orderId>'"
+            )
+        return symbol, order_id

--- a/trading_bot/domain/__init__.py
+++ b/trading_bot/domain/__init__.py
@@ -46,6 +46,7 @@ from trading_bot.domain.instrument import (
     Instrument,
     Symbol,
     normalise,
+    parse_binance_symbol,
     parse_kraken_pair,
 )
 from trading_bot.domain.money import (
@@ -96,6 +97,7 @@ __all__ = [
     "Instrument",
     "normalise",
     "parse_kraken_pair",
+    "parse_binance_symbol",
     # order
     "Order",
     "OrderSide",

--- a/trading_bot/tests/brokers/test_binance_rest.py
+++ b/trading_bot/tests/brokers/test_binance_rest.py
@@ -1,0 +1,827 @@
+"""Tests for the :class:`~trading_bot.brokers.binance.BinanceBroker` REST adapter.
+
+Posture (no API key)
+--------------------
+Signing is proven **deterministically** against Binance's published HMAC-SHA256
+test vector (:func:`test_sign_matches_binance_published_vector`) — no key, no
+network. Every private endpoint (``place_order`` / ``cancel_order`` /
+``open_orders`` / ``balances`` / ``fills``) is exercised through ``pytest-httpx``
+mocks of Binance JSON, with the broker holding **dummy** credentials so the real
+signing path (query → signature → ``X-MBX-APIKEY`` header) runs end to end. Real
+*private* verification against Binance is **deferred to the testnet** (opt-in,
+key-gated): the vector is the proof of signing correctness in this suite. Two
+opt-in ``@pytest.mark.network`` tests hit Binance's real **public**
+``ticker/price`` + ``exchangeInfo`` (no key) and its **testnet** signed
+round-trip (skips without a key).
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from trading_bot.application.config import AppConfig, BrokerConfig
+from trading_bot.application.service_factory import build_engine
+from trading_bot.brokers import BinanceBroker, BrokerError, Capability
+from trading_bot.brokers.binance import TESTNET_API_BASE, _sign
+from trading_bot.brokers.paper import PaperBroker
+from trading_bot.domain import (
+    Fill,
+    Instrument,
+    Order,
+    OrderSide,
+    OrderType,
+    Symbol,
+    money,
+    parse_binance_symbol,
+)
+from trading_bot.domain.errors import LiveTradingNotEnabled
+from trading_bot.transport import AmbiguousRequestError, AsyncHTTPClient
+
+BTC_USDT = Instrument(Symbol("BTC", "USDT"), price_precision=2, qty_precision=5)
+ETH_USDT = Instrument(Symbol("ETH", "USDT"), price_precision=2, qty_precision=4)
+
+# Binance's published HMAC-SHA256 test vector (rest-api docs, ASCII example).
+# NOTE: the leaf spec's secret was truncated by one trailing char; the real
+# Binance vector secret ends in ``...fATj0j``. Verified against the published
+# expected signature below.
+_VECTOR_SECRET = "NhqPtmdSJYdKjVHjA7PZj4Mge3R5YNiP1e3UZjInClVN65XAbvqqM6A7H5fATj0j"
+_VECTOR_QUERY = (
+    "symbol=LTCBTC&side=BUY&type=LIMIT&timeInForce=GTC&quantity=1&price=0.1"
+    "&recvWindow=5000&timestamp=1499827319559"
+)
+_VECTOR_EXPECTED = (
+    "c8db56825ae71d6d79447849e617115f4a920fa2acdcab2b053c4b2838bd6b71"
+)
+
+
+def _broker(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    creds: bool = True,
+    base_url: str | None = "https://api.binance.com",
+    symbols: list[Symbol] | None = None,
+    http: AsyncHTTPClient | None = None,
+) -> BinanceBroker:
+    """Build a broker; with ``creds`` set dummy env credentials (signing runs)."""
+    if creds:
+        monkeypatch.setenv("BINANCE_API_KEY", "DUMMY-KEY")
+        monkeypatch.setenv("BINANCE_API_SECRET", _VECTOR_SECRET)
+    else:
+        monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+        monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    monkeypatch.delenv("BINANCE_API_BASE", raising=False)
+    return BinanceBroker(base_url=base_url, symbols=symbols, http=http)
+
+
+def _query_of(request: httpx.Request) -> dict[str, str]:
+    """The request's query params as a flat dict."""
+    return dict(urllib.parse.parse_qsl(request.url.query.decode()))
+
+
+def _signature_valid(request: httpx.Request) -> bool:
+    """Re-derive the signature over the request's pre-signature query and compare."""
+    raw = request.url.query.decode()
+    base, _, sig = raw.rpartition("&signature=")
+    return _sign(base, _VECTOR_SECRET) == sig
+
+
+# --- signing: the deterministic proof ------------------------------------- #
+
+
+def test_sign_matches_binance_published_vector() -> None:
+    """``_sign`` reproduces Binance's published HMAC-SHA256 signature exactly."""
+    assert _sign(_VECTOR_QUERY, _VECTOR_SECRET) == _VECTOR_EXPECTED
+
+
+# --- capabilities & construction ------------------------------------------ #
+
+
+def test_constructible_without_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The broker builds with no env creds and is public-only."""
+    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    broker = BinanceBroker(api_key="", api_secret="")
+    assert broker.name == "binance"
+    assert broker.has_credentials is False
+
+
+def test_capabilities_declares_six_rest_ops() -> None:
+    broker = BinanceBroker(api_key="", api_secret="")
+    caps = broker.capabilities()
+    assert caps == {
+        Capability.PLACE_ORDER,
+        Capability.CANCEL,
+        Capability.OPEN_ORDERS,
+        Capability.BALANCES,
+        Capability.FILLS,
+        Capability.TICKER,
+    }
+    # The private WS feed is deferred — not part of this REST adapter.
+    assert Capability.PRIVATE_WS not in caps
+
+
+def test_base_url_defaults_to_mainnet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("BINANCE_API_BASE", raising=False)
+    broker = BinanceBroker(api_key="", api_secret="")
+    assert broker._base_url == "https://api.binance.com"
+
+
+def test_base_url_env_toggle_testnet(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BINANCE_API_BASE", TESTNET_API_BASE)
+    broker = BinanceBroker(api_key="", api_secret="")
+    assert broker._base_url == TESTNET_API_BASE
+
+
+# --- order mapping (pure) -------------------------------------------------- #
+
+
+def test_order_params_market() -> None:
+    broker = BinanceBroker(api_key="", api_secret="")
+    order = Order(
+        client_order_id="strat-mkt",
+        instrument=BTC_USDT,
+        side=OrderSide.BUY,
+        qty=money("0.5"),
+        type=OrderType.MARKET,
+    )
+    params = broker._order_params(order)
+    assert params == {
+        "symbol": "BTCUSDT",
+        "side": "BUY",
+        "type": "MARKET",
+        "quantity": "0.5",
+        "newClientOrderId": "strat-mkt",
+    }
+
+
+def test_order_params_limit() -> None:
+    broker = BinanceBroker(api_key="", api_secret="")
+    order = Order(
+        client_order_id="strat-lim",
+        instrument=BTC_USDT,
+        side=OrderSide.SELL,
+        qty=money("1.25"),
+        type=OrderType.LIMIT,
+        limit_price=money("37500"),
+    )
+    params = broker._order_params(order)
+    assert params == {
+        "symbol": "BTCUSDT",
+        "side": "SELL",
+        "type": "LIMIT",
+        "quantity": "1.25",
+        "price": "37500",
+        "timeInForce": "GTC",
+        "newClientOrderId": "strat-lim",
+    }
+
+
+def test_order_params_stop_loss() -> None:
+    broker = BinanceBroker(api_key="", api_secret="")
+    order = Order(
+        client_order_id="strat-stop",
+        instrument=BTC_USDT,
+        side=OrderSide.SELL,
+        qty=money("2"),
+        type=OrderType.STOP_LOSS,
+        stop_price=money("28000"),
+    )
+    params = broker._order_params(order)
+    assert params == {
+        "symbol": "BTCUSDT",
+        "side": "SELL",
+        "type": "STOP_LOSS_LIMIT",
+        "quantity": "2",
+        "stopPrice": "28000",
+        "price": "28000",
+        "timeInForce": "GTC",
+        "newClientOrderId": "strat-stop",
+    }
+
+
+def test_order_params_omits_incompatible_client_order_id() -> None:
+    """A client_order_id that breaks Binance's constraint is not forwarded."""
+    broker = BinanceBroker(api_key="", api_secret="")
+    order = Order(
+        client_order_id="x" * 40,  # > 36 chars: incompatible
+        instrument=BTC_USDT,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        type=OrderType.MARKET,
+    )
+    params = broker._order_params(order)
+    assert "newClientOrderId" not in params
+
+
+# --- private endpoints via mocks ------------------------------------------ #
+
+
+async def test_place_order_signs_and_returns_composite_id(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={"symbol": "BTCUSDT", "orderId": 123456, "status": "NEW"}
+    )
+    broker = _broker(monkeypatch)
+    order = Order(
+        client_order_id="strat-1",
+        instrument=BTC_USDT,
+        side=OrderSide.BUY,
+        qty=money("1.25"),
+        type=OrderType.LIMIT,
+        limit_price=money("37500"),
+    )
+
+    venue_id = await broker.place_order(order)
+
+    # Composite venue id: "<SYMBOL>:<orderId>".
+    assert venue_id == "BTCUSDT:123456"
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.method == "POST"
+    assert str(request.url).startswith("https://api.binance.com/api/v3/order?")
+    # Signed: key header present, signature present and correct.
+    assert request.headers["X-MBX-APIKEY"] == "DUMMY-KEY"
+    assert _signature_valid(request)
+    q = _query_of(request)
+    assert q["symbol"] == "BTCUSDT"
+    assert q["side"] == "BUY"
+    assert q["type"] == "LIMIT"
+    assert q["quantity"] == "1.25"
+    assert q["price"] == "37500"
+    assert q["timeInForce"] == "GTC"
+    assert q["newClientOrderId"] == "strat-1"
+    assert q["recvWindow"] == "5000"
+    assert "timestamp" in q
+    assert "signature" in q
+
+
+async def test_place_order_market_no_price(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(json={"symbol": "BTCUSDT", "orderId": 7})
+    broker = _broker(monkeypatch)
+    order = Order(
+        client_order_id="strat-mkt",
+        instrument=BTC_USDT,
+        side=OrderSide.BUY,
+        qty=money("0.5"),
+        type=OrderType.MARKET,
+    )
+
+    venue_id = await broker.place_order(order)
+
+    assert venue_id == "BTCUSDT:7"
+    q = _query_of(httpx_mock.get_request())
+    assert q["type"] == "MARKET"
+    assert "price" not in q
+    assert "timeInForce" not in q
+
+
+async def test_cancel_order_splits_composite_id(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={"symbol": "BTCUSDT", "orderId": 123456, "status": "CANCELED"}
+    )
+    broker = _broker(monkeypatch)
+
+    await broker.cancel_order("BTCUSDT:123456")
+
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.method == "DELETE"
+    assert str(request.url).startswith("https://api.binance.com/api/v3/order?")
+    assert request.headers["X-MBX-APIKEY"] == "DUMMY-KEY"
+    assert _signature_valid(request)
+    q = _query_of(request)
+    # The composite id is split back into the symbol + orderId Binance needs.
+    assert q["symbol"] == "BTCUSDT"
+    assert q["orderId"] == "123456"
+
+
+async def test_place_then_cancel_round_trips_composite_id(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The composite id from place_order round-trips through cancel_order."""
+    httpx_mock.add_response(json={"symbol": "ETHUSDT", "orderId": 999})
+    httpx_mock.add_response(json={"symbol": "ETHUSDT", "orderId": 999})
+    broker = _broker(monkeypatch)
+    order = Order(
+        client_order_id="strat-rt",
+        instrument=ETH_USDT,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        type=OrderType.LIMIT,
+        limit_price=money("1000"),
+    )
+
+    venue_id = await broker.place_order(order)
+    assert venue_id == "ETHUSDT:999"
+    await broker.cancel_order(venue_id)
+
+    cancel_req = httpx_mock.get_requests()[-1]
+    q = _query_of(cancel_req)
+    assert q["symbol"] == "ETHUSDT"
+    assert q["orderId"] == "999"
+
+
+async def test_cancel_malformed_composite_id_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broker = _broker(monkeypatch)
+    with pytest.raises(BrokerError, match="malformed composite"):
+        await broker.cancel_order("no-colon-here")
+
+
+async def test_balances_returns_decimal_map(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={
+            "balances": [
+                {"asset": "USDT", "free": "1500.50000000", "locked": "0.0"},
+                {"asset": "BTC", "free": "0.50000000", "locked": "0.1"},
+                {"asset": "ETH", "free": "0.00000000", "locked": "0.0"},
+            ]
+        }
+    )
+    broker = _broker(monkeypatch)
+
+    balances = await broker.balances()
+
+    # Zero-free assets skipped; amounts are exact Decimals.
+    assert balances == {
+        "USDT": Decimal("1500.50000000"),
+        "BTC": Decimal("0.50000000"),
+    }
+    assert all(isinstance(v, Decimal) for v in balances.values())
+    # Signed GET to /account.
+    request = httpx_mock.get_request()
+    assert request.method == "GET"
+    assert "/api/v3/account?" in str(request.url)
+    assert _signature_valid(request)
+
+
+async def test_open_orders_rebuilds_domain_orders(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json=[
+            {
+                "symbol": "BTCUSDT",
+                "orderId": 555,
+                "clientOrderId": "strat-7",
+                "price": "30000.00",
+                "origQty": "1.00000",
+                "executedQty": "0.00000",
+                "type": "LIMIT",
+                "side": "BUY",
+                "status": "NEW",
+            }
+        ]
+    )
+    broker = _broker(monkeypatch)
+
+    orders = await broker.open_orders()
+
+    assert len(orders) == 1
+    order = orders[0]
+    assert isinstance(order, Order)
+    # venue_order_id is the composite — reproduced identically for a later cancel.
+    assert order.venue_order_id == "BTCUSDT:555"
+    assert order.instrument.symbol == Symbol("BTC", "USDT")
+    assert order.side is OrderSide.BUY
+    assert order.type is OrderType.LIMIT
+    assert order.qty == Decimal("1.00000")
+    assert order.limit_price == Decimal("30000.00")
+
+
+async def test_open_orders_partial_fill_reflected(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json=[
+            {
+                "symbol": "ETHUSDT",
+                "orderId": 42,
+                "clientOrderId": "strat-9",
+                "price": "2000.00",
+                "origQty": "2.0000",
+                "executedQty": "0.5000",
+                "type": "LIMIT",
+                "side": "SELL",
+                "status": "PARTIALLY_FILLED",
+            }
+        ]
+    )
+    broker = _broker(monkeypatch)
+
+    orders = await broker.open_orders()
+
+    assert orders[0].filled_qty == Decimal("0.5000")
+    assert orders[0].avg_fill_price == Decimal("2000.00")
+
+
+async def test_fills_over_two_symbol_set(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # myTrades is per-symbol: one response per configured symbol.
+    httpx_mock.add_response(
+        json=[
+            {
+                "id": 1001,
+                "orderId": 555,
+                "symbol": "BTCUSDT",
+                "price": "30000.50",
+                "qty": "0.10000000",
+                "commission": "0.30000",
+                "isBuyer": True,
+                "time": 1616492376594,
+            }
+        ]
+    )
+    httpx_mock.add_response(
+        json=[
+            {
+                "id": 2002,
+                "orderId": 42,
+                "symbol": "ETHUSDT",
+                "price": "2000.00",
+                "qty": "1.50000000",
+                "commission": "0.10000",
+                "isBuyer": False,
+                "time": 1616492400000,
+            }
+        ]
+    )
+    broker = _broker(
+        monkeypatch, symbols=[Symbol("BTC", "USDT"), Symbol("ETH", "USDT")]
+    )
+
+    fills = await broker.fills(since_ms=1_616_492_000_000)
+
+    assert len(fills) == 2
+    btc, eth = fills
+    assert isinstance(btc, Fill)
+    assert btc.fill_id == "1001"
+    assert btc.client_order_id == "555"
+    assert btc.instrument.symbol == Symbol("BTC", "USDT")
+    assert btc.side is OrderSide.BUY
+    assert btc.qty == Decimal("0.10000000")
+    assert btc.price == Decimal("30000.50")
+    assert btc.fee == Decimal("0.30000")
+    assert btc.ts == 1616492376594
+
+    assert eth.side is OrderSide.SELL
+    assert eth.instrument.symbol == Symbol("ETH", "USDT")
+    assert eth.qty == Decimal("1.50000000")
+
+    # Each request carried the symbol + startTime cursor + a valid signature.
+    requests = httpx_mock.get_requests()
+    assert len(requests) == 2
+    queried_symbols = {_query_of(r)["symbol"] for r in requests}
+    assert queried_symbols == {"BTCUSDT", "ETHUSDT"}
+    for r in requests:
+        assert _query_of(r)["startTime"] == "1616492000000"
+        assert _signature_valid(r)
+
+
+async def test_fills_without_symbols_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No configured symbols → a clear error (Binance has no account-wide history)."""
+    broker = _broker(monkeypatch, symbols=None)
+    with pytest.raises(BrokerError, match="symbol set"):
+        await broker.fills()
+
+
+# --- ticker / instrument (public, mocked) --------------------------------- #
+
+
+async def test_ticker_returns_last_price(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(json={"symbol": "BTCUSDT", "price": "64250.10000000"})
+    broker = BinanceBroker(api_key="", api_secret="")
+
+    price = await broker.ticker(BTC_USDT)
+
+    assert price == Decimal("64250.10000000")
+    assert isinstance(price, Decimal)
+    request = httpx_mock.get_request()
+    assert request is not None
+    assert request.method == "GET"
+    assert "/api/v3/ticker/price" in str(request.url)
+    assert "symbol=BTCUSDT" in str(request.url)
+
+
+async def test_instrument_builds_precision_from_filters(httpx_mock) -> None:
+    httpx_mock.add_response(
+        json={
+            "symbols": [
+                {
+                    "symbol": "BTCUSDT",
+                    "baseAssetPrecision": 8,
+                    "quoteAssetPrecision": 8,
+                    "filters": [
+                        {"filterType": "PRICE_FILTER", "tickSize": "0.01000000"},
+                        {"filterType": "LOT_SIZE", "stepSize": "0.00001000"},
+                    ],
+                }
+            ]
+        }
+    )
+    broker = BinanceBroker(api_key="", api_secret="")
+
+    inst = await broker.instrument(Symbol("BTC", "USDT"))
+
+    assert inst.symbol == Symbol("BTC", "USDT")
+    assert inst.price_precision == 2  # from tickSize 0.01
+    assert inst.qty_precision == 5  # from stepSize 0.00001
+
+
+async def test_instrument_falls_back_to_asset_precision(httpx_mock) -> None:
+    """No PRICE_FILTER/LOT_SIZE → fall back to base/quote asset precision."""
+    httpx_mock.add_response(
+        json={
+            "symbols": [
+                {
+                    "symbol": "BTCUSDT",
+                    "baseAssetPrecision": 6,
+                    "quoteAssetPrecision": 4,
+                    "filters": [],
+                }
+            ]
+        }
+    )
+    broker = BinanceBroker(api_key="", api_secret="")
+
+    inst = await broker.instrument(Symbol("BTC", "USDT"))
+
+    assert inst.price_precision == 4
+    assert inst.qty_precision == 6
+
+
+# --- venue-idempotency: order POST is sent at most once ------------------- #
+
+
+class _RecordingSleep:
+    """Async ``asyncio.sleep`` stand-in recording every requested backoff delay."""
+
+    def __init__(self) -> None:
+        self.calls: list[float] = []
+
+    async def __call__(self, delay: float) -> None:
+        self.calls.append(delay)
+
+
+async def test_place_order_does_not_retry_on_ambiguous_5xx(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A 5xx on the order POST is attempted once and raises an ambiguous error."""
+    httpx_mock.add_response(status_code=503, text="upstream down")
+    sleep = _RecordingSleep()
+    http = AsyncHTTPClient(exchange="binance", max_retries=3, sleep=sleep)
+    broker = _broker(monkeypatch, http=http)
+    order = Order(
+        client_order_id="strat-amb",
+        instrument=BTC_USDT,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        type=OrderType.MARKET,
+    )
+
+    with pytest.raises(AmbiguousRequestError, match="reconcile"):
+        await broker.place_order(order)
+
+    # The order POST is attempted at most once — no duplicate, no backoff.
+    assert len(httpx_mock.get_requests()) == 1
+    assert sleep.calls == []
+
+
+async def test_place_order_does_not_retry_on_transport_error(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A dropped connection on the order POST raises ambiguous, sent once."""
+    httpx_mock.add_exception(httpx.ConnectError("dropped"))
+    sleep = _RecordingSleep()
+    http = AsyncHTTPClient(exchange="binance", max_retries=3, sleep=sleep)
+    broker = _broker(monkeypatch, http=http)
+    order = Order(
+        client_order_id="strat-drop",
+        instrument=BTC_USDT,
+        side=OrderSide.SELL,
+        qty=money("1"),
+        type=OrderType.MARKET,
+    )
+
+    with pytest.raises(AmbiguousRequestError, match="reconcile"):
+        await broker.place_order(order)
+
+    assert len(httpx_mock.get_requests()) == 1
+    assert sleep.calls == []
+
+
+async def test_balances_still_retries_idempotent_read(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An idempotent signed read (``/account``) still retries a transient 5xx."""
+    httpx_mock.add_response(status_code=503, text="blip")
+    httpx_mock.add_response(
+        json={"balances": [{"asset": "USDT", "free": "100.0", "locked": "0"}]}
+    )
+    sleep = _RecordingSleep()
+    http = AsyncHTTPClient(exchange="binance", max_retries=3, sleep=sleep)
+    broker = _broker(monkeypatch, http=http)
+
+    balances = await broker.balances()
+
+    assert balances == {"USDT": Decimal("100.0")}
+    # Two attempts (one retried 5xx) → one backoff sleep: the read path is intact.
+    assert len(httpx_mock.get_requests()) == 2
+    assert len(sleep.calls) == 1
+
+
+# --- error mapping & credential handling ---------------------------------- #
+
+
+async def test_binance_error_body_raises_broker_error(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    httpx_mock.add_response(
+        json={"code": -2010, "msg": "Account has insufficient balance."}
+    )
+    broker = _broker(monkeypatch)
+    order = Order(
+        client_order_id="strat-x",
+        instrument=BTC_USDT,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        type=OrderType.MARKET,
+    )
+
+    with pytest.raises(BrokerError, match="insufficient balance"):
+        await broker.place_order(order)
+
+
+async def test_private_call_without_credentials_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    broker = _broker(monkeypatch, creds=False)
+    with pytest.raises(BrokerError, match="requires credentials"):
+        await broker.balances()
+
+
+async def test_public_call_needs_no_credentials(
+    httpx_mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A public call works with no credentials present."""
+    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    httpx_mock.add_response(json={"symbol": "BTCUSDT", "price": "100.0"})
+    broker = BinanceBroker(api_key="", api_secret="")
+    assert await broker.ticker(BTC_USDT) == Decimal("100.0")
+
+
+# --- service_factory wiring ----------------------------------------------- #
+
+
+def test_factory_live_binance_no_creds_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """live + opted-in + binance + no creds → BrokerError (no paper fallback)."""
+    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    cfg = AppConfig(
+        mode="live",
+        live_enabled=True,
+        brokers=[BrokerConfig(name="binance-main", exchange="binance")],
+    )
+    assert not BinanceBroker(api_key="", api_secret="").has_credentials
+    with pytest.raises(BrokerError):
+        build_engine(cfg)
+
+
+def test_factory_live_binance_not_enabled_refuses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """binance live but not opted in → LiveTradingNotEnabled (off by default)."""
+    monkeypatch.setenv("BINANCE_API_KEY", "k")
+    monkeypatch.setenv("BINANCE_API_SECRET", "s")
+    cfg = AppConfig(
+        mode="live",
+        live_enabled=False,
+        brokers=[BrokerConfig(name="binance-main", exchange="binance")],
+    )
+    with pytest.raises(LiveTradingNotEnabled):
+        build_engine(cfg)
+
+
+def test_factory_live_binance_with_creds_builds_adapter_no_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Opt-in + creds → the live BinanceBroker is constructed (no order sent)."""
+    monkeypatch.setenv("BINANCE_API_KEY", "k")
+    monkeypatch.setenv("BINANCE_API_SECRET", "s")
+    monkeypatch.delenv("BINANCE_API_BASE", raising=False)
+    cfg = AppConfig(
+        mode="live",
+        live_enabled=True,
+        brokers=[BrokerConfig(name="binance-main", exchange="binance")],
+    )
+
+    engine = build_engine(cfg)
+
+    assert isinstance(engine.broker, BinanceBroker)
+    assert engine.broker.has_credentials
+
+
+def test_factory_paper_mode_untouched_by_binance() -> None:
+    """Paper mode still yields a PaperBroker (the default invariant holds)."""
+    engine = build_engine(AppConfig())
+    assert isinstance(engine.broker, PaperBroker)
+
+
+# --- real public smoke (opt-in: ``-m network``) --------------------------- #
+
+
+@pytest.mark.network
+async def test_real_binance_public_btc_usdt() -> None:
+    """Live Binance ``ticker/price`` + ``exchangeInfo`` for BTC/USDT (no key)."""
+    broker = BinanceBroker()  # no creds: public-only is enough here
+
+    inst = await broker.instrument(Symbol("BTC", "USDT"))
+    assert inst.symbol == Symbol("BTC", "USDT")
+    assert inst.price_precision is not None and inst.price_precision >= 0
+    assert inst.qty_precision is not None and inst.qty_precision >= 0
+
+    # The venue symbol round-trips parse_binance_symbol <-> to_venue_symbol.
+    venue_symbol = inst.symbol.to_venue_symbol("binance")
+    assert venue_symbol == "BTCUSDT"
+    assert parse_binance_symbol(venue_symbol) == Symbol("BTC", "USDT")
+
+    price = await broker.ticker(inst)
+    assert isinstance(price, Decimal)
+    assert price > 0
+
+
+# --- testnet signed round-trip (opt-in: ``-m network``, key-gated) -------- #
+
+
+@pytest.mark.network
+async def test_real_binance_testnet_round_trip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Place → read back → cancel a far-from-market LIMIT on the Binance testnet.
+
+    Skips unless ``BINANCE_API_KEY`` / ``BINANCE_API_SECRET`` are present
+    (testnet keys from https://testnet.binance.vision). Points ``base_url`` at
+    the testnet, places a tiny LIMIT order far below market (so it never fills),
+    reads it back via ``open_orders`` (asserting the broker-reported state
+    matches what was requested), then cancels it via the composite id.
+    """
+    import os
+
+    key = os.environ.get("BINANCE_API_KEY")
+    secret = os.environ.get("BINANCE_API_SECRET")
+    if not key or not secret:
+        pytest.skip("no Binance testnet credentials in the environment")
+
+    symbol = Symbol("BTC", "USDT")
+    broker = BinanceBroker(base_url=TESTNET_API_BASE, symbols=[symbol])
+    inst = await broker.instrument(symbol)
+    mark = await broker.ticker(inst)
+
+    # A LIMIT buy far below market never fills; a small qty keeps it cheap.
+    far_price = (mark * money("0.5")).quantize(money("0.01"))
+    order = Order(
+        client_order_id="tb-testnet-rt",
+        instrument=inst,
+        side=OrderSide.BUY,
+        qty=money("0.001"),
+        type=OrderType.LIMIT,
+        limit_price=far_price,
+    )
+    venue_id = await broker.place_order(order)
+    try:
+        assert venue_id.startswith("BTCUSDT:")
+        # Read it back: the broker-reported open order matches the request.
+        opens = await broker.open_orders()
+        match = [o for o in opens if o.venue_order_id == venue_id]
+        assert match, f"placed order {venue_id} not found in open_orders()"
+        ro = match[0]
+        assert ro.side is OrderSide.BUY
+        assert ro.qty == money("0.001")
+        assert ro.limit_price == far_price
+        # Balances are readable (locked some quote for the resting order).
+        balances = await broker.balances()
+        assert isinstance(balances, dict)
+    finally:
+        # Always cancel via the composite id, even if an assertion failed.
+        await broker.cancel_order(venue_id)

--- a/trading_bot/transport/http.py
+++ b/trading_bot/transport/http.py
@@ -271,6 +271,55 @@ class AsyncHTTPClient:
             "POST", url, data=data, json=json, headers=headers, retry=retry
         )
 
+    async def request(
+        self,
+        method: str,
+        url: str,
+        *,
+        params: Mapping[str, Any] | None = None,
+        headers: Mapping[str, str] | None = None,
+        retry: bool = True,
+    ) -> Any:
+        """Perform an arbitrary-verb request (GET / POST / DELETE / ...).
+
+        A thin public seam over the shared request loop for venues whose signed
+        endpoints use verbs beyond GET/POST (e.g. Binance signs ``DELETE
+        /api/v3/order`` for cancels, carrying all params on the query string and
+        an empty body). The same retry / ambiguity semantics as :meth:`post`
+        apply: ``retry=True`` for idempotent calls, ``retry=False`` for a
+        non-idempotent one (an ambiguous transient failure then raises
+        :class:`AmbiguousRequestError` instead of risking a duplicate).
+
+        Parameters
+        ----------
+        method : str
+            The HTTP verb (``"GET"``, ``"POST"``, ``"DELETE"``, ...).
+        url : str
+            Request URL (or path, if ``base_url`` is set).
+        params : mapping, optional
+            Query-string parameters.
+        headers : mapping, optional
+            Per-request headers, merged over the client defaults.
+        retry : bool, default True
+            Whether transient failures may be retried (see :meth:`post`).
+
+        Returns
+        -------
+        Any
+            The parsed JSON body of the 2xx response.
+
+        Raises
+        ------
+        HTTPError
+            On a non-retryable 4xx, or (when ``retry=True``) once retries are
+            exhausted.
+        AmbiguousRequestError
+            When ``retry=False`` and the single attempt fails ambiguously.
+        """
+        return await self._request(
+            method, url, params=params, headers=headers, retry=retry
+        )
+
     async def _request(
         self,
         method: str,


### PR DESCRIPTION
## Summary
- `brokers.BinanceBroker` — Binance spot REST adapter behind the venue-neutral `Broker` port: HMAC-SHA256 signed orders/balances/fills/ticker, public market data key-free. The **2nd live venue**, proving the multi-exchange design end-to-end.
- Wired into `service_factory` (`binance` ∈ `_LIVE_VENUES`); paper stays default, live behind the existing off-by-default `live_enabled` opt-in. **No mainnet order is ever sent.**

## Why
A second venue is the real test of the `Broker` abstraction. Binance breaks two of Kraken's conveniences — symbol-free cancel and account-wide trade history — both solved **inside the adapter** so the port and engine stay unchanged (see ADR):
- **Composite venue-order-id** `"<SYMBOL>:<orderId>"` → drives Binance's symbol-scoped cancel through the symbol-free port (reproduced identically by `place_order`/`open_orders`).
- **`fills()` over a configured symbol set** (`myTrades` is per-symbol).
- **`newClientOrderId`** carries the client-order-id for venue-level dedup (improves on Kraken), kept alongside the `retry=False` reconcile-on-ambiguous policy.
- **Testnet-capable** base URL → opt-in real round-trip on `testnet.binance.vision`.

## Changes
- `trading_bot/brokers/binance.py` (new) — `BinanceBroker` + pure `_sign` (HMAC-SHA256).
- `trading_bot/transport/http.py` — small public `request(method, …)` seam (Binance signs `DELETE` for cancels), same retry/ambiguity semantics as `post`.
- `service_factory.py` — `binance` live venue + credential gate (no creds → `BrokerError`, never silent paper fallback).
- `brokers/__init__.py`, `domain/__init__.py` — exports; `.env.example` — Binance keys + testnet URL.
- `tests/brokers/test_binance_rest.py` (new, 32 unit + 2 network).

## Verification on real data
- **Public smoke (live, no key):** `BTC/USDT` → venue `BTCUSDT` round-trips parse↔render; `price_precision=2`, `qty_precision=5`; live `ticker()` = `Decimal('59660.00')` (> 0). ✅ ran.
- **Testnet round-trip E2E** (place→read→cancel, paper money): written and key-gated; **skipped** (no testnet key in env). To run: testnet key in `.env` + `BINANCE_API_BASE=https://testnet.binance.vision`.

## Changelog
Added: `brokers.BinanceBroker` (2nd live venue). Changed: `service_factory` `binance` venue; `transport.request()` seam.

## Test plan
- [x] `.venv/bin/python -m pytest` — 617 passed, 7 deselected (network)
- [x] `.venv/bin/python -m pytest -m network` (public) — 1 passed, 1 skipped (testnet, no key)
- [x] `.venv/bin/ruff check trading_bot/` — clean
- [x] `.venv/bin/mypy trading_bot/` — clean
- [ ] CI green

Last leaf of **E11 — Binance adapter** (`doc/dev/plans/binance-adapter/`). Removes the E11 roadmap line.