### PR TITLE
feat: PortfolioFeed — N-coin common-index daily feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a pure `weights_to_signals` sizer (`qty = weight × capital / price` →
   `Signal.target_qty`, exact `Decimal`), and a safe by-reference
   `load_portfolio_signal` loader. Groundwork for native multi-asset strategies (LS1). (#63)
+- `application.PortfolioFeed` — a multi-instrument **causal** feed: replays N coins'
+  daily bars from the dccd store on a **common date index** (inner-join on bar time),
+  gated so a rebalance date is emitted only when **every** coin has that day's closed
+  bar (never forward-filling a stale close); reuses the single-coin `DccdFeed` read
+  path, injectable client, `asof_ms()` helper. Feeds the `PortfolioSignalFn`. (#64)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,39 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 PortfolioFeed — common-index inner-join, no forward-fill; dccd serves 1m only (PR #64)
+
+**Decision.** `application.PortfolioFeed` assembles the N-coin cross-section by an
+**inner-join on the bar timestamp**: a rebalance date is emitted only when **every**
+coin has that day's closed bar. A coin lagging the universe is **logged, never
+raised**, and its missing tail days are simply not emitted — a stale close is
+**never forward-filled** into the cross-section. It reuses the single-coin
+`DccdFeed` per coin (no new dccd read logic), stays causal (`frame[:t+1]` per coin,
+no lookahead), and is client-injectable (offline tests dccd-free). A `symbol_for`
+hook renders a canonical `Symbol` to the store's pair-key convention (the real
+Binance store is keyed `BTC-USDT`; `to_venue_symbol("binance")` yields `BTCUSDT`).
+
+**Finding (load-bearing downstream): dccd serves only 1-minute bars.** dccd's
+`read` is keyed by `span` and does **not** resample — `read(span=86400)` against the
+real Binance store returns 0 rows. Daily bars are a **consumer** responsibility
+(mirroring `fynance_research/data.py`, which resamples 1m→1d via polars
+`group_by_dynamic(every="1d")`). `PortfolioFeed` is kept **agnostic** — it consumes
+whatever daily bars the injected client returns — so the **live wiring (leaf 04)
+must inject a resample-on-read dccd client (1m→1d)**, and leaf 05's LS1 run must
+resample before feeding. The real-data verification ran against the live store with
+a resample-on-read client: 10 coins, 2011 daily dates (2020-08-18 → 2026-06-28),
+common index, causality verified.
+
+**Why.** A cross-sectional signal ranks each coin *relative to* the others *as of
+the same day*; a missing/stale bar on one coin silently shifts the ranking (today's
+BTC vs yesterday's ZEC) — a quiet corruption. Inner-join + no-forward-fill makes
+"all coins fresh, or the day is skipped" structural. **Rejected:** forward-filling a
+stale close (corrupts the cross-section); raising on a lagging coin (a single late
+sync would halt the whole book — degrade to the common-complete prefix instead);
+re-implementing the dccd read here (would duplicate/diverge from the single-coin path).
+
+---
+
 ### 2026-06-28 Portfolio signal contract — weight vector + explicit-qty sizing (PR #63)
 
 **Decision.** The multi-asset strategy contract is a `PortfolioSignalFn`

--- a/doc/dev/plans/portfolio-strategy/00-plan.md
+++ b/doc/dev/plans/portfolio-strategy/00-plan.md
@@ -63,7 +63,7 @@ shape. It is **0.3.0 work** (post the 0.2.0 release).
 ## Leaf checklist
 
 - [x] 01 portfolio-signal — feat/portfolio-signal — medium (→ opus)
-- [ ] 02 portfolio-feed — feat/portfolio-feed — medium (→ opus) (depends on 01)
+- [x] 02 portfolio-feed — feat/portfolio-feed — medium (→ opus) (depends on 01)
 - [ ] 03 portfolio-runner — feat/portfolio-runner — high (→ opus) (depends on 01)
 - [ ] 04 portfolio-config — feat/portfolio-config — medium (→ opus) (depends on 02, 03)
 - [ ] 05 ls1-e2e — feat/portfolio-ls1-e2e — high (→ opus) (depends on 04)

--- a/doc/dev/plans/portfolio-strategy/02-portfolio-feed.md
+++ b/doc/dev/plans/portfolio-strategy/02-portfolio-feed.md
@@ -1,12 +1,12 @@
 ---
 plan: portfolio-strategy/02-portfolio-feed
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: [01]
 parallel: false
 branch: feat/portfolio-feed
-pr: ""
+pr: "#64"
 ---
 
 # Portfolio data feed — N-coin, common-index daily bars (freshness-gated)

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -134,6 +134,7 @@ from trading_bot.application.portfolio import (
     load_portfolio_signal,
     weights_to_signals,
 )
+from trading_bot.application.portfolio_feed import PortfolioFeed
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.reconcile import ReconResult, reconcile
 from trading_bot.application.risk import RiskManager
@@ -191,6 +192,7 @@ __all__ = [
     "PortfolioSignalFn",
     "weights_to_signals",
     "load_portfolio_signal",
+    "PortfolioFeed",
     # strategy runner
     "StrategyRunner",
     "OrderFactory",

--- a/trading_bot/application/portfolio_feed.py
+++ b/trading_bot/application/portfolio_feed.py
@@ -1,0 +1,316 @@
+"""A multi-instrument **causal** feed: N coins on a common daily date index.
+
+Where :class:`~trading_bot.application.data_feed.DccdFeed` replays *one* coin's
+bars as growing causal windows, :class:`PortfolioFeed` does the same for a whole
+**universe** at once — and adds the property a cross-sectional signal lives or
+dies on: every emitted rebalance date is one on which **every** coin has that
+day's *closed* bar. The cross-section is never computed on a partial universe.
+
+Why a common index, inner-join, never forward-fill
+--------------------------------------------------
+A :data:`~trading_bot.application.portfolio.PortfolioSignalFn` reads a per-coin
+mapping of frames and returns a weight *vector*: the weight it gives BTC is a
+function of where BTC sits **relative to** ETH, LTC, …, *as of the same day*. If
+one coin's bar for today is missing or stale and a neighbour's is fresh, the
+cross-section silently shifts (today's BTC rank computed against yesterday's ZEC)
+— a quiet, hard-to-spot corruption of the signal. So :class:`PortfolioFeed`:
+
+* **aligns on a common date index** — an *inner join* on the bar timestamp. A
+  rebalance date is emitted only when it is present for *all* N coins;
+* **never forward-fills** a stale close into the cross-section. A coin missing
+  the latest day simply means that day is not emitted (the freshness gate). A
+  coin lagging the others is **logged, never raised** — the feed degrades to the
+  largest common-complete prefix rather than fabricating a bar.
+
+Causality is inherited bar-for-bar from the single-coin path
+------------------------------------------------------------
+The per-coin read goes through the *same* dccd path the single-coin feed uses
+(:class:`~trading_bot.application.data_feed.DccdFeed`, reading via the injected
+:class:`~trading_bot.application.data_provider.DccdClient`) — this module adds no
+new read logic and no new dccd coupling. Each coin's bars arrive already
+normalised to the bars schema (``time, o, h, l, c, v``), oldest→newest. After the
+inner-join restriction to the common dates, iterating yields, at step ``t``, a
+``Mapping[Symbol, pl.DataFrame]`` where each coin's frame is the causal prefix up
+to and including common-date ``t`` — **no coin's window ever contains a bar dated
+> t** (the no-lookahead invariant), and the windows grow monotonically. So a
+signal evaluated at step ``t`` sees, for each coin, every closed bar ``≤ t`` (≥
+the configured lookback once enough history has accrued, e.g. ≥ 200 closes for an
+SMA-200 trend) and nothing later.
+
+Daily bars / dccd's span
+------------------------
+The default ``span`` is one day (``86400`` s). dccd's ``read`` is keyed by span:
+it returns the dataset stored *at that span*. The offline tests inject a fake
+client whose ``read`` returns canned **daily** bars per coin; a live caller
+points the injected client at a store that serves daily bars at that span (see
+the real-data verification in the tests for how the Binance 1-minute store is
+resampled to daily before this feed consumes it).
+
+This module lives in the application layer: it depends on :mod:`polars`, reuses
+the data-feed / data-provider use-cases, and performs no I/O of its own beyond
+the injected dccd client's reads (which happen inside the reused
+:class:`DccdFeed`). It introduces no ``float`` arithmetic — it only aligns and
+slices frames on the integer ``time`` column, leaving each bar's OHLC values
+exactly as dccd reported them.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from trading_bot.application.data_feed import DccdFeed
+from trading_bot.domain.instrument import Symbol
+
+if TYPE_CHECKING:
+    from trading_bot.application.data_provider import DccdClient
+
+__all__ = [
+    "PortfolioFeed",
+]
+
+logger = logging.getLogger(__name__)
+
+#: Default bar width: one day in seconds (dccd's ``span`` for daily bars).
+_DAILY_SPAN: int = 86_400
+
+
+class PortfolioFeed:
+    """A causal, common-index feed over a universe of coins' daily bars.
+
+    Reads each coin's bars through the *same* single-coin dccd path
+    (:class:`~trading_bot.application.data_feed.DccdFeed` over the injected
+    :class:`~trading_bot.application.data_provider.DccdClient`), aligns them on a
+    **common date index** (inner join on the bar ``time``), and replays the
+    aligned cross-section as growing causal windows — one common date advanced per
+    step. The freshness gate falls out of the inner join: a date is emitted only
+    when *every* coin has that day's closed bar; a coin lagging the others is
+    **logged, never raised**, and its missing tail days are simply not emitted
+    (the cross-section is never forward-filled onto a stale close).
+
+    The dccd coupling is **injectable**: pass a ``client`` (a fake in offline
+    tests, the real ``dccd.Client`` live) and nothing here imports dccd.
+
+    Parameters
+    ----------
+    universe : Sequence[Symbol]
+        The canonical :class:`~trading_bot.domain.instrument.Symbol`\\ s to feed,
+        in the order the per-coin mapping iterates. Must be non-empty and free of
+        duplicates.
+    exchange : str
+        The venue key each coin's bars are stored under (e.g. ``"binance"``),
+        forwarded to ``client.read``. Must be non-empty.
+    client : DccdClient or None
+        The dccd client to read through. ``None`` lazily constructs a real
+        ``dccd.Client`` (importing dccd only then, via the data-provider path).
+        Injecting a fake keeps the offline tests dccd-free.
+    span : int, optional
+        Bar width in **seconds** forwarded to ``client.read``. Defaults to
+        ``86400`` (daily). Must be ``> 0``.
+    start_ns, end_ns : int or None, optional
+        Optional inclusive nanosecond bounds forwarded to every coin's read.
+    data_type : str, optional
+        The dccd data kind to read. Defaults to ``"ohlc"``.
+    data_path : str or None, optional
+        Forwarded to the real ``dccd.Client`` constructor (its ``config_path``)
+        when ``client is None``; ignored when a client is injected.
+    symbol_for : Callable[[Symbol], str] or None, optional
+        How a canonical :class:`Symbol` is rendered to the pair string the store
+        is keyed by. ``None`` (default) renders it for ``exchange`` via
+        :meth:`~trading_bot.domain.instrument.Symbol.to_venue_symbol`.
+
+    Raises
+    ------
+    ValueError
+        If ``universe`` is empty or has duplicates, ``exchange`` is blank, or
+        ``span`` is not positive.
+
+    Examples
+    --------
+    >>> from trading_bot.domain.instrument import Symbol
+    >>> feed = PortfolioFeed(  # doctest: +SKIP
+    ...     [Symbol("BTC", "USDT"), Symbol("ETH", "USDT")],
+    ...     exchange="binance",
+    ...     client=my_fake_client,
+    ... )
+    >>> for frames in feed:  # doctest: +SKIP
+    ...     ...  # frames[Symbol("BTC","USDT")] is the causal window up to day t
+    """
+
+    def __init__(
+        self,
+        universe: Sequence[Symbol],
+        *,
+        exchange: str,
+        client: DccdClient | None = None,
+        span: int = _DAILY_SPAN,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+        data_type: str = "ohlc",
+        data_path: str | None = None,
+        symbol_for: Callable[[Symbol], str] | None = None,
+    ) -> None:
+        coins = tuple(universe)
+        if not coins:
+            raise ValueError("universe must be a non-empty sequence of Symbol")
+        if len(set(coins)) != len(coins):
+            raise ValueError(f"universe has duplicate symbols: {coins}")
+        if not exchange or not exchange.strip():
+            raise ValueError("exchange must be a non-empty string")
+        if span <= 0:
+            raise ValueError(f"span must be positive seconds, got {span}")
+
+        self._universe = coins
+        self._exchange = exchange
+        self._span = span
+        self._data_type = data_type
+
+        if client is None:
+            client = _make_client(data_path)
+        self._client = client
+
+        # Default symbol rendering: canonical Symbol -> the venue's pair code the
+        # store is keyed by (e.g. BTC/USDT -> "BTCUSDT" on binance). A callable
+        # override lets a caller match a store keyed by a different convention
+        # (e.g. "BTC-USDT").
+        render: Callable[[Symbol], str] = (
+            symbol_for
+            if symbol_for is not None
+            else (lambda sym: sym.to_venue_symbol(exchange))
+        )
+
+        # One single-coin DccdFeed per coin — the *reused* read/normalise path.
+        # Nothing in this module re-implements the dccd read; each coin's bars
+        # arrive already normalised to the bars schema, oldest→newest.
+        self._feeds: dict[Symbol, DccdFeed] = {
+            sym: DccdFeed(
+                client,
+                exchange,
+                render(sym),
+                span,
+                start_ns=start_ns,
+                end_ns=end_ns,
+            )
+            for sym in coins
+        }
+
+    @property
+    def universe(self) -> tuple[Symbol, ...]:
+        """The coins this feed allocates across, in mapping order."""
+        return self._universe
+
+    def _read_all(self) -> dict[Symbol, pl.DataFrame]:
+        """Read every coin's full normalised bars frame (oldest→newest).
+
+        Delegates each coin's read+normalise to its single-coin
+        :class:`DccdFeed` (the reused dccd path) — this module adds no read
+        logic of its own.
+        """
+        return {sym: feed.latest() for sym, feed in self._feeds.items()}
+
+    def _common_dates(self, frames: Mapping[Symbol, pl.DataFrame]) -> list[int]:
+        """The sorted intersection of every coin's bar timestamps (the gate).
+
+        A rebalance date survives only when *all* coins carry that day's closed
+        bar (inner join on ``time``). A coin whose latest bar lags the universe
+        maximum is logged (never raised) — its missing tail days are excluded
+        from the result, so the cross-section is never computed on a partial or
+        stale universe.
+        """
+        date_sets = {sym: set(f["time"].to_list()) for sym, f in frames.items()}
+        common: set[int] = set.intersection(*date_sets.values()) if date_sets else set()
+
+        # Freshness diagnostics: a coin whose newest bar is behind the universe
+        # maximum is lagging — log it (the day it lacks is simply not emitted).
+        maxima = {
+            sym: (max(dates) if dates else None) for sym, dates in date_sets.items()
+        }
+        present = [m for m in maxima.values() if m is not None]
+        if present:
+            universe_max = max(present)
+            for sym, latest in maxima.items():
+                if latest is None:
+                    logger.warning(
+                        "portfolio feed: %s has no bars; it cannot enter the "
+                        "cross-section", sym,
+                    )
+                elif latest < universe_max:
+                    logger.warning(
+                        "portfolio feed: %s lags the universe (latest bar %d < "
+                        "%d); the cross-section stops at the last common date "
+                        "(stale day not emitted, never forward-filled)",
+                        sym, latest, universe_max,
+                    )
+
+        return sorted(common)
+
+    def _aligned(
+        self, frames: Mapping[Symbol, pl.DataFrame]
+    ) -> tuple[list[int], dict[Symbol, pl.DataFrame]]:
+        """Restrict every coin to the common dates, oldest→newest.
+
+        Returns the sorted common dates and, per coin, that coin's bars filtered
+        to exactly those dates (same row order across coins, so step ``t`` is the
+        same calendar day for every coin).
+        """
+        dates = self._common_dates(frames)
+        if not dates:
+            return [], {sym: f.clear() for sym, f in frames.items()}
+        keep = set(dates)
+        aligned = {
+            sym: f.filter(pl.col("time").is_in(keep)).sort("time")
+            for sym, f in frames.items()
+        }
+        return dates, aligned
+
+    def __iter__(self) -> Iterator[Mapping[Symbol, pl.DataFrame]]:
+        """Read once, align, and yield growing causal cross-sections.
+
+        At step ``t`` yields ``{Symbol: window}`` where each window is the coin's
+        bars over common dates ``0 .. t`` inclusive — every coin's last ``time``
+        is common-date ``t``'s, never a later one (no lookahead), and the windows
+        grow one common date per step.
+        """
+        _dates, aligned = self._aligned(self._read_all())
+        n = next(iter(aligned.values())).height if aligned else 0
+        for t in range(n):
+            # frame[: t + 1] is common dates 0..t inclusive — the causal window.
+            yield {sym: f[: t + 1] for sym, f in aligned.items()}
+
+    def latest(self) -> Mapping[Symbol, pl.DataFrame]:
+        """Return the full aligned per-coin frames (every common date).
+
+        Each coin's frame holds exactly the common dates (the freshness-gated
+        cross-section), oldest→newest — the multi-coin analogue of
+        :meth:`DccdFeed.latest`. Handy for a one-shot evaluation or warmup.
+        """
+        _dates, aligned = self._aligned(self._read_all())
+        return aligned
+
+    def asof_ms(self) -> int | None:
+        """The latest common date's close, in **milliseconds** since the epoch.
+
+        dccd stamps bars in nanoseconds; the portfolio signal contract speaks
+        milliseconds, so the latest common ``time`` is converted ns → ms. Returns
+        ``None`` when there is no common date (an empty or non-overlapping
+        universe), so a caller can skip rather than rebalance on nothing.
+        """
+        dates = self._common_dates(self._read_all())
+        if not dates:
+            return None
+        return dates[-1] // 1_000_000
+
+
+def _make_client(data_path: str | None) -> DccdClient:
+    """Lazily construct a real dccd client (importing dccd only here).
+
+    Reuses :func:`trading_bot.application.data_provider._make_client` so the
+    single, audited dccd-construction seam is shared — this module never imports
+    dccd directly.
+    """
+    from trading_bot.application.data_provider import _make_client as make
+
+    return make(data_path)

--- a/trading_bot/tests/application/test_portfolio_feed.py
+++ b/trading_bot/tests/application/test_portfolio_feed.py
@@ -1,0 +1,463 @@
+"""Tests for :mod:`trading_bot.application.portfolio_feed`.
+
+These prove :class:`PortfolioFeed` is a correct **multi-instrument, common-index,
+causal** feed over a universe of coins, all offline against an **injected fake
+dccd client** returning canned daily bars per coin (no real dccd / network):
+
+* **common-index alignment** — coins with mismatched date ranges yield only the
+  *intersection* of their bar dates; a coin missing the latest day means that day
+  is never emitted (the freshness gate; the cross-section is never computed on a
+  partial universe);
+* **causality / no lookahead** — at step ``t`` no coin's window contains a
+  timestamp ``> t``; the windows grow monotonically, one common date per step;
+* the per-coin window at the final step carries ``≥`` the configured lookback
+  rows when the fixture provides them (≥ 200 daily closes for an SMA-200 trend);
+* :meth:`PortfolioFeed.asof_ms` equals the latest common date's close in ms;
+* a lagging coin is **logged, never raised**.
+
+A separate ``-m network`` test verifies the same properties on the **real** dccd
+Binance store (10 LS1 coins resampled 1m→1d), skipping with a clear how-to-sync
+reason when the store is absent.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+
+import polars as pl
+import pytest
+
+from trading_bot.application.portfolio_feed import PortfolioFeed
+from trading_bot.domain.instrument import Symbol
+
+# --- helpers --------------------------------------------------------------- #
+
+_DAY_NS = 86_400 * 1_000_000_000
+
+
+def _dccd_ohlc(closes: list[float], *, start_ns: int, span_ns: int = _DAY_NS) -> pl.DataFrame:
+    """A frame mimicking ``dccd.Client.read(..., 'ohlc')`` (dccd's column names)."""
+    n = len(closes)
+    return pl.DataFrame(
+        {
+            "TS": [start_ns + span_ns * i for i in range(n)],
+            "open": closes,
+            "high": closes,
+            "low": closes,
+            "close": closes,
+            "volume": [1.0] * n,
+            "quote_volume": [10.0] * n,
+            "trades": [5] * n,
+        }
+    )
+
+
+class _FakeDccdClient:
+    """A fake dccd client keyed by ``symbol`` → a canned daily OHLC frame.
+
+    ``read`` looks the canned frame up by the pair string the feed passes
+    (honouring ``end_ns`` so a cutoff read still works) and records each call's
+    args so a test can assert what the feed forwarded. No real dccd needed.
+    """
+
+    def __init__(self, frames: dict[str, pl.DataFrame]) -> None:
+        self._frames = frames
+        self.calls: list[dict[str, object]] = []
+
+    def read(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+    ) -> pl.DataFrame:
+        self.calls.append(
+            {
+                "exchange": exchange,
+                "symbol": symbol,
+                "data_type": data_type,
+                "span": span,
+                "start_ns": start_ns,
+                "end_ns": end_ns,
+            }
+        )
+        frame = self._frames[symbol]
+        if end_ns is not None:
+            frame = frame.filter(pl.col("TS") <= end_ns)
+        return frame
+
+
+def _client_for(
+    universe: list[Symbol],
+    frames_by_coin: Mapping[Symbol, pl.DataFrame],
+    *,
+    exchange: str = "binance",
+) -> _FakeDccdClient:
+    """Build a fake client keyed by each coin's venue pair string."""
+    return _FakeDccdClient(
+        {sym.to_venue_symbol(exchange): frames_by_coin[sym] for sym in universe}
+    )
+
+
+# --- construction validation ----------------------------------------------- #
+
+
+def test_rejects_empty_universe() -> None:
+    """An empty universe is a clear ValueError."""
+    with pytest.raises(ValueError, match="non-empty"):
+        PortfolioFeed([], exchange="binance", client=_FakeDccdClient({}))
+
+
+def test_rejects_duplicate_universe() -> None:
+    """A universe with a duplicate symbol is rejected."""
+    btc = Symbol("BTC", "USDT")
+    with pytest.raises(ValueError, match="duplicate"):
+        PortfolioFeed([btc, btc], exchange="binance", client=_FakeDccdClient({}))
+
+
+def test_rejects_blank_exchange() -> None:
+    """A blank exchange is rejected."""
+    with pytest.raises(ValueError, match="exchange"):
+        PortfolioFeed(
+            [Symbol("BTC", "USDT")], exchange="  ", client=_FakeDccdClient({})
+        )
+
+
+def test_rejects_non_positive_span() -> None:
+    """A non-positive span is rejected."""
+    with pytest.raises(ValueError, match="span"):
+        PortfolioFeed(
+            [Symbol("BTC", "USDT")],
+            exchange="binance",
+            span=0,
+            client=_FakeDccdClient({}),
+        )
+
+
+# --- common-index alignment + freshness gate ------------------------------- #
+
+
+def test_aligns_on_intersection_of_dates() -> None:
+    """Mismatched ranges yield only the intersection of bar dates."""
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = [btc, eth]
+    # BTC: days 0..4; ETH: days 2..6. Intersection = days 2,3,4 (3 dates).
+    frames = {
+        btc: _dccd_ohlc([1.0, 2, 3, 4, 5], start_ns=0),
+        eth: _dccd_ohlc([10.0, 20, 30, 40, 50], start_ns=2 * _DAY_NS),
+    }
+    feed = PortfolioFeed(universe, exchange="binance", client=_client_for(universe, frames))
+
+    latest = feed.latest()
+    assert latest[btc].height == 3
+    assert latest[eth].height == 3
+    # The common dates are days 2,3,4 (in ns).
+    expected = [2 * _DAY_NS, 3 * _DAY_NS, 4 * _DAY_NS]
+    assert latest[btc]["time"].to_list() == expected
+    assert latest[eth]["time"].to_list() == expected
+
+    windows = list(feed)
+    assert len(windows) == 3  # one step per common date
+
+
+def test_coin_missing_latest_day_not_emitted() -> None:
+    """A coin missing the latest day → that day is never emitted (freshness gate)."""
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = [btc, eth]
+    # BTC has 5 days (0..4); ETH lags by one (only days 0..3).
+    frames = {
+        btc: _dccd_ohlc([1.0, 2, 3, 4, 5], start_ns=0),
+        eth: _dccd_ohlc([10.0, 20, 30, 40], start_ns=0),
+    }
+    feed = PortfolioFeed(universe, exchange="binance", client=_client_for(universe, frames))
+
+    windows = list(feed)
+    # Day 4 is BTC-only -> dropped. Only the 4 common days (0..3) are emitted.
+    assert len(windows) == 4
+    final = windows[-1]
+    # The stale day (day 4) must NOT appear in any coin's final window.
+    assert final[btc]["time"].max() == 3 * _DAY_NS
+    assert final[eth]["time"].max() == 3 * _DAY_NS
+    # The fresh coin's day-4 bar is never forward-filled into the cross-section.
+    assert 4 * _DAY_NS not in final[btc]["time"].to_list()
+
+
+def test_lagging_coin_logs_not_raises(caplog: pytest.LogCaptureFixture) -> None:
+    """A coin lagging the universe is logged (warning), never raised."""
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = [btc, eth]
+    frames = {
+        btc: _dccd_ohlc([1.0, 2, 3, 4, 5], start_ns=0),  # to day 4
+        eth: _dccd_ohlc([10.0, 20, 30], start_ns=0),  # to day 2 (lags)
+    }
+    feed = PortfolioFeed(universe, exchange="binance", client=_client_for(universe, frames))
+
+    with caplog.at_level(logging.WARNING, logger="trading_bot.application.portfolio_feed"):
+        windows = list(feed)  # does not raise
+
+    assert len(windows) == 3  # common days 0..2
+    assert any("lags the universe" in r.message for r in caplog.records)
+
+
+def test_no_common_dates_yields_nothing() -> None:
+    """Non-overlapping coins yield no windows and asof_ms is None."""
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = [btc, eth]
+    frames = {
+        btc: _dccd_ohlc([1.0, 2], start_ns=0),  # days 0,1
+        eth: _dccd_ohlc([10.0, 20], start_ns=10 * _DAY_NS),  # days 10,11
+    }
+    feed = PortfolioFeed(universe, exchange="binance", client=_client_for(universe, frames))
+
+    assert list(feed) == []
+    assert feed.asof_ms() is None
+
+
+# --- causality / no lookahead ---------------------------------------------- #
+
+
+def test_windows_are_causal_and_grow_monotonically() -> None:
+    """At step t no coin's window has a bar > day t; windows grow by one date."""
+    btc, eth, ltc = Symbol("BTC", "USDT"), Symbol("ETH", "USDT"), Symbol("LTC", "USDT")
+    universe = [btc, eth, ltc]
+    # All three share days 0..5 (plus tails that drop out by inner-join).
+    frames = {
+        btc: _dccd_ohlc([float(i) for i in range(6)], start_ns=0),
+        eth: _dccd_ohlc([float(i) for i in range(8)], start_ns=0),  # extra tail
+        ltc: _dccd_ohlc([float(i) for i in range(6)], start_ns=0),
+    }
+    feed = PortfolioFeed(universe, exchange="binance", client=_client_for(universe, frames))
+
+    common = sorted({0 * _DAY_NS + _DAY_NS * i for i in range(6)})  # days 0..5
+    windows = list(feed)
+    assert len(windows) == 6
+
+    prev_height: dict[Symbol, int] = {sym: 0 for sym in universe}
+    for t, window in enumerate(windows):
+        for sym in universe:
+            f = window[sym]
+            # Causal: every coin's window holds exactly common dates 0..t, and
+            # its last time is common-date t's — never a later bar (no lookahead).
+            assert f.height == t + 1
+            assert f["time"].to_list() == common[: t + 1]
+            assert f["time"].max() == common[t]
+            # Monotonic growth: each window is one date longer than the last.
+            assert f.height == prev_height[sym] + 1
+            prev_height[sym] = f.height
+
+
+def test_final_window_has_at_least_lookback_rows() -> None:
+    """The per-coin final window has ≥ the configured lookback rows."""
+    lookback = 200
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = [btc, eth]
+    n = lookback + 30  # comfortably above lookback
+    frames = {
+        btc: _dccd_ohlc([float(i) for i in range(n)], start_ns=0),
+        eth: _dccd_ohlc([float(i) for i in range(n)], start_ns=0),
+    }
+    feed = PortfolioFeed(universe, exchange="binance", client=_client_for(universe, frames))
+
+    final = list(feed)[-1]
+    for sym in universe:
+        assert final[sym].height >= lookback
+
+
+# --- asof timestamp -------------------------------------------------------- #
+
+
+def test_asof_ms_is_latest_common_date_in_ms() -> None:
+    """asof_ms equals the latest common date's close, ns → ms."""
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = [btc, eth]
+    frames = {
+        btc: _dccd_ohlc([1.0, 2, 3, 4], start_ns=0),  # days 0..3
+        eth: _dccd_ohlc([10.0, 20, 30], start_ns=0),  # days 0..2 (lags one)
+    }
+    feed = PortfolioFeed(universe, exchange="binance", client=_client_for(universe, frames))
+
+    # Latest common date is day 2 (ETH stops there). asof = its ns // 1e6.
+    expected_ms = (2 * _DAY_NS) // 1_000_000
+    assert feed.asof_ms() == expected_ms
+
+
+# --- forwarding to the dccd read ------------------------------------------- #
+
+
+def test_forwards_exchange_span_symbol_to_read() -> None:
+    """Each coin's read gets the exchange, span and its venue pair string."""
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = [btc, eth]
+    frames = {
+        btc: _dccd_ohlc([1.0, 2], start_ns=0),
+        eth: _dccd_ohlc([10.0, 20], start_ns=0),
+    }
+    client = _client_for(universe, frames)
+    feed = PortfolioFeed(universe, exchange="binance", span=86_400, client=client)
+
+    list(feed)  # drive the reads
+
+    symbols_read = {c["symbol"] for c in client.calls}
+    assert symbols_read == {"BTCUSDT", "ETHUSDT"}
+    assert all(c["exchange"] == "binance" for c in client.calls)
+    assert all(c["span"] == 86_400 for c in client.calls)
+    assert all(c["data_type"] == "ohlc" for c in client.calls)
+
+
+def test_symbol_for_override_renders_store_keys() -> None:
+    """A symbol_for override matches a store keyed by a different convention."""
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = [btc, eth]
+    # Store keyed dccd-dir-style "BTC-USDT" (hyphen) rather than "BTCUSDT".
+    client = _FakeDccdClient(
+        {
+            "BTC-USDT": _dccd_ohlc([1.0, 2, 3], start_ns=0),
+            "ETH-USDT": _dccd_ohlc([10.0, 20, 30], start_ns=0),
+        }
+    )
+    feed = PortfolioFeed(
+        universe,
+        exchange="binance",
+        client=client,
+        symbol_for=lambda s: f"{s.base}-{s.quote}",
+    )
+
+    windows = list(feed)
+    assert len(windows) == 3
+    assert {c["symbol"] for c in client.calls} == {"BTC-USDT", "ETH-USDT"}
+
+
+# --- Verification on real data (opt-in) ------------------------------------ #
+
+# The 10 LS1 coins (all *-USDT, daily) — the universe the real-data check drains.
+_LS1_COINS = ["BTC", "ETH", "BCH", "LTC", "XRP", "XLM", "DOGE", "DOT", "TRX", "ZEC"]
+
+
+@pytest.mark.network
+def test_real_binance_daily_portfolio_feed_is_causal_and_gated() -> None:
+    """Real dccd Binance store: drain a 10-coin daily PortfolioFeed and check it.
+
+    Asserts (a) every emitted rebalance date has a closed bar for ALL 10 coins
+    (inner-join freshness gate), (b) the final window has ≥ 200 daily closes per
+    coin, and (c) no window contains a future bar (causality).
+
+    The Binance store holds **1-minute** bars (``span 60``); dccd's ``read`` is
+    keyed by span and does **not** resample, so daily bars are resampled here the
+    same way the rest of the triptych does (``fynance_research.data.load_ohlc`` —
+    polars ``group_by_dynamic(every="1d")``, OHLCV-correct). The resampling
+    client is then injected, so this exercises the real common-index alignment +
+    causality on real prices.
+
+    Skips with a clear how-to-sync reason when the store is absent (per
+    ``../fynance-research/DEPLOY_LS1.md`` §3: the alt USDT pairs sync to
+    ``~/data/arthurserver/binance/ohlc/<PAIR>/1m/``).
+    """
+    from pathlib import Path
+
+    root = Path.home() / "data" / "arthurserver" / "binance" / "ohlc"
+    if not root.is_dir():
+        pytest.skip(
+            "no dccd Binance store at ~/data/arthurserver/binance/ohlc; sync the "
+            "10 LS1 *-USDT daily pairs via the dccd daemon (DEPLOY_LS1.md §3) — "
+            "they land at ~/data/arthurserver/binance/ohlc/<PAIR>/1m/"
+        )
+
+    universe = [Symbol(c, "USDT") for c in _LS1_COINS]
+
+    # Resample-on-read client: reads the 1m parquet for a coin and aggregates to
+    # daily, returning dccd-shaped OHLC columns (mirrors fynance_research.data).
+    agg = [
+        pl.col("open").first(),
+        pl.col("high").max(),
+        pl.col("low").min(),
+        pl.col("close").last(),
+        pl.col("volume").sum(),
+    ]
+
+    class _ResampleClient:
+        def read(
+            self,
+            exchange: str,
+            symbol: str,
+            data_type: str = "ohlc",
+            span: int | None = None,
+            start_ns: int | None = None,
+            end_ns: int | None = None,
+        ) -> pl.DataFrame:
+            base = root / symbol / "1m"
+            files = sorted(base.glob("*.parquet"))
+            if not files:
+                pytest.skip(f"no 1m parquet for {symbol} under {base}")
+            raw = (
+                pl.concat([pl.read_parquet(f) for f in files])
+                .unique(subset="TS", keep="last")
+                .sort("TS")
+            )
+            daily = (
+                raw.with_columns(pl.from_epoch("TS", time_unit="ns").alias("dt"))
+                .group_by_dynamic("dt", every="1d")
+                .agg(*agg)
+                .sort("dt")
+                .with_columns(
+                    [
+                        pl.col("dt").dt.timestamp("ns").alias("TS"),
+                        pl.lit(0.0).alias("quote_volume"),
+                        pl.lit(0).alias("trades"),
+                    ]
+                )
+                .select(
+                    "TS", "open", "high", "low", "close", "volume",
+                    "quote_volume", "trades",
+                )
+            )
+            if end_ns is not None:
+                daily = daily.filter(pl.col("TS") <= end_ns)
+            return daily
+
+    feed = PortfolioFeed(
+        universe,
+        exchange="binance",
+        client=_ResampleClient(),
+        span=86_400,
+        symbol_for=lambda s: f"{s.base}-{s.quote}",  # store dirs are "BTC-USDT"
+    )
+
+    latest = feed.latest()
+    # All coins present, same number of common dates each.
+    heights = {sym: latest[sym].height for sym in universe}
+    assert len(set(heights.values())) == 1, f"unequal common-date counts: {heights}"
+    common_dates = next(iter(latest.values()))["time"].to_list()
+    assert len(common_dates) > 200, f"too few common daily dates: {len(common_dates)}"
+
+    # (a) every emitted rebalance date has a closed bar for ALL 10 coins.
+    common_set = set(common_dates)
+    for sym in universe:
+        assert set(latest[sym]["time"].to_list()) == common_set
+
+    # Drain and check causality on a sampled set of steps (full drain is ~2000
+    # steps × 10 coins — sample to keep the test brisk while still proving it).
+    windows = list(feed)
+    assert len(windows) == len(common_dates)
+    sorted_common = sorted(common_dates)
+    step_indices = sorted(
+        {0, 1, len(windows) // 2, len(windows) - 2, len(windows) - 1}
+    )
+    for t in step_indices:
+        window = windows[t]
+        for sym in universe:
+            f = window[sym]
+            # (c) no future bar: the window's last time is common-date t's.
+            assert f.height == t + 1
+            assert f["time"].max() == sorted_common[t]
+            assert f["time"][-1] == sorted_common[t]
+
+    # (b) the final window has ≥ 200 daily closes per coin.
+    final = windows[-1]
+    for sym in universe:
+        assert final[sym].height >= 200, f"{sym} final window < 200 closes"
+
+    # asof is the latest common date in ms.
+    assert feed.asof_ms() == sorted_common[-1] // 1_000_000


### PR DESCRIPTION
## Summary
- `application.PortfolioFeed` — a multi-instrument **causal** feed replaying N coins' daily bars from the dccd store on a **common date index** (inner-join on bar `time`), gated so a rebalance date is emitted only when **every** coin has that day's closed bar — never forward-filling a stale close.
- Reuses the single-coin `DccdFeed` read path (no new dccd coupling), injectable client (offline tests dccd-free), `asof_ms()` helper, `symbol_for` hook for the store's pair-key convention.

## Why
A cross-sectional signal ranks each coin *relative to the others as of the same day*; a missing/stale bar silently shifts the ranking. Inner-join + no-forward-fill makes "all coins fresh, or skip the day" structural. Causal (`frame[:t+1]`, no lookahead). See ADR.

## ⚠️ Finding (load-bearing downstream)
**dccd serves only 1-minute bars** — `read(span=86400)` returns 0 rows; daily resampling is a *consumer* responsibility (as in `fynance_research/data.py`). `PortfolioFeed` is kept **agnostic** (consumes whatever daily bars the injected client returns), so **leaf 04's live wiring must inject a resample-on-read (1m→1d) dccd client**, and leaf 05's LS1 run resamples before feeding.

## Verification on real data (ran)
Against the live dccd Binance store with a resample-on-read client: 10 LS1 coins, **2011 daily dates (2020-08-18 → 2026-06-28)**, common index; every emitted date has all 10 coins; final window ≥ 200 closes/coin; no future bar. (Network-marked test.)

## Changes
- `trading_bot/application/portfolio_feed.py` (new), `application/__init__.py` (export).
- `trading_bot/tests/application/test_portfolio_feed.py` (new — 13 offline + 1 network).

## Changelog
Added under [Unreleased] (0.3.0): `application.PortfolioFeed`.

## Test plan
- [x] `.venv/bin/python -m pytest` — 650 passed, 8 deselected
- [x] `.venv/bin/python -m pytest -m network` (portfolio feed) — passed on the real dccd store
- [x] `.venv/bin/ruff check trading_bot/` — clean
- [x] `.venv/bin/mypy trading_bot/` — clean
- [ ] CI green

Leaf 02 of **portfolio-strategy**. Leaf 03 (runner) depends on leaf 01; leaf 04 depends on 02+03.