### PR TITLE
feat: portfolio signal contract + by-ref loader + sizing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `application.portfolio` — the multi-asset `PortfolioSignalFn` contract
+  (`(asof_ms, frames) -> {Symbol: weight}`, weight = signed fraction of capital),
+  a frozen `PortfolioStrategy` (universe + signal + capital + optional gross cap),
+  a pure `weights_to_signals` sizer (`qty = weight × capital / price` →
+  `Signal.target_qty`, exact `Decimal`), and a safe by-reference
+  `load_portfolio_signal` loader. Groundwork for native multi-asset strategies (LS1). (#63)
+
 ### Changed
 
 ### Fixed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,32 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-28 Portfolio signal contract — weight vector + explicit-qty sizing (PR #63)
+
+**Decision.** The multi-asset strategy contract is a `PortfolioSignalFn`
+`(asof_ms, {Symbol: frame}) -> {Symbol: weight}` — a **weight vector**, weight =
+**signed fraction of capital**, returned for the whole universe in one shot
+(`application.portfolio`). Sizing is `qty = weight × capital / price`, emitted as
+an **explicit-quantity** `Signal.target_qty` (not a fractional
+`SignalMode.EXPOSURE`). The signal is loaded **by reference** (`module:function`,
+safe `importlib`+`getattr`, no loose-file exec), exactly like the single-instrument
+signal; there is no builtin portfolio registry. The engine **does not re-normalise**
+the vector (it trusts the signal's own `Σ|w|` cap); `gross_cap` is recorded,
+advisory.
+
+**Why.** LS1 (the first validated multi-asset strategy) is a *vector* of target
+weights over ~10 coins, gross-capped 2× — the single-instrument `(bars) -> Signal`
+can't express it, and per-coin weight can exceed 1 under leverage, which a bounded
+`[-1, 1]` exposure signal would reject. An explicit-qty signal carries its own
+scale, so `delta_to(position)` needs no `reference_qty` and the runner diffs
+directly against live positions. Keeping the loader by-reference keeps the engine
+**generic** — LS1 lives in config, not in `trading_bot`. **Rejected:** a fractional
+exposure vector (can't express `|w|>1`); the engine re-normalising the book (would
+silently override the strategy's risk sizing); a frame-coupled sizer (kept
+`weights_to_signals` pure by passing prices explicitly).
+
+---
+
 ### 2026-06-28 BinanceBroker — 2nd live venue; composite id, fills scoping, newClientOrderId, testnet (PR #61)
 
 **Decision.** `BinanceBroker` (spot REST) is the second adapter behind the

--- a/doc/dev/plans/portfolio-strategy/00-plan.md
+++ b/doc/dev/plans/portfolio-strategy/00-plan.md
@@ -62,7 +62,7 @@ shape. It is **0.3.0 work** (post the 0.2.0 release).
 
 ## Leaf checklist
 
-- [ ] 01 portfolio-signal — feat/portfolio-signal — medium (→ opus)
+- [x] 01 portfolio-signal — feat/portfolio-signal — medium (→ opus)
 - [ ] 02 portfolio-feed — feat/portfolio-feed — medium (→ opus) (depends on 01)
 - [ ] 03 portfolio-runner — feat/portfolio-runner — high (→ opus) (depends on 01)
 - [ ] 04 portfolio-config — feat/portfolio-config — medium (→ opus) (depends on 02, 03)

--- a/doc/dev/plans/portfolio-strategy/01-portfolio-signal.md
+++ b/doc/dev/plans/portfolio-strategy/01-portfolio-signal.md
@@ -1,12 +1,12 @@
 ---
 plan: portfolio-strategy/01-portfolio-signal
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: []
 parallel: false
 branch: feat/portfolio-signal
-pr: ""
+pr: "#63"
 ---
 
 # Portfolio signal contract + by-reference loader + sizing helper

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -128,6 +128,12 @@ from trading_bot.application.events import (
 from trading_bot.application.orchestrator import Orchestrator, RunnerGroupError
 from trading_bot.application.order_router import OrderRouter
 from trading_bot.application.performance_service import PerformanceService
+from trading_bot.application.portfolio import (
+    PortfolioSignalFn,
+    PortfolioStrategy,
+    load_portfolio_signal,
+    weights_to_signals,
+)
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.reconcile import ReconResult, reconcile
 from trading_bot.application.risk import RiskManager
@@ -180,6 +186,11 @@ __all__ = [
     "SignalFn",
     "load_strategy",
     "ma_crossover_signal",
+    # portfolio (multi-asset signal)
+    "PortfolioStrategy",
+    "PortfolioSignalFn",
+    "weights_to_signals",
+    "load_portfolio_signal",
     # strategy runner
     "StrategyRunner",
     "OrderFactory",

--- a/trading_bot/application/portfolio.py
+++ b/trading_bot/application/portfolio.py
@@ -1,0 +1,273 @@
+"""The multi-asset analogue of :mod:`~trading_bot.application.strategy`.
+
+Where a single-instrument :data:`~trading_bot.application.strategy.SignalFn`
+returns *one* :class:`~trading_bot.domain.signal.Signal` for *one* instrument, a
+:data:`PortfolioSignalFn` returns a **weight vector** — a target *portfolio
+allocation* across a whole universe of symbols at once. This is the contract a
+multi-asset strategy speaks: "I want this signed fraction of capital in BTC,
+that fraction in ETH, ...", said once, venue-neutrally, before any order is
+shaped.
+
+The portfolio signal contract
+------------------------------
+A :data:`PortfolioSignalFn` takes ``(asof_ms, frames)`` — the as-of timestamp
+(ms since the Unix epoch, UTC) and a per-coin mapping of **causal** OHLC(V)
+frames (at step ``t`` each frame holds only bars ``≤ t``, never a future bar) —
+and returns a :class:`Mapping` ``{Symbol: weight}``. Each weight is a **signed
+fraction of capital**: ``+0.5`` means *target a long worth half the capital*,
+``-0.25`` means *target a short worth a quarter*. ``Σ|w|`` (the gross exposure)
+*may* be capped by the signal itself (see :attr:`PortfolioStrategy.gross_cap`),
+but **the engine does not re-normalise** the vector — a signal that returns
+``Σ|w| = 2`` is taken at face value as 2× gross leverage. A symbol the signal
+omits (or maps to ``0``) targets a flat position. A weight with ``|w| > 1`` is
+*allowed* (it is leverage on a single name, not an error): the weight→quantity
+sizing below carries its own scale, so there is no ``[-1, 1]`` rejection here
+(unlike a fractional :data:`~trading_bot.domain.signal.SignalMode.EXPOSURE`
+:class:`~trading_bot.domain.signal.Signal`, which *is* bounded).
+
+Sizing — weight → quantity
+--------------------------
+:func:`weights_to_signals` is the pure helper the runner (leaf 03) uses to turn
+a weight vector into per-instrument :class:`~trading_bot.domain.signal.Signal`\\
+s. For each symbol::
+
+    qty = weight * capital / price
+
+and the result is an *explicit-quantity* signal
+(:meth:`~trading_bot.domain.signal.Signal.target_qty`) — it carries its own
+scale, so the runner can diff it against a live position with no
+``reference_qty``. Everything stays exact :class:`~decimal.Decimal` (prices,
+weights, capital, quantities); never ``float``. The helper takes the latest
+``price`` per coin as an **explicit mapping** (the runner reads the latest close
+off each frame and passes it in) rather than pulling it from a frame itself —
+that keeps the helper pure, frame-agnostic and unit-testable.
+
+Loading — no arbitrary-file exec
+--------------------------------
+:func:`load_portfolio_signal` resolves a ``"module:function"`` string to a
+:data:`PortfolioSignalFn` via :func:`importlib.import_module` + :func:`getattr`,
+exactly like :func:`~trading_bot.application.strategy.load_strategy` — only an
+*already-importable* dotted module may be named, **never** an ``exec`` of a
+loose file. There is no builtin portfolio-signal registry yet, so a ``ref`` with
+no ``":"`` is a clear :class:`~trading_bot.domain.errors.ConfigError` (it cannot
+be a builtin name).
+
+This module lives in the application layer: it may import the pure domain, holds
+all money/quantities as :class:`~decimal.Decimal`, and performs no I/O of its
+own.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from trading_bot.domain.errors import ConfigError, SignalError
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.signal import Signal
+
+if TYPE_CHECKING:
+    import polars as pl
+
+__all__ = [
+    "PortfolioSignalFn",
+    "PortfolioStrategy",
+    "weights_to_signals",
+    "load_portfolio_signal",
+]
+
+#: A multi-asset strategy's signal callable: ``(asof_ms, {Symbol: frame})`` →
+#: a weight vector ``{Symbol: weight}``. Each weight is a **signed fraction of
+#: capital**; ``Σ|w|`` may be capped by the signal but the engine never
+#: re-normalises it. The frames are per-coin **causal** OHLC(V) windows (at step
+#: ``t`` only bars ``≤ t``). The analogue of
+#: :data:`~trading_bot.application.strategy.SignalFn` for a whole universe.
+PortfolioSignalFn = Callable[
+    [int, Mapping[Symbol, "pl.DataFrame"]], Mapping[Symbol, Money]
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioStrategy:
+    """A declared multi-asset strategy: a universe + a weight-vector signal.
+
+    The portfolio analogue of :class:`~trading_bot.application.strategy.
+    Strategy`. Immutable: build one directly or (later) from config. The runner
+    (leaf 03) evaluates :attr:`signal_fn` on each step's per-coin frames to get a
+    weight vector, then sizes it against :attr:`capital` via
+    :func:`weights_to_signals`.
+
+    Parameters
+    ----------
+    name : str
+        Logical id of the strategy instance.
+    universe : tuple of Symbol
+        The canonical :class:`~trading_bot.domain.instrument.Symbol`\\ s the
+        strategy allocates across. A tuple (ordered, hashable) so the strategy
+        stays frozen/hashable.
+    signal_fn : PortfolioSignalFn
+        The weight-vector signal callable: ``(asof_ms, frames)`` → ``{Symbol:
+        weight}``.
+    capital : Money
+        The capital base (in quote units) the weights are a fraction of — a
+        weight ``w`` for a symbol targets a position worth ``w * capital``.
+    gross_cap : Money or None, optional
+        An optional declared gross-exposure cap (``Σ|w| ≤ gross_cap``), recorded
+        for a signal/runner to honour. ``None`` (default) means uncapped. The
+        engine does **not** enforce or re-normalise against this — it is the
+        signal's documented budget, carried here for reference.
+
+    """
+
+    name: str
+    universe: tuple[Symbol, ...]
+    signal_fn: PortfolioSignalFn
+    capital: Money
+    gross_cap: Money | None = None
+
+
+def weights_to_signals(
+    weights: Mapping[Symbol, Money],
+    *,
+    prices: Mapping[Symbol, Money],
+    capital: Money,
+    asof_ms: int,
+) -> list[Signal]:
+    """Size a weight vector into per-instrument target-quantity signals.
+
+    Pure helper (no I/O, no frame). For each ``(symbol, weight)`` in
+    ``weights`` the target net quantity is::
+
+        qty = weight * capital / price
+
+    and the result is an explicit-quantity
+    :meth:`~trading_bot.domain.signal.Signal.target_qty` for
+    ``Instrument(symbol)`` at ``asof_ms``. A weight of ``0`` yields a flat
+    (``0``) target. A weight with ``|w| > 1`` (single-name leverage) is allowed
+    — there is no ``[-1, 1]`` rejection; the explicit-quantity signal carries
+    its own scale.
+
+    All arithmetic stays exact :class:`~decimal.Decimal`: ``capital`` and each
+    ``price`` / ``weight`` are :class:`~trading_bot.domain.money.Money`, and the
+    quotient is taken via :func:`~trading_bot.domain.money.money` on the exact
+    string form — never through ``float``.
+
+    Parameters
+    ----------
+    weights : Mapping[Symbol, Money]
+        The target weight vector ``{Symbol: signed fraction of capital}``.
+    prices : Mapping[Symbol, Money]
+        The latest price (quote per base unit) per symbol — supplied explicitly
+        by the caller (the runner reads each frame's latest close). Every symbol
+        in ``weights`` must have a strictly-positive price here.
+    capital : Money
+        The capital base (quote units) the weights are a fraction of. Must be
+        positive.
+    asof_ms : int
+        The signal timestamp (ms since the Unix epoch, UTC) stamped on every
+        produced :class:`~trading_bot.domain.signal.Signal`. Must be
+        non-negative.
+
+    Returns
+    -------
+    list of Signal
+        One explicit-quantity :class:`~trading_bot.domain.signal.Signal` per
+        symbol in ``weights``, in iteration order of ``weights``.
+
+    Raises
+    ------
+    ConfigError
+        If ``capital`` is not strictly positive.
+    SignalError
+        If a symbol in ``weights`` has no price in ``prices`` or a
+        non-positive one.
+
+    """
+    if capital <= 0:
+        raise ConfigError(
+            f"capital must be positive to size weights, got {capital}"
+        )
+
+    signals: list[Signal] = []
+    for symbol, weight in weights.items():
+        price = prices.get(symbol)
+        if price is None:
+            raise SignalError(
+                f"no price for {symbol} to size its weight {weight}"
+            )
+        if price <= 0:
+            raise SignalError(
+                f"price for {symbol} must be positive, got {price}"
+            )
+        # Keep everything Decimal: (weight * capital) / price, exactly.
+        qty = money(str(weight * capital / price))
+        signals.append(
+            Signal.target_qty(Instrument(symbol), qty, ts=asof_ms)
+        )
+    return signals
+
+
+def load_portfolio_signal(ref: str) -> PortfolioSignalFn:
+    """Resolve a ``"module:function"`` string to a :data:`PortfolioSignalFn`.
+
+    The portfolio counterpart of
+    :func:`~trading_bot.application.strategy.load_strategy`'s resolver, with the
+    same safety guarantee: the module is imported with
+    :func:`importlib.import_module` and the function pulled with
+    :func:`getattr` — only an *already-importable* dotted module can be named,
+    and nothing is ever ``exec``\\ 'd from a loose file.
+
+    There is **no** builtin portfolio-signal registry yet, so a ``ref`` with no
+    ``":"`` cannot resolve to a builtin name and is rejected outright.
+
+    Parameters
+    ----------
+    ref : str
+        A ``"module:function"`` import reference (e.g.
+        ``"my_pkg.signals:momentum"``).
+
+    Returns
+    -------
+    PortfolioSignalFn
+        The resolved callable.
+
+    Raises
+    ------
+    ConfigError
+        If ``ref`` is not a ``"module:function"`` string, names a module that
+        cannot be imported, has no such attribute, or resolves to a non-callable.
+
+    """
+    if ":" not in ref:
+        raise ConfigError(
+            f"portfolio signal reference {ref!r} must be 'module:function' "
+            "(there is no builtin portfolio-signal registry yet)"
+        )
+    module_name, _, attr = ref.partition(":")
+    if not module_name or not attr:
+        raise ConfigError(
+            f"portfolio signal reference {ref!r} must be 'module:function'"
+        )
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        raise ConfigError(
+            f"cannot import module {module_name!r} for portfolio signal "
+            f"{ref!r}: {exc}"
+        ) from exc
+    try:
+        fn = getattr(module, attr)
+    except AttributeError as exc:
+        raise ConfigError(
+            f"module {module_name!r} has no attribute {attr!r} "
+            f"for portfolio signal {ref!r}"
+        ) from exc
+    if not callable(fn):
+        raise ConfigError(
+            f"portfolio signal {ref!r} resolved to a non-callable "
+            f"{type(fn).__name__}"
+        )
+    return fn  # type: ignore[no-any-return]

--- a/trading_bot/tests/application/test_portfolio_signal.py
+++ b/trading_bot/tests/application/test_portfolio_signal.py
@@ -1,0 +1,214 @@
+"""Tests for :mod:`trading_bot.application.portfolio`.
+
+These prove the multi-asset signal contract and its safe by-reference loader:
+
+* :func:`weights_to_signals` sizes a weight vector into explicit-quantity
+  :class:`~trading_bot.domain.signal.Signal`\\ s with **exact** ``Decimal``
+  arithmetic (``qty = weight * capital / price``): a hand-calc round-trips to the
+  precise target quantities, a ``0`` weight is flat, and a missing/non-positive
+  price (or non-positive capital) raises;
+* single-name leverage (``|w| > 1``) is **allowed** — there is no ``[-1, 1]``
+  rejection on the way to a target-quantity signal;
+* :func:`load_portfolio_signal` resolves a ``"module:function"`` ref to a
+  callable and raises a clear :class:`~trading_bot.domain.errors.ConfigError` on
+  a no-``":"`` ref, a missing attribute, an unimportable module, or a
+  non-callable target;
+* the in-repo fake :func:`~trading_bot.tests.fixtures.fake_book.fixed_weights`
+  round-trips through :func:`weights_to_signals` to the exact target quantities a
+  hand-calc gives.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from trading_bot.application.portfolio import (
+    PortfolioStrategy,
+    load_portfolio_signal,
+    weights_to_signals,
+)
+from trading_bot.domain.errors import ConfigError, SignalError
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.signal import SignalMode
+from trading_bot.tests.fixtures import fake_book
+
+BTC = Symbol("BTC", "USDT")
+ETH = Symbol("ETH", "USDT")
+
+PRICES = {BTC: money("50000"), ETH: money("2500")}
+CAPITAL = money("100000")
+
+
+def _by_symbol(signals: list) -> dict[Symbol, object]:
+    """Index a list of signals by their instrument's symbol."""
+    return {sig.instrument.symbol: sig for sig in signals}
+
+
+# --- weights_to_signals: exact sizing -------------------------------------- #
+
+
+def test_weights_to_signals_exact_quantities() -> None:
+    weights = {BTC: money("0.5"), ETH: money("-0.25")}
+    signals = weights_to_signals(
+        weights, prices=PRICES, capital=CAPITAL, asof_ms=1_700
+    )
+    assert len(signals) == 2
+    by_sym = _by_symbol(signals)
+
+    btc_sig = by_sym[BTC]
+    # 0.5 * 100000 / 50000 = +1.0 BTC (exact Decimal).
+    assert btc_sig.mode is SignalMode.TARGET_QTY
+    assert btc_sig.target == money("1")
+    assert btc_sig.instrument == Instrument(BTC)
+    assert btc_sig.ts == 1_700
+
+    eth_sig = by_sym[ETH]
+    # -0.25 * 100000 / 2500 = -10.0 ETH (exact Decimal).
+    assert eth_sig.mode is SignalMode.TARGET_QTY
+    assert eth_sig.target == money("-10")
+    assert eth_sig.ts == 1_700
+
+
+def test_zero_weight_is_flat_target() -> None:
+    signals = weights_to_signals(
+        {BTC: money("0")}, prices=PRICES, capital=CAPITAL, asof_ms=0
+    )
+    assert len(signals) == 1
+    assert signals[0].mode is SignalMode.TARGET_QTY
+    assert signals[0].target == money("0")
+
+
+def test_leverage_weight_allowed_no_bound() -> None:
+    # |w| = 2.5 > 1: single-name leverage. Allowed — no [-1, 1] rejection.
+    # 2.5 * 100000 / 50000 = +5.0 BTC.
+    signals = weights_to_signals(
+        {BTC: money("2.5")}, prices=PRICES, capital=CAPITAL, asof_ms=1
+    )
+    assert signals[0].target == money("5")
+
+    # And a leveraged short likewise.
+    short = weights_to_signals(
+        {BTC: money("-2")}, prices=PRICES, capital=CAPITAL, asof_ms=1
+    )
+    # -2 * 100000 / 50000 = -4.0 BTC.
+    assert short[0].target == money("-4")
+
+
+def test_missing_price_raises() -> None:
+    with pytest.raises(SignalError):
+        weights_to_signals(
+            {ETH: money("0.5")},  # ETH price omitted below
+            prices={BTC: money("50000")},
+            capital=CAPITAL,
+            asof_ms=0,
+        )
+
+
+@pytest.mark.parametrize("bad_price", ["0", "-1", "-50000"])
+def test_non_positive_price_raises(bad_price: str) -> None:
+    with pytest.raises(SignalError):
+        weights_to_signals(
+            {BTC: money("0.5")},
+            prices={BTC: money(bad_price)},
+            capital=CAPITAL,
+            asof_ms=0,
+        )
+
+
+@pytest.mark.parametrize("bad_capital", ["0", "-100000"])
+def test_non_positive_capital_raises(bad_capital: str) -> None:
+    with pytest.raises(ConfigError):
+        weights_to_signals(
+            {BTC: money("0.5")},
+            prices=PRICES,
+            capital=money(bad_capital),
+            asof_ms=0,
+        )
+
+
+def test_empty_weights_yields_no_signals() -> None:
+    assert weights_to_signals({}, prices=PRICES, capital=CAPITAL, asof_ms=0) == []
+
+
+# --- PortfolioStrategy ----------------------------------------------------- #
+
+
+def test_portfolio_strategy_is_frozen_and_hashable() -> None:
+    strat = PortfolioStrategy(
+        name="p",
+        universe=(BTC, ETH),
+        signal_fn=fake_book.fixed_weights,
+        capital=CAPITAL,
+    )
+    assert strat.gross_cap is None
+    # Frozen: attribute assignment is rejected.
+    with pytest.raises(Exception):
+        strat.name = "other"  # type: ignore[misc]
+    # Hashable (frozen + tuple universe).
+    assert hash(strat) == hash(strat)
+
+
+def test_portfolio_strategy_records_gross_cap() -> None:
+    strat = PortfolioStrategy(
+        name="p",
+        universe=(BTC,),
+        signal_fn=fake_book.fixed_weights,
+        capital=CAPITAL,
+        gross_cap=money("1.5"),
+    )
+    assert strat.gross_cap == money("1.5")
+
+
+# --- load_portfolio_signal ------------------------------------------------- #
+
+
+def test_load_portfolio_signal_resolves_callable() -> None:
+    ref = "trading_bot.tests.fixtures.fake_book:fixed_weights"
+    fn = load_portfolio_signal(ref)
+    assert callable(fn)
+    assert fn is fake_book.fixed_weights
+
+
+@pytest.mark.parametrize(
+    "ref",
+    [
+        "no_colon_here",
+        ":missing_module",
+        "trading_bot.tests.fixtures.fake_book:",
+        "trading_bot.does.not.exist:fn",
+        "trading_bot.tests.fixtures.fake_book:nonexistent_attr",
+    ],
+)
+def test_load_portfolio_signal_bad_ref_raises_config_error(ref: str) -> None:
+    with pytest.raises(ConfigError):
+        load_portfolio_signal(ref)
+
+
+def test_load_portfolio_signal_non_callable_raises() -> None:
+    # WEIGHTS is a dict on the module -> resolvable but not callable.
+    with pytest.raises(ConfigError):
+        load_portfolio_signal(
+            "trading_bot.tests.fixtures.fake_book:WEIGHTS"
+        )
+
+
+# --- fixture round-trip ---------------------------------------------------- #
+
+
+def test_fake_fixture_weights_round_trip_to_exact_quantities() -> None:
+    """The fake's fixed weights size to the exact hand-calc target quantities."""
+    weights = fake_book.fixed_weights(asof_ms=0, frames={})
+    signals = weights_to_signals(
+        weights,
+        prices=fake_book.PRICES,
+        capital=fake_book.CAPITAL,
+        asof_ms=42,
+    )
+    by_sym = _by_symbol(signals)
+
+    # Hand-calc: 0.5 * 100000 / 50000 = +1 BTC ; -0.25 * 100000 / 2500 = -10 ETH.
+    assert by_sym[BTC].target == money("1")
+    assert by_sym[ETH].target == money("-10")
+    assert all(s.mode is SignalMode.TARGET_QTY for s in signals)
+    assert all(s.ts == 42 for s in signals)

--- a/trading_bot/tests/fixtures/__init__.py
+++ b/trading_bot/tests/fixtures/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable in-repo test fixtures (fakes, canned data) for the suite."""

--- a/trading_bot/tests/fixtures/fake_book.py
+++ b/trading_bot/tests/fixtures/fake_book.py
@@ -1,0 +1,69 @@
+"""A tiny in-repo fake :data:`PortfolioSignalFn` for the portfolio tests.
+
+:func:`fixed_weights` is a deterministic, frame-agnostic portfolio signal over a
+small two-name universe (``BTC/USDT``, ``ETH/USDT``): it ignores its inputs and
+always returns the same weight vector. It exists so downstream leaves (the
+by-reference loader test here, the runner in leaf 03) have an *importable*
+``module:function`` portfolio signal to resolve and drive — never an
+``exec``\\ 'd loose file.
+
+The fixed weights are deliberately chosen so they round-trip *exactly* through
+:func:`~trading_bot.application.portfolio.weights_to_signals` with the
+hand-calc constants below — see :data:`UNIVERSE` / :data:`PRICES` /
+:data:`CAPITAL` and the test that asserts the resulting target quantities.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from trading_bot.domain.instrument import Symbol
+from trading_bot.domain.money import Money, money
+
+if TYPE_CHECKING:
+    import polars as pl
+
+#: The fake's two-name universe (canonical symbols).
+UNIVERSE: tuple[Symbol, ...] = (Symbol("BTC", "USDT"), Symbol("ETH", "USDT"))
+
+#: A reference price per symbol the hand-calc / round-trip test uses.
+PRICES: Mapping[Symbol, Money] = {
+    Symbol("BTC", "USDT"): money("50000"),
+    Symbol("ETH", "USDT"): money("2500"),
+}
+
+#: The capital base the hand-calc / round-trip test uses.
+CAPITAL: Money = money("100000")
+
+#: The fixed weight vector the fake always returns: long half the capital in
+#: BTC, short a quarter in ETH. With :data:`PRICES` / :data:`CAPITAL` this sizes
+#: to exactly ``+1.0`` BTC and ``-10.0`` ETH (the round-trip the test asserts).
+WEIGHTS: Mapping[Symbol, Money] = {
+    Symbol("BTC", "USDT"): money("0.5"),
+    Symbol("ETH", "USDT"): money("-0.25"),
+}
+
+
+def fixed_weights(
+    asof_ms: int, frames: Mapping[Symbol, "pl.DataFrame"]
+) -> Mapping[Symbol, Money]:
+    """Return a fixed weight vector, ignoring ``asof_ms`` / ``frames``.
+
+    A deterministic :data:`~trading_bot.application.portfolio.PortfolioSignalFn`
+    for tests: always :data:`WEIGHTS`, regardless of inputs.
+
+    Parameters
+    ----------
+    asof_ms : int
+        Ignored (a real signal would stamp it; this fake is constant).
+    frames : Mapping[Symbol, polars.DataFrame]
+        Ignored (a real signal would read causal bars; this fake is constant).
+
+    Returns
+    -------
+    Mapping[Symbol, Money]
+        The fixed :data:`WEIGHTS` vector.
+
+    """
+    return WEIGHTS


### PR DESCRIPTION
## Summary
- `application.portfolio` — the multi-asset analogue of the single-instrument signal:
  - `PortfolioSignalFn` = `(asof_ms, {Symbol: frame}) -> {Symbol: weight}` (weight = signed fraction of capital);
  - `PortfolioStrategy` (frozen: universe + signal + capital + optional `gross_cap`);
  - `weights_to_signals(weights, *, prices, capital, asof_ms)` — pure sizer, `qty = weight × capital / price` → `Signal.target_qty` (exact `Decimal`, never float);
  - `load_portfolio_signal(ref)` — safe `module:function` loader (`importlib`+`getattr`, no loose-file exec).
- Reusable fake `PortfolioSignalFn` fixture (`tests/fixtures/fake_book.py`) for downstream leaves.

## Why
LS1 (first validated multi-asset strategy) is a *vector* of target weights over ~10 coins, gross-capped 2×; the single-instrument `(bars) -> Signal` can't express it, and a per-coin `|w|>1` (leverage) would be rejected by a bounded `[-1,1]` exposure signal. An explicit-quantity signal carries its own scale, so the runner diffs it against live positions with no `reference_qty`. The loader stays by-reference so the engine is generic (LS1 lives in config). See ADR.

## Changes
- `trading_bot/application/portfolio.py` (new), `application/__init__.py` (exports).
- `trading_bot/tests/fixtures/{__init__,fake_book}.py` (new), `tests/application/test_portfolio_signal.py` (new, 20 tests).

## Changelog
Added under [Unreleased] (0.3.0): `application.portfolio` weight-vector contract + sizer + loader.

## Test plan
- [x] `.venv/bin/python -m pytest` — 637 passed, 7 deselected
- [x] `.venv/bin/ruff check trading_bot/` — clean
- [x] `.venv/bin/mypy trading_bot/` — clean
- [ ] CI green

Leaf 01 of **portfolio-strategy** (`doc/dev/plans/portfolio-strategy/`). Leaves 02 (feed) and 03 (runner) depend on this.