### PR TITLE
feat: PortfolioRunner — weight vector → N idempotent risk-gated orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   gated so a rebalance date is emitted only when **every** coin has that day's closed
   bar (never forward-filling a stale close); reuses the single-coin `DccdFeed` read
   path, injectable client, `asof_ms()` helper. Feeds the `PortfolioSignalFn`. (#64)
+- `application.PortfolioRunner` — the multi-asset rebalance loop: each tick calls the
+  `PortfolioSignalFn` for the whole book, sizes the weight vector to per-coin target
+  quantities, and routes **N** idempotent (`{name}-{symbol}-{step}`), risk-gated
+  **maker-LIMIT** legs through the shared `OrderRouter` (a coin omitted from the
+  weights is targeted **flat**). Per-leg failures (`RiskLimitBreached`/`BrokerError`)
+  are collected on a `RebalanceResult` and don't abort the book; cooperative
+  `run(stop_event=...)`. (#65)
 
 ### Changed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,35 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 PortfolioRunner — whole-universe targeting, per-leg failure isolation (PR #65)
+
+**Decision.** `application.PortfolioRunner` mirrors `StrategyRunner` for a whole
+universe: per tick it sizes the weight vector (`weights_to_signals`) and routes one
+leg per coin through the **shared** `OrderRouter`/`PositionTracker`/`EventBus`.
+Three choices: (1) **whole-universe targeting** — it iterates `strategy.universe`,
+not the weight keys, synthesising a **0-weight (flat)** target for any coin the
+signal omits, so a dropped name is closed rather than left stranded (the book always
+covers the full universe). (2) **Per-coin idempotency id** `f"{name}-{symbol}-{step}"`
+— a re-run/retry dedups per coin per rebalance at the router. (3) **Per-leg failure
+isolation** — a leg that raises `RiskLimitBreached`/`BrokerError` is caught, recorded
+as a `RebalanceFailure` on the `RebalanceResult`, and the **other legs still route**
+(not all-or-nothing). Maker-LIMIT legs priced at each coin's latest close (fee +
+self-contained paper fills). The optional gross guard stays **off** (trust the
+signal's cap, per [[the leaf-01 portfolio-signal ADR]]).
+
+**Why.** A cross-sectional book is only correct as a *set* — leaving an omitted coin
+at its old position silently changes the realised exposure, so omitted ⇒ flat. Per-leg
+isolation: aborting the whole rebalance because one coin breached a limit would leave
+the book half-rebalanced and let one bad name veto every good one; recording the
+failure and continuing keeps the rest of the book on target and surfaces the breach.
+Idempotency at the position level (delta vs the shared tracker) already makes a
+deterministic re-run a no-op *before* id-dedup matters; the namespaced id covers the
+retry-after-ambiguous case. **Rejected:** all-or-nothing rebalance (one bad leg
+freezes the book); iterating the weight keys (would strand omitted coins);
+re-implementing submission instead of reusing the risk-gated `OrderRouter`.
+
+---
+
 ### 2026-06-29 PortfolioFeed — common-index inner-join, no forward-fill; dccd serves 1m only (PR #64)
 
 **Decision.** `application.PortfolioFeed` assembles the N-coin cross-section by an

--- a/doc/dev/plans/portfolio-strategy/00-plan.md
+++ b/doc/dev/plans/portfolio-strategy/00-plan.md
@@ -64,7 +64,7 @@ shape. It is **0.3.0 work** (post the 0.2.0 release).
 
 - [x] 01 portfolio-signal — feat/portfolio-signal — medium (→ opus)
 - [x] 02 portfolio-feed — feat/portfolio-feed — medium (→ opus) (depends on 01)
-- [ ] 03 portfolio-runner — feat/portfolio-runner — high (→ opus) (depends on 01)
+- [x] 03 portfolio-runner — feat/portfolio-runner — high (→ opus) (depends on 01)
 - [ ] 04 portfolio-config — feat/portfolio-config — medium (→ opus) (depends on 02, 03)
 - [ ] 05 ls1-e2e — feat/portfolio-ls1-e2e — high (→ opus) (depends on 04)
 

--- a/doc/dev/plans/portfolio-strategy/03-portfolio-runner.md
+++ b/doc/dev/plans/portfolio-strategy/03-portfolio-runner.md
@@ -1,12 +1,12 @@
 ---
 plan: portfolio-strategy/03-portfolio-runner
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [01]
 parallel: false
 branch: feat/portfolio-runner
-pr: ""
+pr: "#65"
 ---
 
 # Portfolio runner — weight vector → N idempotent risk-gated orders

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -87,6 +87,21 @@ It then layers the engine's use-cases:
   opt-in/injectable (the process entrypoint calls
   :meth:`~trading_bot.application.orchestrator.Orchestrator.install_signal_handlers`;
   importing installs nothing). Replaces the legacy multiprocessing server.
+* portfolio_runner — the
+  :class:`~trading_bot.application.portfolio_runner.PortfolioRunner`, the
+  **multi-asset** analogue of the ``StrategyRunner``: each (daily) rebalance tick
+  it evaluates the
+  :data:`~trading_bot.application.portfolio.PortfolioSignalFn` for the whole book,
+  sizes the weight vector into per-coin target quantities
+  (:func:`~trading_bot.application.portfolio.weights_to_signals`), diffs each
+  against the **shared** ``PositionTracker``, and routes **N** idempotent,
+  risk-gated orders through the **shared** ``OrderRouter`` — a coin omitted from
+  the weights is targeted *flat* (the book covers the whole universe), each leg's
+  ``client_order_id`` is symbol-namespaced (``f"{name}-{symbol}-{step}"``) so a
+  re-run dedups per coin, and a per-leg failure (risk breach / broker error) is
+  collected without aborting the other legs (a
+  :class:`~trading_bot.application.portfolio_runner.RebalanceResult` reports
+  submitted-vs-failed).
 * run_app — :func:`~trading_bot.application.run_app.run_app` (and
   :func:`~trading_bot.application.run_app.build_runners`), the **triptych
   entrypoint**: one :class:`~trading_bot.application.config.AppConfig` →
@@ -135,6 +150,13 @@ from trading_bot.application.portfolio import (
     weights_to_signals,
 )
 from trading_bot.application.portfolio_feed import PortfolioFeed
+from trading_bot.application.portfolio_runner import (
+    PortfolioOrderFactory,
+    PortfolioRunner,
+    RebalanceFailure,
+    RebalanceResult,
+    portfolio_limit_at_close_factory,
+)
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.reconcile import ReconResult, reconcile
 from trading_bot.application.risk import RiskManager
@@ -196,6 +218,12 @@ __all__ = [
     # strategy runner
     "StrategyRunner",
     "OrderFactory",
+    # portfolio runner (multi-asset loop)
+    "PortfolioRunner",
+    "PortfolioOrderFactory",
+    "RebalanceResult",
+    "RebalanceFailure",
+    "portfolio_limit_at_close_factory",
     # orchestration
     "Orchestrator",
     "RunnerGroupError",

--- a/trading_bot/application/portfolio_runner.py
+++ b/trading_bot/application/portfolio_runner.py
@@ -1,0 +1,566 @@
+"""The :class:`PortfolioRunner` — the multi-asset analogue of the runner.
+
+Where the single-instrument :class:`~trading_bot.application.strategy_runner.
+StrategyRunner` drives **one** instrument (feed → signal → ``delta_to`` → order →
+router), the :class:`PortfolioRunner` drives a **whole universe** at once. On each
+(daily) rebalance tick it evaluates the
+:data:`~trading_bot.application.portfolio.PortfolioSignalFn` for the entire book,
+turns the returned weight *vector* into per-coin target quantities, computes each
+coin's signed change against the **shared**
+:class:`~trading_bot.application.position_tracker.PositionTracker`, and routes
+**N** idempotent, risk-gated orders through the **shared**
+:class:`~trading_bot.application.order_router.OrderRouter` — then holds to the
+next tick:
+
+    feed → signal_fn → weights_to_signals → per-coin delta_to(position)
+        → order → router → broker → FillEvent → tracker → (next tick's position)
+
+It owns no money logic of its own — sizing is delegated to the pure
+:func:`~trading_bot.application.portfolio.weights_to_signals`, each per-coin diff
+to :meth:`~trading_bot.domain.signal.Signal.delta_to`, every submission to the
+router, and every fill fold to the tracker. The runner only *sequences* those
+collaborators across a universe.
+
+Universe-complete, never partial (carried into the ADR)
+-------------------------------------------------------
+The book must cover the **whole universe** every tick. A coin the signal *omits*
+this tick (or maps to ``0``) is **not** left untouched — it is targeted **flat**
+(a full close of whatever the shared tracker reports). So the runner iterates
+:attr:`PortfolioStrategy.universe`, not the weight vector's keys: a 0-weight
+signal is synthesised for any omitted coin, and its ``delta_to`` the current
+position closes it out. This is what makes a rebalance a *re-allocation of the
+whole book*, not an additive set of new bets.
+
+Per-coin idempotency (carried into the ADR)
+-------------------------------------------
+Each leg's ``client_order_id`` is ``f"{strategy.name}-{symbol}-{step}"`` —
+**namespaced by symbol** so the N legs of one rebalance never collide, and
+deterministic in ``step`` so a re-run / retry of the *same* rebalance dedups
+**per coin** at the router (one id → one venue order). The runner stamps this id
+onto whatever the ``order_factory`` returns, exactly as
+:class:`StrategyRunner` does: idempotency is the runner's concern, not the
+factory's.
+
+Maker-LIMIT legs (carried into the ADR)
+---------------------------------------
+The default :func:`portfolio_limit_at_close_factory` prices each leg as a LIMIT
+at that coin's latest close, so the in-process :class:`~trading_bot.brokers.
+paper.PaperBroker` fills self-contained (at the exact close the signal saw)
+without seeded mark prices; a live broker ignores the synthetic price and fills
+at the venue. This mirrors :func:`~trading_bot.application.run_app.
+_limit_at_close_factory`, generalised to take a per-coin instrument + close.
+
+Per-leg failure policy (carried into the ADR)
+---------------------------------------------
+A rebalance is **not** all-or-nothing. Routing one leg can fail — a
+:class:`~trading_bot.domain.errors.RiskLimitBreached` (the order exceeds
+``max_order`` / would breach a limit / the kill-switch is tripped), or a
+:class:`~trading_bot.domain.errors.BrokerError`. **The runner continues the other
+legs** and collects the failures: aborting the whole book because one coin
+breached a limit would leave the book in a *worse*, half-rebalanced-then-frozen
+state and let one bad name veto every good one. Each failure is recorded as a
+:class:`RebalanceFailure` (symbol + the exception) and surfaced on the
+:class:`RebalanceResult`; a :class:`~trading_bot.application.events.LogEvent` is
+emitted per failure when a bus is wired. The kill-switch is *not* a special case
+here: a tripped switch simply makes **every** leg raise
+:class:`RiskLimitBreached`, so the result reports N failures and zero
+submissions — the halt is total, by the gate, without the runner needing to know
+about it. (A caller that wants strict all-or-nothing can inspect
+:attr:`RebalanceResult.failures` and act.)
+
+Cooperative stop & cadence (carried into the ADR)
+-------------------------------------------------
+:meth:`run` mirrors :class:`StrategyRunner.run`: it iterates the feed, checks an
+optional :class:`asyncio.Event` ``stop_event`` **at the top of each iteration**
+(between rebalances, never mid-rebalance, so no leg is torn in half), and returns
+the total number of orders submitted. The daily cadence is the feed's — the
+runner does not busy-wait; it holds between ticks by simply awaiting the next
+window the (daily) feed yields.
+
+This module lives in the application layer: it imports the pure domain and the
+sibling use-cases, holds money as :class:`~decimal.Decimal` end to end, and
+performs no I/O of its own (the router/broker/feed do).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from trading_bot.application.events import EventBus, LogEvent
+from trading_bot.application.portfolio import weights_to_signals
+from trading_bot.domain.errors import BrokerError, RiskLimitBreached
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import Money, money
+from trading_bot.domain.order import Order, OrderSide, OrderType
+from trading_bot.domain.position import Position
+
+if TYPE_CHECKING:
+    import polars as pl
+
+    from trading_bot.application.order_router import OrderRouter
+    from trading_bot.application.portfolio import PortfolioStrategy
+    from trading_bot.application.position_tracker import PositionTracker
+
+__all__ = [
+    "PortfolioRunner",
+    "PortfolioOrderFactory",
+    "RebalanceFailure",
+    "RebalanceResult",
+    "portfolio_limit_at_close_factory",
+]
+
+logger = logging.getLogger(__name__)
+
+#: A caller-supplied per-coin order builder:
+#: ``(strategy, instrument, delta, close) -> Order``. Given the coin's signed
+#: target delta (``> 0`` buy, ``< 0`` sell) and its latest close, it returns the
+#: :class:`Order` to route for that leg (e.g. a maker LIMIT at the close). The
+#: runner overrides the order's ``client_order_id`` with its deterministic,
+#: symbol-namespaced per-step id, so a factory need not (and should not rely on)
+#: set one.
+PortfolioOrderFactory = Callable[
+    ["PortfolioStrategy", Instrument, Money, Money], Order
+]
+
+_ZERO: Money = money("0")
+
+
+@dataclass(frozen=True, slots=True)
+class RebalanceFailure:
+    """One coin's leg that failed to route during a rebalance.
+
+    Attributes
+    ----------
+    symbol : Symbol
+        The coin whose leg failed.
+    error : Exception
+        The exception raised routing it — a
+        :class:`~trading_bot.domain.errors.RiskLimitBreached` (a breached limit
+        or a tripped kill-switch) or a
+        :class:`~trading_bot.domain.errors.BrokerError`. Carried so a caller can
+        inspect the cause without re-running.
+
+    """
+
+    symbol: Symbol
+    error: Exception
+
+
+@dataclass(frozen=True, slots=True)
+class RebalanceResult:
+    """The outcome of one rebalance tick — what routed and what failed.
+
+    Attributes
+    ----------
+    submitted : int
+        Number of legs whose order routed successfully this tick (non-zero-delta
+        coins that were not refused). On-target coins (``delta == 0``) submit
+        nothing and are **not** counted.
+    failures : list of RebalanceFailure
+        One entry per coin whose leg raised (a risk breach or a broker error),
+        in universe order. Empty on a clean rebalance. See the module docstring's
+        per-leg failure policy: a failure does **not** abort the other legs.
+
+    """
+
+    submitted: int = 0
+    failures: list[RebalanceFailure] = field(default_factory=list)
+
+    @property
+    def failed(self) -> int:
+        """Number of legs that failed to route this tick."""
+        return len(self.failures)
+
+
+class PortfolioRunner:
+    """Drive a :class:`PortfolioStrategy` over a portfolio feed, routing N legs.
+
+    On each rebalance tick the runner evaluates the strategy's weight-vector
+    signal for the whole book, sizes it into per-coin target-quantity signals,
+    diffs each against the shared :class:`PositionTracker`, and routes one
+    idempotent, risk-gated order per non-on-target coin through the shared
+    :class:`OrderRouter`. See the module docstring for the universe-complete
+    rule, the per-coin idempotency scheme, the maker-LIMIT legs and the per-leg
+    failure policy.
+
+    Parameters
+    ----------
+    strategy : PortfolioStrategy
+        The multi-asset strategy to drive: its ``universe`` (every coin the book
+        must cover each tick), ``signal_fn`` (the weight vector), ``capital``
+        (the base the weights are a fraction of) and ``name`` (the per-leg
+        ``client_order_id`` seed) govern every rebalance.
+    feed : Iterable[Mapping[Symbol, polars.DataFrame]]
+        The source of causal per-coin cross-sections (e.g. a
+        :class:`~trading_bot.application.portfolio_feed.PortfolioFeed`). At step
+        ``t`` each coin's frame holds only bars ``≤ t`` — no lookahead. If the
+        feed exposes ``asof_ms()`` it is used for the signal/Signal timestamps;
+        otherwise the latest common ``time`` across the frames is derived (ns →
+        ms).
+    router : OrderRouter
+        The shared idempotent write path. Each leg is ``await``\\ ed through
+        :meth:`OrderRouter.submit`; a duplicate ``client_order_id`` (a re-run)
+        is deduped there into a single venue order, and the risk gate refuses a
+        breaching leg before the broker is ever touched.
+    tracker : PositionTracker
+        The shared live net-position read-back. ``tracker.position(instrument)``
+        gives each coin's current exposure the per-coin delta is computed
+        against; a ``None`` (no fill yet) is treated as flat. For the loop to
+        close, the same broker's fills must reach this tracker (wire
+        ``PaperBroker(event_bus=bus)`` + ``PositionTracker(event_bus=bus)``), so
+        a tick's fills are reflected in the *next* tick's positions.
+    event_bus : EventBus, optional
+        If given, the runner emits a :class:`~trading_bot.application.events.
+        LogEvent` per submitted leg and per failed leg (a human-readable trace
+        of the rebalance). Defaults to ``None`` (no trace; orders still flow
+        through the router's own ``OrderEvent``\\ s).
+    order_factory : PortfolioOrderFactory, optional
+        Builds each leg's :class:`Order` from ``(strategy, instrument, delta,
+        close)``. Defaults to :func:`portfolio_limit_at_close_factory` (a maker
+        LIMIT at the coin's latest close, so the paper broker fills
+        self-contained). Whatever it returns, the runner overrides the
+        ``client_order_id`` with its deterministic, symbol-namespaced per-step id
+        (so idempotency is the runner's, not the factory's, concern).
+
+    Examples
+    --------
+    >>> # runner = PortfolioRunner(strategy, feed, router, tracker, event_bus=bus)
+    >>> # n_orders = await runner.run()        # drive the whole feed
+    >>> # result = await runner.rebalance(frames)  # or pump one tick by hand
+
+    """
+
+    def __init__(
+        self,
+        strategy: PortfolioStrategy,
+        feed: object,
+        router: OrderRouter,
+        tracker: PositionTracker,
+        *,
+        event_bus: EventBus | None = None,
+        order_factory: PortfolioOrderFactory | None = None,
+    ) -> None:
+        self._strategy = strategy
+        self._feed = feed
+        self._router = router
+        self._tracker = tracker
+        self._bus = event_bus
+        self._order_factory = (
+            order_factory
+            if order_factory is not None
+            else portfolio_limit_at_close_factory()
+        )
+        # Monotonic rebalance index — also the per-leg client-order-id seed. An
+        # instance counter so a fresh runner over the same feed reproduces the
+        # same ids (deterministic re-run), while a single runner re-driven via
+        # repeated ``run`` calls keeps advancing.
+        self._step_index = 0
+
+    @property
+    def strategy(self) -> PortfolioStrategy:
+        """The :class:`PortfolioStrategy` this runner drives (read-only)."""
+        return self._strategy
+
+    @property
+    def step_index(self) -> int:
+        """The next rebalance index (== number of ticks processed so far)."""
+        return self._step_index
+
+    async def run(
+        self,
+        max_steps: int | None = None,
+        *,
+        stop_event: asyncio.Event | None = None,
+    ) -> int:
+        """Drive the feed tick-by-tick, rebalancing the whole book each tick.
+
+        Iterates the feed (the sync iterable of causal per-coin cross-sections)
+        and calls :meth:`rebalance` on each, stopping early after ``max_steps``
+        ticks if given, or as soon as ``stop_event`` is set. Honours causality by
+        construction — each cross-section is the feed's causal prefix and the
+        runner never reads past it.
+
+        Parameters
+        ----------
+        max_steps : int or None, optional
+            Process at most this many rebalance ticks. ``None`` (default) drains
+            the feed to exhaustion.
+        stop_event : asyncio.Event or None, optional
+            A cooperative stop signal, checked at the top of each iteration —
+            **between** rebalances, never mid-rebalance — so an in-flight leg is
+            never interrupted. ``None`` (default) runs without a stop signal.
+
+        Returns
+        -------
+        int
+            The total number of orders **submitted** across every rebalance this
+            call (summed over ticks; on-target / refused legs are not counted).
+
+        """
+        submitted = 0
+        processed = 0
+        for frames in self._feed:  # type: ignore[attr-defined]
+            # Cooperative stop is checked *before* the rebalance: a rebalance
+            # that has begun always finishes all its legs (no leg torn
+            # mid-submit); a stop only takes effect at this between-ticks
+            # boundary.
+            if stop_event is not None and stop_event.is_set():
+                break
+            if max_steps is not None and processed >= max_steps:
+                break
+            result = await self.rebalance(frames)
+            submitted += result.submitted
+            processed += 1
+            # Yield to the event loop once per tick when a stop signal is in play
+            # (the live/looping case), mirroring StrategyRunner — a tick that
+            # submits nothing never awaits a venue, so without this a tight sync
+            # loop over a live feed would starve the cooperative shutdown. This is
+            # a between-ticks boundary, so it never interrupts a leg.
+            if stop_event is not None:
+                await asyncio.sleep(0)
+        return submitted
+
+    async def rebalance(
+        self, frames: Mapping[Symbol, pl.DataFrame]
+    ) -> RebalanceResult:
+        """Process **one** rebalance tick: weight vector → N idempotent legs.
+
+        Evaluates ``strategy.signal_fn(asof, frames)`` for the whole book, sizes
+        the weight vector into per-coin target-quantity signals via
+        :func:`~trading_bot.application.portfolio.weights_to_signals`, then for
+        **every coin in the universe** (a coin the signal omitted is targeted
+        flat) computes ``delta = signal.delta_to(tracker.position(instrument))``
+        and, **only if ``delta != 0``**, routes one order through the router with
+        the deterministic, symbol-namespaced per-step ``client_order_id``. A leg
+        that raises (risk breach / broker error) is recorded and the remaining
+        legs continue (see the module docstring's per-leg failure policy). The
+        rebalance index is always advanced (so ids stay aligned to the tick
+        sequence even on a no-trade rebalance).
+
+        Parameters
+        ----------
+        frames : Mapping[Symbol, polars.DataFrame]
+            The causal per-coin cross-section for this tick. The runner reads the
+            latest close per coin (as exact :class:`~decimal.Decimal`) and the
+            as-of timestamp from it (or from the feed's ``asof_ms``).
+
+        Returns
+        -------
+        RebalanceResult
+            The number of legs submitted and the list of per-coin failures (empty
+            on a clean rebalance).
+
+        """
+        step = self._step_index
+        # Advance the index *before* any routing so a no-trade tick still consumes
+        # its slot — keeping ``f"{name}-{symbol}-{step}"`` aligned 1:1 with the
+        # tick sequence (re-run determinism does not depend on the outcome).
+        self._step_index += 1
+
+        asof = self._asof_ms(frames)
+        prices = self._latest_closes(frames)
+        weights = self._strategy.signal_fn(asof, frames)
+
+        # Universe-complete: cover every coin, defaulting an omitted one to a
+        # 0-weight (flat) target so it is fully closed. Iterate the *universe*,
+        # not the weight keys.
+        full_weights: dict[Symbol, Money] = {
+            symbol: weights.get(symbol, _ZERO)
+            for symbol in self._strategy.universe
+        }
+
+        signals = weights_to_signals(
+            full_weights,
+            prices=prices,
+            capital=self._strategy.capital,
+            asof_ms=asof,
+        )
+        signal_by_symbol = {sig.instrument.symbol: sig for sig in signals}
+
+        submitted = 0
+        failures: list[RebalanceFailure] = []
+        # Route in universe order for a deterministic per-tick leg sequence.
+        for symbol in self._strategy.universe:
+            signal = signal_by_symbol[symbol]
+            instrument = signal.instrument
+            current = self._tracker.position(instrument)
+            position = current if current is not None else _flat(instrument)
+            delta = signal.delta_to(position)
+            if delta == 0:
+                # Already on target (incl. a flat target against a flat position):
+                # no leg.
+                continue
+
+            order = self._build_order(symbol, instrument, delta, prices[symbol], step)
+            try:
+                routed = await self._router.submit(order)
+            except (RiskLimitBreached, BrokerError) as exc:
+                # Per-leg failure: record it and continue the other legs (the
+                # rebalance is not all-or-nothing — see the module docstring).
+                failures.append(RebalanceFailure(symbol=symbol, error=exc))
+                if self._bus is not None:
+                    self._bus.emit(
+                        LogEvent(
+                            message=(
+                                f"{self._strategy.name} step {step}: leg "
+                                f"{symbol} FAILED "
+                                f"({type(exc).__name__}: {exc})"
+                            ),
+                            level="warning",
+                        )
+                    )
+                continue
+
+            submitted += 1
+            if self._bus is not None:
+                self._bus.emit(
+                    LogEvent(
+                        message=(
+                            f"{self._strategy.name} step {step}: "
+                            f"{routed.side.value} {routed.qty} "
+                            f"{routed.instrument} "
+                            f"(delta={delta}, cid={routed.client_order_id})"
+                        )
+                    )
+                )
+
+        return RebalanceResult(submitted=submitted, failures=failures)
+
+    def _build_order(
+        self,
+        symbol: Symbol,
+        instrument: Instrument,
+        delta: Money,
+        close: Money,
+        step: int,
+    ) -> Order:
+        """Build a leg's order, stamping its deterministic per-coin per-step id.
+
+        Delegates the order *shape* to the ``order_factory`` (the maker-LIMIT
+        default), then overrides its ``client_order_id`` with
+        ``f"{strategy.name}-{symbol}-{step}"`` — symbol-namespaced so the N legs
+        of one tick never collide and a re-run dedups per coin at the router.
+        """
+        order = self._order_factory(self._strategy, instrument, delta, close)
+        # The runner owns idempotency, not the factory: stamp the per-coin,
+        # per-step id regardless of what the factory chose.
+        order.client_order_id = f"{self._strategy.name}-{symbol}-{step}"
+        return order
+
+    def _asof_ms(self, frames: Mapping[Symbol, pl.DataFrame]) -> int:
+        """Resolve the as-of timestamp (ms) for this tick.
+
+        Prefers the feed's ``asof_ms()`` when it exposes one (a
+        :class:`~trading_bot.application.portfolio_feed.PortfolioFeed` reports the
+        latest common date's close in ms); otherwise derives it from the frames'
+        latest common ``time`` (dccd stamps bars in nanoseconds, so it is
+        converted ns → ms). Both paths read the *latest* bar across the
+        cross-section, never a future one.
+        """
+        feed_asof = getattr(self._feed, "asof_ms", None)
+        if callable(feed_asof):
+            value = feed_asof()
+            if value is not None:
+                return int(value)
+        return self._derive_asof_ms(frames)
+
+    @staticmethod
+    def _derive_asof_ms(frames: Mapping[Symbol, pl.DataFrame]) -> int:
+        """Derive the as-of ms from the frames' latest common bar time (ns → ms).
+
+        Each coin's frame is a causal window oldest→newest; the cross-section's
+        as-of is the *minimum* of the per-coin latest ``time`` (the last day on
+        which **every** coin has a bar — never beyond any coin's data). dccd
+        timestamps are nanoseconds, so the value is integer-divided to ms.
+        """
+        latest_per_coin = [
+            int(frame["time"][-1]) for frame in frames.values() if frame.height > 0
+        ]
+        if not latest_per_coin:
+            return 0
+        return min(latest_per_coin) // 1_000_000
+
+    @staticmethod
+    def _latest_closes(
+        frames: Mapping[Symbol, pl.DataFrame]
+    ) -> dict[Symbol, Money]:
+        """Read each coin's latest close as exact :class:`~decimal.Decimal`.
+
+        Reads the last ``c`` per coin via ``money(str(...))`` — never ``float`` —
+        so the sizing arithmetic in
+        :func:`~trading_bot.application.portfolio.weights_to_signals` and the
+        maker-LIMIT leg price stay exact.
+        """
+        return {
+            symbol: money(str(frame["c"][-1]))
+            for symbol, frame in frames.items()
+            if frame.height > 0
+        }
+
+
+def portfolio_limit_at_close_factory(
+    close_col: str = "c",
+) -> PortfolioOrderFactory:
+    """Build a per-coin order factory that prices each leg at its latest close.
+
+    The portfolio analogue of :func:`~trading_bot.application.run_app.
+    _limit_at_close_factory`, generalised to take the coin's instrument + close
+    directly (the runner has already read the latest close as exact
+    :class:`~decimal.Decimal`). Each leg is a maker LIMIT at that close, so the
+    in-process :class:`~trading_bot.brokers.paper.PaperBroker` fills it
+    self-contained (at the exact close the signal saw) without seeded mark
+    prices; a live broker ignores the synthetic price and fills at the venue. The
+    runner overrides the ``client_order_id`` afterwards.
+
+    Parameters
+    ----------
+    close_col : str, optional
+        Unused — kept for parity with the single-instrument factory's signature
+        (the runner reads the close and passes it in, so the column name is no
+        longer needed here). Defaults to ``"c"``.
+
+    Returns
+    -------
+    PortfolioOrderFactory
+        A ``(strategy, instrument, delta, close) -> Order`` builder producing a
+        maker LIMIT for ``abs(delta)`` on the side implied by ``delta``'s sign.
+
+    """
+
+    def _factory(
+        strategy: PortfolioStrategy,
+        instrument: Instrument,
+        delta: Money,
+        close: Money,
+    ) -> Order:
+        side = OrderSide.BUY if delta > 0 else OrderSide.SELL
+        return Order(
+            client_order_id="pending",  # overridden by the runner
+            instrument=instrument,
+            side=side,
+            qty=abs(delta),
+            type=OrderType.LIMIT,
+            limit_price=close,
+        )
+
+    return _factory
+
+
+def _flat(instrument: Instrument) -> Position:
+    """A zero (flat) :class:`Position` for ``instrument`` — the no-fill default.
+
+    Used when the shared tracker has no position for a coin yet, so
+    :meth:`~trading_bot.domain.signal.Signal.delta_to` can be called uniformly
+    (the target *is* the delta against a flat book).
+    """
+    return Position(
+        instrument=instrument,
+        net_qty=_ZERO,
+        avg_entry_price=None,
+        realised_pnl=_ZERO,
+        fees_paid=_ZERO,
+    )

--- a/trading_bot/tests/application/test_portfolio_runner.py
+++ b/trading_bot/tests/application/test_portfolio_runner.py
@@ -1,0 +1,473 @@
+"""Tests for the :class:`~trading_bot.application.portfolio_runner.PortfolioRunner`.
+
+These prove the multi-asset loop's contract — ``feed → signal_fn →
+weights_to_signals → per-coin delta_to(position) → order → router → broker →
+fill → tracker`` — end to end against the **real**
+:class:`~trading_bot.brokers.paper.PaperBroker`, fully offline:
+
+* **flat → N orders**: one rebalance from flat routes one leg per non-zero-weight
+  coin, with sizes equal to ``weightᵢ × capital / priceᵢ`` (exact ``Decimal``) and
+  sides matching the weight signs; the broker-confirmed fills (read off the shared
+  tracker) match the intended per-coin targets;
+* **delta on rebalance**: a second rebalance with *changed* weights routes the
+  **delta** vs the now-non-flat positions (read from the shared tracker), not the
+  absolute target — and a coin whose weight goes to ``0`` is targeted *flat* (full
+  close);
+* **idempotency**: re-submitting the same rebalance step (same ``step``) places no
+  duplicate orders — the router dedups on the per-coin id;
+* **risk gate**: a leg exceeding ``max_order`` raises
+  :class:`~trading_bot.domain.errors.RiskLimitBreached`, never reaches the broker,
+  and the **other** legs still route (the documented continue-other-legs policy);
+* **reconciliation honesty**: after fills, ``tracker.position(coin)`` equals the
+  routed cumulative qty per coin — broker-confirmed state, not local optimism.
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from decimal import Decimal
+
+import polars as pl
+
+from trading_bot.application import (
+    EventBus,
+    OrderRouter,
+    PortfolioRunner,
+    PortfolioStrategy,
+    PositionTracker,
+    RiskManager,
+)
+from trading_bot.application.config import RiskConfig
+from trading_bot.brokers import PaperBroker
+from trading_bot.domain import (
+    Instrument,
+    OrderSide,
+    Symbol,
+    money,
+)
+from trading_bot.domain.errors import RiskLimitBreached
+
+BTC = Symbol("BTC", "USDT")
+ETH = Symbol("ETH", "USDT")
+UNIVERSE = (BTC, ETH)
+CAPITAL = money("100000")
+
+# Reference prices the hand-calc round-trips through exactly.
+BTC_PRICE = money("50000")
+ETH_PRICE = money("2500")
+
+
+# --- helpers --------------------------------------------------------------- #
+
+
+def _frame(close: float, *, time_ns: int = 1_700_000_000_000_000_000) -> pl.DataFrame:
+    """A minimal one-row OHLC(V) frame whose latest close is ``close``."""
+    return pl.DataFrame(
+        {
+            "time": [time_ns],
+            "o": [close],
+            "h": [close],
+            "l": [close],
+            "c": [close],
+            "v": [1.0],
+        }
+    )
+
+
+def _frames(
+    btc_close: float = 50000.0, eth_close: float = 2500.0
+) -> dict[Symbol, pl.DataFrame]:
+    """The per-coin cross-section for one rebalance tick."""
+    return {BTC: _frame(btc_close), ETH: _frame(eth_close)}
+
+
+class _ListFeed:
+    """A fake portfolio feed: yields canned per-coin cross-sections, with asof.
+
+    Mirrors the iterable a :class:`~trading_bot.application.portfolio_feed.
+    PortfolioFeed` is — an iterator of ``Mapping[Symbol, pl.DataFrame]`` — and
+    exposes an ``asof_ms()`` so the runner reads the as-of from the feed (the
+    real-feed path), not only by deriving it from the frames.
+    """
+
+    def __init__(self, ticks: list[Mapping[Symbol, pl.DataFrame]], *, asof: int) -> None:
+        self._ticks = ticks
+        self._asof = asof
+
+    def __iter__(self):  # type: ignore[no-untyped-def]
+        return iter(self._ticks)
+
+    def asof_ms(self) -> int:
+        return self._asof
+
+
+def _weights_signal(weights: Mapping[Symbol, Decimal]):  # type: ignore[no-untyped-def]
+    """A fake :data:`PortfolioSignalFn` returning a fixed weight vector."""
+
+    def _fn(
+        asof_ms: int, frames: Mapping[Symbol, pl.DataFrame]
+    ) -> Mapping[Symbol, Decimal]:
+        return dict(weights)
+
+    return _fn
+
+
+def _engine(
+    *, risk: RiskConfig | None = None
+) -> tuple[OrderRouter, PositionTracker, EventBus, PaperBroker]:
+    """A real paper-broker engine: router + tracker + bus, optionally risk-gated.
+
+    The broker fills LIMIT legs at their (close) limit price and emits a
+    ``FillEvent`` per fill onto the bus the tracker subscribes to, so the loop
+    closes (a tick's fills update the *next* tick's positions).
+    """
+    bus = EventBus()
+    tracker = PositionTracker(event_bus=bus)
+    broker = PaperBroker(
+        fee_bps=money("0"),
+        fill_model="immediate",
+        starting_balances={"USDT": money("100000000"), "BTC": money("0"), "ETH": money("0")},
+        event_bus=bus,
+    )
+    risk_manager = (
+        RiskManager(risk, position_tracker=tracker) if risk is not None else None
+    )
+    router = OrderRouter(broker, bus, risk_manager=risk_manager)
+    return router, tracker, bus, broker
+
+
+def _strategy(signal_fn, *, name: str = "book") -> PortfolioStrategy:  # type: ignore[no-untyped-def]
+    return PortfolioStrategy(
+        name=name,
+        universe=UNIVERSE,
+        signal_fn=signal_fn,
+        capital=CAPITAL,
+    )
+
+
+# --- flat → N orders ------------------------------------------------------- #
+
+
+async def test_one_rebalance_from_flat_routes_n_sized_orders() -> None:
+    """From flat, a rebalance routes one leg per coin sized weight*capital/price.
+
+    Weights ``+0.5`` BTC / ``-0.25`` ETH at prices 50000 / 2500 with capital
+    100000 size to exactly ``+1.0`` BTC (BUY) and ``-10.0`` ETH (SELL). We assert
+    the router's submitted orders' sizes/sides, then the **broker-confirmed**
+    positions on the shared tracker.
+    """
+    weights = {BTC: money("0.5"), ETH: money("-0.25")}
+    router, tracker, _bus, broker = _engine()
+    runner = PortfolioRunner(
+        _strategy(_weights_signal(weights)),
+        _ListFeed([_frames()], asof=1_700),
+        router,
+        tracker,
+        event_bus=_bus,
+    )
+
+    result = await runner.rebalance(_frames())
+
+    assert result.submitted == 2
+    assert result.failed == 0
+
+    # Router-side: the submitted orders carry the exact target sizes & sides.
+    orders = router.tracked_orders()
+    assert set(orders) == {"book-BTC/USDT-0", "book-ETH/USDT-0"}
+    btc_order = orders["book-BTC/USDT-0"]
+    eth_order = orders["book-ETH/USDT-0"]
+    assert btc_order.side is OrderSide.BUY and btc_order.qty == Decimal("1")
+    assert eth_order.side is OrderSide.SELL and eth_order.qty == Decimal("10")
+
+    # Broker-confirmed: the shared tracker (fed off the bus) reflects the fills,
+    # not local optimism.
+    btc_pos = tracker.position(Instrument(BTC))
+    eth_pos = tracker.position(Instrument(ETH))
+    assert btc_pos is not None and btc_pos.net_qty == Decimal("1")
+    assert eth_pos is not None and eth_pos.net_qty == Decimal("-10")
+
+
+async def test_zero_weight_coin_routes_no_leg() -> None:
+    """A coin with weight 0 (and flat) is on target → no leg for it."""
+    weights = {BTC: money("0.5"), ETH: money("0")}
+    router, tracker, _bus, _broker = _engine()
+    runner = PortfolioRunner(
+        _strategy(_weights_signal(weights)),
+        _ListFeed([_frames()], asof=1_700),
+        router,
+        tracker,
+    )
+
+    result = await runner.rebalance(_frames())
+
+    assert result.submitted == 1  # only BTC traded
+    assert set(router.tracked_orders()) == {"book-BTC/USDT-0"}
+    # ETH never traded → no fill → no tracked position.
+    assert tracker.position(Instrument(ETH)) is None
+
+
+async def test_omitted_coin_is_targeted_flat() -> None:
+    """A coin the signal *omits* (not in the weight vector) is covered as flat.
+
+    The book covers the whole universe: an omitted coin defaults to weight 0, so
+    once it holds a position it is fully closed on the next rebalance.
+    """
+    # First: open both. Second: signal omits ETH entirely → ETH closed flat.
+    router, tracker, _bus, _broker = _engine()
+    open_both = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")}))
+    runner = PortfolioRunner(open_both, _ListFeed([], asof=1_700), router, tracker)
+    await runner.rebalance(_frames())
+    assert tracker.position(Instrument(ETH)).net_qty == Decimal("-10")
+
+    # Now a signal that only mentions BTC; ETH is omitted → targeted flat. A
+    # distinct strategy name namespaces the new legs (the first runner's ids are
+    # already tracked at the shared router).
+    runner_2 = PortfolioRunner(
+        _strategy(_weights_signal({BTC: money("0.5")}), name="book2"),  # ETH omitted
+        _ListFeed([], asof=1_701),
+        router,
+        tracker,
+    )
+    result = await runner_2.rebalance(_frames())
+
+    # BTC already on target (+1) → no leg; ETH closed from -10 → +10 BUY leg.
+    assert result.submitted == 1
+    eth_close_leg = router.tracked_orders()["book2-ETH/USDT-0"]
+    assert eth_close_leg.side is OrderSide.BUY and eth_close_leg.qty == Decimal("10")
+    assert tracker.position(Instrument(ETH)).net_qty == Decimal("0")
+
+
+# --- delta on rebalance ---------------------------------------------------- #
+
+
+async def test_second_rebalance_routes_delta_not_absolute() -> None:
+    """A second rebalance routes the delta vs the now-non-flat shared positions.
+
+    Tick 0: +0.5 BTC (+1) / -0.25 ETH (-10). Tick 1 (changed weights): +0.8 BTC
+    (target +1.6, so delta +0.6 BUY) / +0.1 ETH (target +4, from -10 so delta +14
+    BUY). The legs must be the *deltas*, not the absolute targets.
+    """
+    router, tracker, _bus, _broker = _engine()
+
+    t0 = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")}))
+    runner_0 = PortfolioRunner(t0, _ListFeed([], asof=1_700), router, tracker)
+    await runner_0.rebalance(_frames())
+    assert tracker.position(Instrument(BTC)).net_qty == Decimal("1")
+    assert tracker.position(Instrument(ETH)).net_qty == Decimal("-10")
+
+    # A *different* runner (fresh step index 0) re-allocates the shared book.
+    t1 = _strategy(_weights_signal({BTC: money("0.8"), ETH: money("0.1")}), name="book2")
+    runner_1 = PortfolioRunner(t1, _ListFeed([], asof=1_701), router, tracker)
+    result = await runner_1.rebalance(_frames())
+
+    assert result.submitted == 2
+    btc_leg = router.tracked_orders()["book2-BTC/USDT-0"]
+    eth_leg = router.tracked_orders()["book2-ETH/USDT-0"]
+    # target +1.6, current +1 → +0.6 BUY
+    assert btc_leg.side is OrderSide.BUY and btc_leg.qty == Decimal("0.6")
+    # target +4, current -10 → +14 BUY
+    assert eth_leg.side is OrderSide.BUY and eth_leg.qty == Decimal("14")
+
+    # Broker-confirmed resulting positions are the new absolute targets.
+    assert tracker.position(Instrument(BTC)).net_qty == Decimal("1.6")
+    assert tracker.position(Instrument(ETH)).net_qty == Decimal("4")
+
+
+async def test_on_target_rebalance_submits_nothing() -> None:
+    """Re-running the *same* weights against the resulting book is a no-op.
+
+    After a rebalance lands the targets, an immediate identical rebalance finds
+    every coin already on target (delta 0) and routes no leg.
+    """
+    router, tracker, _bus, broker = _engine()
+    strat = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")}))
+    runner = PortfolioRunner(strat, _ListFeed([], asof=1_700), router, tracker)
+
+    await runner.rebalance(_frames())
+    fills_after_1 = len(await broker.fills())
+
+    # Same weights, same book → delta 0 everywhere.
+    result_2 = await runner.rebalance(_frames())
+    assert result_2.submitted == 0
+    assert len(await broker.fills()) == fills_after_1
+
+
+# --- idempotency ----------------------------------------------------------- #
+
+
+async def test_resubmitting_same_step_does_not_double_route() -> None:
+    """Re-submitting the same rebalance step places no duplicate venue orders.
+
+    The per-coin ids ``f"{name}-{symbol}-{step}"`` make a re-run a no-op at the
+    router. We capture the legs of step 0, then replay those exact orders through
+    the same router and assert the broker placed no new fills.
+    """
+    router, tracker, _bus, broker = _engine()
+    strat = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")}))
+    runner = PortfolioRunner(strat, _ListFeed([], asof=1_700), router, tracker)
+
+    await runner.rebalance(_frames())
+    fills_after_1 = len(await broker.fills())
+    tracked_after_1 = set(router.tracked_orders())
+    submitted_orders = list(router.tracked_orders().values())
+
+    # Replay the very same orders (same client-order-ids) through the router.
+    for order in submitted_orders:
+        again = await router.submit(order)
+        assert again is order  # already-tracked order, never re-submits
+
+    assert len(await broker.fills()) == fills_after_1
+    assert set(router.tracked_orders()) == tracked_after_1
+
+
+async def test_rerun_same_step_index_is_deterministic_noop() -> None:
+    """A *fresh* runner replaying step 0's tick against the filled book is a no-op.
+
+    Two runners (same name, same feed, fresh step indices) over the *shared*
+    engine. Runner A's fills already moved the shared tracker to target, so
+    runner B finds every coin on target (delta 0) and routes nothing — no new
+    fills, no double-counting. (Even had a leg been built, its id matches A's and
+    the router would dedup it; here it never gets that far because the position is
+    already correct — reconciliation honesty at the position level.)
+    """
+    router, tracker, _bus, broker = _engine()
+    strat = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")}))
+
+    runner_a = PortfolioRunner(strat, _ListFeed([], asof=1_700), router, tracker)
+    await runner_a.rebalance(_frames())
+    fills_after_a = len(await broker.fills())
+
+    runner_b = PortfolioRunner(strat, _ListFeed([], asof=1_700), router, tracker)
+    result_b = await runner_b.rebalance(_frames())
+
+    # On target everywhere → no legs, no new fills, positions unchanged.
+    assert result_b.submitted == 0
+    assert len(await broker.fills()) == fills_after_a
+    assert tracker.position(Instrument(BTC)).net_qty == Decimal("1")
+    assert tracker.position(Instrument(ETH)).net_qty == Decimal("-10")
+
+
+# --- risk gate ------------------------------------------------------------- #
+
+
+async def test_risk_breach_on_one_leg_does_not_abort_others() -> None:
+    """A leg over ``max_order`` raises and never fills, but other legs still route.
+
+    With ``max_order = 5``, BTC's +1 leg passes but ETH's -10 leg breaches. The
+    documented policy is *continue the other legs*: BTC routes and fills, ETH is
+    recorded as a failure, and the rebalance is not aborted.
+    """
+    router, tracker, _bus, broker = _engine(risk=RiskConfig(max_order=money("5")))
+    strat = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")}))
+    runner = PortfolioRunner(strat, _ListFeed([], asof=1_700), router, tracker)
+
+    result = await runner.rebalance(_frames())
+
+    # BTC (+1) routed; ETH (-10) breached max_order and was recorded.
+    assert result.submitted == 1
+    assert result.failed == 1
+    assert result.failures[0].symbol == ETH
+    assert isinstance(result.failures[0].error, RiskLimitBreached)
+
+    # BTC filled (broker-confirmed); ETH never reached the broker.
+    assert tracker.position(Instrument(BTC)).net_qty == Decimal("1")
+    assert tracker.position(Instrument(ETH)) is None
+    # The breaching leg is not tracked (a refused order leaves no record).
+    assert "book-ETH/USDT-0" not in router.tracked_orders()
+    assert "book-BTC/USDT-0" in router.tracked_orders()
+
+
+async def test_kill_switch_fails_every_leg() -> None:
+    """A tripped kill-switch refuses every leg → N failures, zero submitted."""
+    risk = RiskConfig()
+    router, tracker, _bus, broker = _engine(risk=risk)
+    # Reach into the router's risk manager to trip it.
+    runner = PortfolioRunner(
+        _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")})),
+        _ListFeed([], asof=1_700),
+        router,
+        tracker,
+    )
+    router._risk.trip("test halt")  # type: ignore[union-attr]
+
+    result = await runner.rebalance(_frames())
+
+    assert result.submitted == 0
+    assert result.failed == 2
+    assert {f.symbol for f in result.failures} == {BTC, ETH}
+    assert await broker.fills() == []
+
+
+# --- reconciliation honesty + run() loop ----------------------------------- #
+
+
+async def test_run_drives_feed_and_tracker_matches_routed_qty() -> None:
+    """``run`` over a feed routes each tick; final positions = routed cumulative.
+
+    A two-tick feed: tick 0 opens, tick 1 (same runner, same weights) is on
+    target → no new legs. The final broker-confirmed positions equal the routed
+    cumulative quantity per coin.
+    """
+    router, tracker, _bus, broker = _engine()
+    strat = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")}))
+    feed = _ListFeed([_frames(), _frames()], asof=1_700)
+    runner = PortfolioRunner(strat, feed, router, tracker, event_bus=_bus)
+
+    total = await runner.run()
+
+    # Tick 0 routed 2 legs; tick 1 found everything on target → 0.
+    assert total == 2
+    assert runner.step_index == 2  # both ticks consumed
+
+    # Broker-confirmed positions equal the routed targets, read off the tracker.
+    assert tracker.position(Instrument(BTC)).net_qty == Decimal("1")
+    assert tracker.position(Instrument(ETH)).net_qty == Decimal("-10")
+
+    # And the signed fills per coin sum to the tracked net (no double counting).
+    fills = await broker.fills()
+    by_coin: dict[Symbol, Decimal] = {}
+    for f in fills:
+        signed = f.qty if f.side is OrderSide.BUY else -f.qty
+        by_coin[f.instrument.symbol] = by_coin.get(f.instrument.symbol, Decimal("0")) + signed
+    assert by_coin[BTC] == Decimal("1")
+    assert by_coin[ETH] == Decimal("-10")
+
+
+async def test_asof_derived_from_frames_when_feed_has_none() -> None:
+    """When the feed exposes no ``asof_ms``, the as-of is derived from the frames.
+
+    A bare list feed (no ``asof_ms``) → the runner derives the as-of from the
+    frames' latest common ``time`` (ns → ms) and stamps it on the signals; the
+    rebalance still routes correctly.
+    """
+    router, tracker, _bus, _broker = _engine()
+    strat = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("-0.25")}))
+    # A plain list is iterable but has no asof_ms().
+    runner = PortfolioRunner(strat, [_frames()], router, tracker)
+
+    result = await runner.rebalance(_frames())
+
+    assert result.submitted == 2
+    assert tracker.position(Instrument(BTC)).net_qty == Decimal("1")
+
+
+async def test_money_read_off_frame_is_exact_decimal() -> None:
+    """The latest close is read as exact ``Decimal`` (no float), driving sizing.
+
+    A close with a fraction (50000.5) that a ``float`` would not represent
+    exactly is read via ``money(str(...))``; the BTC target is sized off the exact
+    value. We assert the leg's limit price is the exact decimal and the size is
+    ``0.5 * 100000 / 50000.5`` exactly.
+    """
+    router, tracker, _bus, _broker = _engine()
+    strat = _strategy(_weights_signal({BTC: money("0.5"), ETH: money("0")}))
+    runner = PortfolioRunner(strat, [_frames(btc_close=50000.5)], router, tracker)
+
+    await runner.rebalance(_frames(btc_close=50000.5))
+
+    btc_leg = router.tracked_orders()["book-BTC/USDT-0"]
+    assert btc_leg.limit_price == Decimal("50000.5")
+    expected = money(str(money("0.5") * CAPITAL / money("50000.5")))
+    assert btc_leg.qty == abs(expected)


### PR DESCRIPTION
## Summary
- `application.PortfolioRunner` — the multi-asset analogue of `StrategyRunner`. Each tick: call the `PortfolioSignalFn` for the whole book → `weights_to_signals` (per-coin `target_qty`) → per-coin `delta_to(shared tracker position)` → route **N** idempotent, risk-gated **maker-LIMIT** legs through the shared `OrderRouter`. Cooperative `run(stop_event=...)`.

## Why (design — see ADR)
- **Whole-universe targeting:** iterates `strategy.universe` (not the weight keys), synthesising a **0-weight flat** target for any coin the signal omits → a dropped name is closed, not stranded.
- **Per-coin idempotency id** `f"{name}-{symbol}-{step}"` → re-run/retry dedups per coin per rebalance.
- **Per-leg failure isolation:** a leg raising `RiskLimitBreached`/`BrokerError` is recorded on the `RebalanceResult` and the other legs still route (not all-or-nothing). Gross guard off (trust the signal's cap).

## Verification on real data (PaperBroker)
Drove the runner (fake signal) against a real in-process `PaperBroker`; broker-confirmed fills read off the shared tracker match intended targets exactly:

| coin | intended | broker-filled |
|---|--:|--:|
| BTC/USDT | 1.0 | 1 (BUY @ 50000) |
| ETH/USDT | -10.00 | -10.0 (SELL @ 2500) |

Signed-fill sums == `tracker.net_qty` (no double-count). Delta-on-rebalance, idempotent replay, risk-gate/kill-switch per-leg all tested.

## Changes
- `trading_bot/application/portfolio_runner.py` (new), `application/__init__.py` (exports).
- `trading_bot/tests/application/test_portfolio_runner.py` (new — 12 tests).

## Changelog
Added under [Unreleased] (0.3.0): `application.PortfolioRunner`.

## Test plan
- [x] `.venv/bin/python -m pytest` — 662 passed, 8 deselected
- [x] `.venv/bin/ruff check trading_bot/` — clean
- [x] `.venv/bin/mypy trading_bot/` — clean
- [ ] CI green

Leaf 03 of **portfolio-strategy**. Leaf 04 (config + wiring) depends on 02 + 03.