### PR TITLE
docs: plan portfolio-strategy (multi-asset / LS1)

### DIFF
--- a/doc/dev/plans/portfolio-strategy/00-plan.md
+++ b/doc/dev/plans/portfolio-strategy/00-plan.md
@@ -1,0 +1,91 @@
+---
+plan: portfolio-strategy
+kind: global
+status: planning
+roadmap: "- [ ] **Multi-asset / portfolio strategy unit** (signalé par `fynance-research`). Today a `SignalFn` is `(bars) -> Signal` for **one** instrument; the first validated research strategy, **LS1**, is a **multi-asset long/short book** (a *vector* of target weights over ~10 Binance USDT coins, gross-capped 2×). Add a portfolio-strategy abstraction that consumes a weight vector in one shot (e.g. `fynance_research.strategies.ls1_live.target_weights()` → `{pair: weight}`, fraction of capital, Σ\\|w\\|≤2) and emits N venue-neutral `Signal`s + the per-coin order routing. **Interim**: deployable now as 10 single-instrument strategies each calling `ls1_live.coin_exposure(\"<PAIR>\")` (works, but recomputes the book 10×). Spec: `fynance-research/DEPLOY_LS1.md`. Daily rebalance; reads bars from the dccd Binance store."
+release_on_done: false
+---
+
+# Multi-asset / portfolio strategy unit (native)
+
+## Goal
+
+Add a **native portfolio-strategy** abstraction to `trading_bot`: a *single*
+logical strategy that spans **N instruments**, consumes a **target-weight vector**
+`{Symbol: weight}` (weight = signed fraction of capital, Σ|w| ≤ cap) **in one
+shot**, and drives all N instruments to target via idempotent, risk-gated orders
+on one venue. The validating use case is **LS1** (`../fynance-research`,
+`DEPLOY_LS1.md`): a daily long/short book over **10 Binance USDT** coins
+(`BTC ETH BCH LTC XRP XLM DOGE DOT TRX ZEC`), Σ|w| ≤ 2, bars from **dccd's Binance
+store**, daily rebalance.
+
+This is the **clean** path the LS1 dossier calls for (vs the interim "10
+single-instrument strategies each calling `coin_exposure()`" — which works today
+but recomputes the book 10× and fights `_reject_commingled`). `trading_bot` stays
+**generic**: the portfolio signal is loaded **by reference**
+(`module:function`, exactly like the single-instrument `SignalFn`), so LS1 lives in
+config (`fynance_research.strategies.ls1_live:target_weights`), not in the engine.
+
+## Why now
+
+E11 just landed **Binance** as the execution venue. LS1 is the first validated
+research strategy and it is *inherently multi-asset*, so the single-instrument
+`SignalFn`/`StrategyRunner` cannot express it. This epic is the missing execution
+shape. It is **0.3.0 work** (post the 0.2.0 release).
+
+## Context the leaves rely on (already in the repo)
+
+- `domain.signal.Signal.target_qty(instrument, qty)` — an **explicit signed net
+  quantity** signal (no `[-1,1]` bound), exactly right for `weight × capital /
+  price` (a single coin's weight can exceed 1 under leverage). `delta_to(position)`
+  gives the order size/side.
+- `application.run_app.build_runners` / `_resolve_signal_fn` / `_reject_commingled`
+  — the single-instrument wiring to mirror/extend; `StrategyRunner` — the loop to
+  mirror; `application.data_provider.feed_for` + `DataSourceConfig` — the dccd feed
+  to generalise to N coins; the shared `Engine` (`OrderRouter`+risk, `PositionTracker`,
+  `EventBus`, `PerformanceService`).
+- `brokers.BinanceBroker` (E11) — the venue; maker LIMIT orders for the 0.10% fee.
+
+## Decomposition
+
+1. **portfolio-signal** — the `PortfolioSignalFn` contract + a safe by-reference
+   loader + the weight→`Signal.target_qty` sizing helper. (application)
+2. **portfolio-feed** — a multi-instrument, common-date-index daily-bars feed from
+   dccd's Binance store, with an "all N coins have today's close" freshness gate.
+3. **portfolio-runner** — the rebalance loop: weights × capital ÷ price → per-coin
+   `delta_to(position)` → N idempotent risk-gated **maker LIMIT** orders; hold to
+   the next (daily) tick.
+4. **portfolio-config** — `PortfolioStrategyConfig` in `AppConfig` + wiring into
+   `run_app`/`build_runners`; `fynance-research` as an optional editable extra.
+5. **ls1-e2e** — LS1 end-to-end on real dccd Binance bars (deltas == intended) +
+   an opt-in Binance **testnet** rebalance round-trip.
+
+## Leaf checklist
+
+- [ ] 01 portfolio-signal — feat/portfolio-signal — medium (→ opus)
+- [ ] 02 portfolio-feed — feat/portfolio-feed — medium (→ opus) (depends on 01)
+- [ ] 03 portfolio-runner — feat/portfolio-runner — high (→ opus) (depends on 01)
+- [ ] 04 portfolio-config — feat/portfolio-config — medium (→ opus) (depends on 02, 03)
+- [ ] 05 ls1-e2e — feat/portfolio-ls1-e2e — high (→ opus) (depends on 04)
+
+## Dependencies
+
+- 01 first. 02 and 03 both depend on 01 (and may proceed in parallel, but the
+  default is serial). 04 depends on 02 + 03. 05 depends on 04. Otherwise serial.
+
+## Done criteria
+
+- A `PortfolioStrategy` runs end-to-end: one config declares a universe + a
+  by-reference weight-vector signal + capital + (daily) cadence + venue=binance;
+  `run_app` builds it; it emits the right **N** orders to converge each coin to
+  `weight × capital / price`, idempotently, risk-gated, on the shared engine.
+- LS1 is wired purely by config (`fynance_research.strategies.ls1_live:target_weights`)
+  — no LS1 specifics in the engine. `fynance-research` is an optional `[triptych]`
+  extra (offline tests run without it via a fake weight-vector signal).
+- **Verified on real data:** over real dccd Binance daily bars, the routed per-coin
+  deltas equal `weightᵢ × capital / priceᵢ − current_qtyᵢ`; an opt-in Binance
+  **testnet** rebalance places/reconciles the legs against broker-reported state.
+- Paper stays the default; the portfolio path is risk-gated (gross cap honoured)
+  and money stays `Decimal`. `ruff`/`mypy`/`pytest` green via `.venv`.
+- Last leaf (05) removes the multi-asset roadmap line from `07-roadmap.md` and
+  updates `06-status.md`.

--- a/doc/dev/plans/portfolio-strategy/01-portfolio-signal.md
+++ b/doc/dev/plans/portfolio-strategy/01-portfolio-signal.md
@@ -1,0 +1,90 @@
+---
+plan: portfolio-strategy/01-portfolio-signal
+kind: leaf
+status: planned
+complexity: medium
+depends: []
+parallel: false
+branch: feat/portfolio-signal
+pr: ""
+---
+
+# Portfolio signal contract + by-reference loader + sizing helper
+
+## Goal
+
+Introduce the **multi-asset** analogue of the single-instrument `SignalFn`: a
+`PortfolioSignalFn` that returns a **weight vector** `{Symbol: weight}` (signed
+fraction of capital, Σ|w| ≤ a cap), a safe **by-reference loader** (mirroring
+`_resolve_signal_fn`/`load_strategy`), and the pure **weight→quantity** sizing
+helper used by the runner (leaf 03). No I/O.
+
+## Files to change
+
+- `trading_bot/application/portfolio.py` — new. Define:
+  - `PortfolioSignalFn` = `Callable[[int, Mapping[Symbol, "pl.DataFrame"]], Mapping[Symbol, Money]]`
+    (`asof_ms`, per-coin causal frames → weights). Document: weight is a **signed
+    fraction of capital**; Σ|w| may be capped by the signal; the engine does not
+    re-normalise (it trusts the signal's cap, see ADR in leaf 03 for the optional
+    engine-side gross guard).
+  - `PortfolioStrategy` (frozen dataclass): `name: str`, `universe: tuple[Symbol, ...]`,
+    `signal_fn: PortfolioSignalFn`, `capital: Money`, `gross_cap: Money | None = None`.
+  - `weights_to_signals(weights, *, frames|prices, capital, asof_ms) -> list[Signal]`:
+    pure helper — for each `Symbol`, `qty = weight * capital / price`,
+    `Signal.target_qty(Instrument(symbol), qty, ts=asof_ms)`. Skip a symbol with a
+    non-positive price (raise a clear `ConfigError`/`SignalError`). Keep everything
+    `Decimal` (`money(str(...))`); never float.
+  - `load_portfolio_signal(ref: str) -> PortfolioSignalFn`: a **safe** loader for a
+    `"module:function"` ref (reuse the import path of
+    `strategy.load_strategy` — `importlib.import_module` + `getattr`, **never**
+    exec a loose file). A `ref` with no `":"` is a clear `ConfigError` (no builtin
+    portfolio registry yet).
+- `trading_bot/application/__init__.py` — export the new public names if the
+  package surface lists application use-cases (match what's already exported).
+- `trading_bot/tests/application/test_portfolio_signal.py` — new.
+
+## Steps
+
+1. Read `application/strategy.py` (`SignalFn`, `load_strategy` — the safe import)
+   and `application/run_app.py` (`_resolve_signal_fn`) to mirror the loader style;
+   read `domain/signal.py` (`Signal.target_qty`, `delta_to`).
+2. Define the types/dataclass above. `PortfolioStrategy` is frozen; `universe` is a
+   tuple of canonical `Symbol`s.
+3. Implement `weights_to_signals` purely. Decide and document the price source
+   contract: it takes an explicit `prices: Mapping[Symbol, Money]` (the runner
+   passes the latest close per coin) — keeps this helper pure and unit-testable
+   without a frame. (The runner extracts prices from the feed in leaf 03.)
+4. Implement `load_portfolio_signal` with the same safety guarantees as
+   `load_strategy` (importable module only; clear `ConfigError` on a bad ref or a
+   non-callable target).
+
+## Tests
+
+- `weights_to_signals`: `{BTC/USDT:+0.5, ETH/USDT:-0.25}`, capital `100000`,
+  prices `{BTC:50000, ETH:2500}` → `Signal.target_qty` of `+1.0` BTC and `-10.0`
+  ETH (exact `Decimal`); a weight of `0` yields a flat (`0`) target; a missing or
+  non-positive price raises.
+- A weight whose `|w|>1` (leverage) is allowed (target_qty carries its own scale)
+  — assert no `[-1,1]` rejection.
+- `load_portfolio_signal("trading_bot.tests.fixtures.fake_book:weights")` resolves
+  and returns a callable; a no-`":"` ref and a missing attribute each raise
+  `ConfigError`.
+- A tiny in-repo **fake** `PortfolioSignalFn` fixture (returns fixed weights for a
+  small universe) for downstream leaves to reuse — add it under
+  `trading_bot/tests/fixtures/`.
+
+## Verification on real data
+
+Not a data path yet (pure). The real-data check lands in leaf 05 (LS1). Here, make
+the contract honest: the fake fixture's weights round-trip through
+`weights_to_signals` to the exact `Decimal` target quantities a hand-calc gives.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.portfolio` — multi-asset `PortfolioSignalFn`
+  (weight-vector) contract + safe by-reference loader + weight→`Signal.target_qty`
+  sizing."
+- ADR: the `(asof, frames) -> {Symbol: weight}` contract choice and weight =
+  fraction-of-capital sizing via explicit-qty `Signal` (vs fractional exposure,
+  which can't express |w|>1). Mirrors the single-instrument signal-by-reference ADR.
+- Status/roadmap: no change (deferred to leaf 05).

--- a/doc/dev/plans/portfolio-strategy/02-portfolio-feed.md
+++ b/doc/dev/plans/portfolio-strategy/02-portfolio-feed.md
@@ -1,0 +1,80 @@
+---
+plan: portfolio-strategy/02-portfolio-feed
+kind: leaf
+status: planned
+complexity: medium
+depends: [01]
+parallel: false
+branch: feat/portfolio-feed
+pr: ""
+---
+
+# Portfolio data feed — N-coin, common-index daily bars (freshness-gated)
+
+## Goal
+
+A **multi-instrument** causal feed that assembles, for a universe of N coins,
+their daily bars from **dccd's Binance store** on a **common date index**, and
+gates each rebalance on **"all N coins have today's close"** (the LS1 dossier §7:
+a missing/stale bar silently changes the cross-section). Causal: only closed daily
+bars, growing windows — never a future bar.
+
+## Files to change
+
+- `trading_bot/application/portfolio_feed.py` — new (or extend
+  `application/data_provider.py` if that is where `feed_for`/`DccdFeed` live —
+  read first and match the existing module boundary).
+- `trading_bot/tests/application/test_portfolio_feed.py` — new.
+
+## Steps
+
+1. Read `application/data_provider.py` (`feed_for`, `DccdClient`, `DccdFeed`) and
+   `application/data_feed.py` (the causal `DataFeed` protocol: `__iter__` yields
+   growing `frame[:t+1]` windows, `latest()`), to reuse the single-coin dccd read
+   and the causality contract.
+2. Implement `PortfolioFeed`:
+   - construct from a `universe: Sequence[Symbol]`, a per-coin dccd
+     `DataSourceConfig`-equivalent (Binance, `span = 86400` for daily), an injected
+     `DccdClient | None` (offline-testable), and `data_path`;
+   - read each coin's daily bars via the same dccd path `feed_for` uses;
+   - **align** on a common date index (inner-join on bar timestamp): a rebalance
+     date is only emitted when **every** coin has that day's closed bar;
+   - iterate **causally**: at step *t* yield a `Mapping[Symbol, pl.DataFrame]` of
+     each coin's window up to and including day *t* (so the signal sees ≥ lookback
+     closes, e.g. LS1 needs ≥ 200);
+   - `latest()` → the full aligned per-coin frames.
+3. Freshness gate: expose the asof timestamp of the latest common date; if a coin
+   is missing the latest day, that day is simply not emitted (the cross-section is
+   never computed on a partial universe). Log (never raise) a coin lagging the
+   others.
+
+## Tests
+
+- Offline, with a **fake `DccdClient`** returning canned daily bars per coin:
+  - common-index alignment: coins with mismatched date ranges yield only the
+    intersection of dates; a coin missing the latest day → that day not emitted.
+  - causality: window at step *t* contains no timestamp > day *t* for any coin;
+    windows grow monotonically.
+  - the per-coin window at the final step has ≥ the configured lookback rows when
+    the fixture provides them.
+- The asof timestamp equals the latest common date's close ms.
+
+## Verification on real data
+
+**Mandatory (data path).** Against the **real dccd Binance store** (the 10 LS1
+coins, `*-USDT`, daily): build a `PortfolioFeed`, drain it, and assert (a) every
+emitted rebalance date has a closed bar for **all 10** coins, (b) the final window
+has ≥ 200 daily closes per coin (LS1's SMA-200 need), (c) no window contains a
+future bar. If the dccd Binance daily store is present locally, **run it and paste
+the date range + per-coin row counts**; otherwise mark `@pytest.mark.network`/skip
+and document how to sync it (`DEPLOY_LS1.md` §3 — the 15 alt USDT pairs added to
+the dccd daemon on 2026-06-28).
+
+## Closeout
+
+- CHANGELOG (Added): "`application.PortfolioFeed` — N-coin common-index daily-bars
+  feed from the dccd Binance store, gated on all coins having today's close."
+- ADR: only if a non-trivial choice arises (e.g. inner-join vs forward-fill on a
+  missing coin-day — default **inner-join / skip the day**, never forward-fill a
+  stale close into the cross-section).
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/portfolio-strategy/03-portfolio-runner.md
+++ b/doc/dev/plans/portfolio-strategy/03-portfolio-runner.md
@@ -1,0 +1,88 @@
+---
+plan: portfolio-strategy/03-portfolio-runner
+kind: leaf
+status: planned
+complexity: high
+depends: [01]
+parallel: false
+branch: feat/portfolio-runner
+pr: ""
+---
+
+# Portfolio runner — weight vector → N idempotent risk-gated orders
+
+## Goal
+
+The multi-asset analogue of `StrategyRunner`: a `PortfolioRunner` that, each
+rebalance tick, calls the `PortfolioSignalFn` for the **whole book**, converts the
+weight vector to per-coin target quantities, computes each coin's delta vs the
+**shared** `PositionTracker`, and routes **N** idempotent, risk-gated orders
+through the **shared** `OrderRouter` — then holds to the next (daily) tick.
+
+## Files to change
+
+- `trading_bot/application/portfolio_runner.py` — new (`PortfolioRunner`).
+- `trading_bot/tests/application/test_portfolio_runner.py` — new.
+
+## Steps
+
+1. Read `application/strategy_runner.py` (the single-instrument loop: feed →
+   signal → `delta_to` → `order_factory` → `OrderRouter.submit`; the per-step
+   `client_order_id = f"{name}-{step}"`; the cooperative `run(stop_event=...)`),
+   and `application/order_router.py` (idempotent `submit`, risk gate) to mirror.
+2. `PortfolioRunner(strategy: PortfolioStrategy, feed: PortfolioFeed, router,
+   tracker, *, event_bus, order_factory)`:
+   - per tick *t*: `frames = next(feed)`; `asof = feed asof ms`;
+     `prices = {sym: latest close of frames[sym]}`;
+     `weights = strategy.signal_fn(asof, frames)`;
+     `signals = weights_to_signals(weights, prices=prices, capital=strategy.capital, asof_ms=asof)`;
+   - for each `Symbol` in the **universe** (so a coin dropped from `weights` this
+     tick is targeted **flat** — Σ must cover the whole book):
+     `delta = signal.delta_to(tracker.position(instrument))`; if `delta == 0` skip;
+     else build an order via `order_factory` and `await router.submit(order)`.
+   - **Idempotent ids:** `client_order_id = f"{strategy.name}-{symbol}-{step}"` so a
+     re-run/retry dedups per coin per rebalance (mirror the single-instrument
+     scheme, namespaced by symbol).
+   - **Maker LIMIT orders:** the order factory prices each leg as a LIMIT at the
+     coin's latest close (LS1 pays the 0.10% maker fee; also lets the paper broker
+     fill self-contained). A live broker fills at the venue.
+   - Count orders submitted; surface per-coin failures without aborting the whole
+     rebalance (collect + report, like the orchestrator).
+   - Cooperative stop: `run(stop_event=...)` holds between ticks (daily cadence is
+     driven by the feed/scheduler, not a busy loop).
+3. **Optional engine-side gross guard (ADR):** if `strategy.gross_cap` is set,
+   assert Σ|wᵢ| ≤ gross_cap before sizing and raise/clip per the documented policy
+   (LS1's signal already caps at 2×; this is defence in depth, default **off**).
+
+## Tests
+
+- With the **fake `PortfolioSignalFn`** (leaf 01 fixture) + a `PaperBroker` engine
+  + a fake feed: one rebalance from flat → N orders whose sizes equal
+  `weightᵢ × capital / priceᵢ` (exact `Decimal`); sides match weight signs.
+- Second rebalance with changed weights → orders equal the **delta** vs the now-non-flat
+  positions (read from the shared tracker after the first fills), not the absolute
+  target. A coin whose weight goes to 0 is targeted flat (full close).
+- Idempotency: re-submitting the same rebalance step (same `step`) places **no**
+  duplicate orders (router dedup on the per-coin id).
+- Risk gate: an order exceeding `max_order` raises `RiskLimitBreached` and never
+  reaches the broker; the other legs still route (or the documented all-or-nothing
+  policy — decide + test).
+- Reconciliation honesty: after fills, `tracker.position(coin)` equals the routed
+  cumulative qty for each coin.
+
+## Verification on real data
+
+**Mandatory.** Drive the runner with the **fake** signal but a **real**
+`PaperBroker` and assert the **broker-reported** fills (via the bus/tracker) match
+the intended per-coin targets — i.e. read what the broker confirmed, not local
+optimism (the project's core testing rule). The real LS1 signal + real Binance
+data/testnet round-trip is leaf 05.
+
+## Closeout
+
+- CHANGELOG (Added): "`application.PortfolioRunner` — rebalance loop turning a
+  weight vector into N idempotent, risk-gated maker-LIMIT orders on the shared engine."
+- ADR: the per-coin idempotency id scheme (`{name}-{symbol}-{step}`); whole-universe
+  targeting (a dropped coin → flat); per-leg failure policy; the optional gross-cap
+  guard (default off — trust the signal's cap).
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/portfolio-strategy/04-portfolio-config.md
+++ b/doc/dev/plans/portfolio-strategy/04-portfolio-config.md
@@ -1,0 +1,86 @@
+---
+plan: portfolio-strategy/04-portfolio-config
+kind: leaf
+status: planned
+complexity: medium
+depends: [02, 03]
+parallel: false
+branch: feat/portfolio-config
+pr: ""
+---
+
+# Portfolio config + wiring into run_app; fynance-research extra
+
+## Goal
+
+Make a portfolio strategy **declarable** in `AppConfig` and **runnable** through
+`run_app`, alongside the existing single-instrument strategies, and add
+`fynance-research` as an optional editable dependency so LS1's signal can be
+imported by reference.
+
+## Files to change
+
+- `trading_bot/application/config.py` — add `PortfolioStrategyConfig` and hang it
+  off `AppConfig` (e.g. `portfolios: list[PortfolioStrategyConfig] = []`).
+- `trading_bot/application/run_app.py` — build a `PortfolioRunner` per declared
+  portfolio and add it to the orchestrator alongside the single-instrument runners;
+  extend `RunReport`/`StrategyReport` (or add a `PortfolioReport`) for per-coin
+  outcomes.
+- `pyproject.toml` — add `fynance-research` to the `[triptych]` extra (editable
+  from `../fynance-research`, kept out of the hard deps like `dccd`); document it
+  in the extra's comment.
+- `trading_bot/tests/application/test_portfolio_config.py` — new.
+
+## Steps
+
+1. `PortfolioStrategyConfig` (pydantic v2, mirror `StrategyConfig` validators):
+   - `name: str` (non-empty);
+   - `universe: list[str]` (canonical pairs, e.g. `["BTC/USDT", ...]`; non-empty,
+     each parsed to a `Symbol`; reject duplicates within the universe);
+   - `signal: SignalRefConfig` (a `module:function` ref → `target_weights`-shaped
+     callable; reuse `SignalRefConfig`);
+   - `capital: Decimal` (positive; exact from YAML scalar);
+   - `data: DataSourceConfig` (the dccd Binance source; `span` = 86400 for daily);
+   - `gross_cap: Decimal | None = None`; `cadence`/rebalance is daily (driven by the
+     daily `span`); `venue: str = "binance"`.
+2. In `run_app`/`build_runners` (or a sibling `build_portfolio_runners`):
+   - resolve the signal via `load_portfolio_signal(signal.ref)` (leaf 01);
+   - build a `PortfolioFeed` (leaf 02) over the universe from `data`;
+   - build a `PortfolioStrategy` + `PortfolioRunner` (leaf 03) over the **shared**
+     engine; add to the orchestrator.
+   - **Commingling:** a portfolio **owns** its N instruments, so it is exempt from
+     the single-instrument `_reject_commingled`, but assert **no overlap** between
+     any portfolio's universe and any other strategy/portfolio's instruments
+     (same shared per-instrument tracker → same attribution problem). Raise a clear
+     `ConfigError` on overlap.
+3. Keep **paper the default**; the portfolio path goes through the same factory /
+   live opt-in gate (live still off by default).
+
+## Tests
+
+- A YAML/dict config with one `portfolios:` entry (fake signal ref, 3-coin
+  universe, capital) validates and `run_app` (offline, injected fake dccd client +
+  fake signal) produces the expected per-coin orders/positions.
+- Overlap detection: a portfolio universe sharing a coin with a single-instrument
+  strategy (or another portfolio) → `ConfigError`.
+- Validators: empty universe, duplicate coin in a universe, non-positive capital →
+  `ValidationError`/`ConfigError`.
+- Backward-compat: a config with **no** `portfolios:` still validates and runs
+  exactly as before.
+
+## Verification on real data
+
+**Mandatory.** Offline end-to-end through `run_app` with a fake signal + fake dccd
+client over a small universe: assert the per-coin routed orders and final tracker
+positions match the intended `weight × capital / price` targets read back from the
+engine (broker-confirmed). The **real** LS1 + real dccd Binance run is leaf 05.
+
+## Closeout
+
+- CHANGELOG (Added): "`AppConfig.portfolios` + `run_app` — declare and run a native
+  multi-asset portfolio strategy (universe + weight-vector signal + capital)."
+  (Changed: `[triptych]` extra now includes `fynance-research`.)
+- ADR: the `PortfolioStrategyConfig` shape; the no-instrument-overlap rule (vs
+  single-instrument `_reject_commingled`); `fynance-research` as an optional extra
+  (engine stays generic; LS1 is config).
+- Status/roadmap: deferred to leaf 05.

--- a/doc/dev/plans/portfolio-strategy/05-ls1-e2e.md
+++ b/doc/dev/plans/portfolio-strategy/05-ls1-e2e.md
@@ -1,0 +1,79 @@
+---
+plan: portfolio-strategy/05-ls1-e2e
+kind: leaf
+status: planned
+complexity: high
+depends: [04]
+parallel: false
+branch: feat/portfolio-ls1-e2e
+pr: ""
+---
+
+# LS1 end-to-end — real dccd Binance bars + opt-in testnet rebalance
+
+## Goal
+
+Prove the whole portfolio path on the **real** LS1 strategy and **real** data: a
+config wiring `fynance_research.strategies.ls1_live:target_weights` over the
+10-coin Binance USDT universe, run against **dccd's Binance daily store**, with the
+routed per-coin deltas matching `weightᵢ × capital / priceᵢ − current_qtyᵢ`; plus
+an **opt-in Binance testnet** rebalance that places and reconciles the legs.
+
+## Files to change
+
+- `trading_bot/tests/application/test_ls1_e2e.py` — new (`@pytest.mark.network` /
+  dependency-gated).
+- `configs/ls1.yaml` (or `examples/`) — a runnable LS1 config (paper by default):
+  universe = the 10 coins, `signal.ref = "fynance_research.strategies.ls1_live:target_weights"`,
+  capital, `data` = dccd Binance daily (`span: 86400`), `gross_cap: 2`.
+- `doc/dev/` — a short "running LS1" note (or extend `09-go-live.md`) pointing at
+  `../fynance-research/DEPLOY_LS1.md`.
+
+## Steps
+
+1. Confirm `fynance_research.strategies.ls1_live.target_weights()` is importable
+   (the `[triptych]` extra from leaf 04). If its signature is argument-free (reads
+   the dccd store itself, per `DEPLOY_LS1.md` §5), wrap it in a thin adapter that
+   matches `PortfolioSignalFn`'s `(asof, frames) -> {Symbol: weight}` — ignoring the
+   passed frames (the frames still drive the freshness gate + prices in the runner).
+   Normalise the returned `{"BTC-USDT": w}` keys to canonical `Symbol`s
+   (`parse_binance_symbol`).
+2. Build the LS1 config; run it offline-ish through `run_app` against the **real**
+   dccd Binance daily store (the feed reads real bars; the broker is `PaperBroker`).
+3. Assert: for the latest rebalance, each coin's routed order delta ==
+   `weightᵢ × capital / priceᵢ − current_qtyᵢ` (exact `Decimal`); Σ of routed
+   notionals ≤ `gross_cap × capital`; the freshness gate holds (all 10 coins have
+   the day's close).
+4. **Opt-in Binance testnet rebalance** (`network`, skips without testnet creds):
+   point the engine at `BinanceBroker` testnet, run **one** rebalance with a tiny
+   capital, read back `open_orders()`/`balances()`, assert the placed legs match
+   the intended deltas, then **cancel** all legs in a `finally`. No mainnet.
+
+## Tests
+
+- The delta-correctness assertion above on real dccd bars (gated on the dccd
+  Binance store being present; otherwise skip with a clear reason).
+- The `target_weights` key-normalisation adapter: `"BTC-USDT" → Symbol("BTC","USDT")`.
+- Σ|w| ≤ 2 (the cap holds on the live signal output).
+- Testnet rebalance round-trip (opt-in) — place → read → cancel, broker-reported
+  state matches intent.
+
+## Verification on real data
+
+This **is** the real-data leaf. Run the dccd-backed delta-correctness check and (if
+a testnet key is present) the testnet rebalance; **paste the evidence** — the asof
+date, the 10 weights, the per-coin intended vs routed deltas, and the testnet
+order/cancel confirmations. If neither real source is available in the run
+environment, state exactly how to run each and why it is skipped (do not fake it).
+
+## Closeout
+
+- CHANGELOG (Added): "LS1 runnable end-to-end via the portfolio strategy
+  (`configs/ls1.yaml`): dccd Binance bars → `ls1_live.target_weights` → N Binance
+  legs; delta-correctness verified on real data; opt-in testnet rebalance."
+- ADR: the `target_weights` adapter (store-reading signal vs the `(asof, frames)`
+  contract — frames drive freshness/prices, the signal supplies weights).
+- Status: `06-status.md` — record LS1 as deployable (paper / dccd-verified; testnet
+  rebalance opt-in; mainnet real-key still behind the live opt-in).
+- Roadmap: **last leaf** — remove the multi-asset / portfolio-strategy line from
+  `07-roadmap.md`.


### PR DESCRIPTION
## Goal

The **native portfolio-strategy** abstraction: a single logical strategy spanning
**N instruments** that consumes a **weight vector** `{Symbol: weight}` (signed
fraction of capital, Σ|w| ≤ cap) in one shot and drives all N to target via
idempotent, risk-gated orders on one venue. Validating use case: **LS1**
(`../fynance-research/DEPLOY_LS1.md`) — a daily long/short book over **10 Binance
USDT** coins, bars from the dccd Binance store.

The engine stays **generic**: the portfolio signal is loaded **by reference**
(`fynance_research.strategies.ls1_live:target_weights`), so LS1 lives in config,
not in `trading_bot`. This is the "clean" path the LS1 dossier calls for (vs the
interim 10-single-instrument-strategies workaround).

**0.3.0 work** — sits on top of E11 (Binance, the execution venue).

## Leaf checklist

- [ ] 01 portfolio-signal — `feat/portfolio-signal` — `PortfolioSignalFn` contract + by-ref loader + weight→`Signal.target_qty` sizing
- [ ] 02 portfolio-feed — `feat/portfolio-feed` — N-coin common-index daily feed from dccd Binance, freshness-gated (depends 01)
- [ ] 03 portfolio-runner — `feat/portfolio-runner` — rebalance loop → N idempotent risk-gated maker-LIMIT orders (depends 01)
- [ ] 04 portfolio-config — `feat/portfolio-config` — `AppConfig.portfolios` + `run_app` wiring + `fynance-research` extra (depends 02,03)
- [ ] 05 ls1-e2e — `feat/portfolio-ls1-e2e` — LS1 on real dccd Binance bars (deltas == intended) + opt-in testnet rebalance (depends 04)

## Key design (in the leaves)

- Weight → `Signal.target_qty(inst, weight × capital / price)` (explicit-qty signal, so a single coin's `|w|>1` under leverage is expressible).
- `PortfolioFeed` gates on **all N coins having today's close** (LS1 §7: a stale bar silently changes the cross-section).
- Per-coin idempotency id `f"{name}-{symbol}-{step}"`; a coin dropped from the weights → targeted **flat**.
- A portfolio **owns** its N instruments (exempt from `_reject_commingled`), but no overlap with other strategies is allowed.

## Test plan
- [ ] Plan tree reviewed; merge, then `/execute-leaf portfolio-strategy next`.

> Note: this is the epic for the multi-asset roadmap item already on `develop`. Depends on the 0.2.0 release landing first (its leaves' CHANGELOG entries belong in the post-0.2.0 `[Unreleased]`).