### PR TITLE
feat: portfolio config + run_app wiring + resample-on-read daily client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   weights is targeted **flat**). Per-leg failures (`RiskLimitBreached`/`BrokerError`)
   are collected on a `RebalanceResult` and don't abort the book; cooperative
   `run(stop_event=...)`. (#65)
+- `AppConfig.portfolios` + `PortfolioStrategyConfig` + `run_app` wiring — declare and
+  run a native multi-asset portfolio (universe + weight-vector signal by reference +
+  capital + daily dccd source) alongside single-instrument strategies on the shared
+  engine; per-coin `PortfolioReport`. Overlap detection now spans strategies **and**
+  portfolio universes (no instrument claimed twice). (#66)
+- `application.ResamplingDccdClient` — an injectable resample-on-read dccd client
+  (reads the 1-minute store, aggregates OHLCV to daily via `group_by_dynamic`,
+  causal: closed days only, partial last day dropped, OHLC carried exact). The live
+  daily-bars seam for the portfolio path (dccd serves only 1m). (#66)
 
 ### Changed
+
+- `[triptych]` extra documents `fynance-research` as an editable sibling install
+  (`pip install -e ../fynance-research`, like `dccd`) — the source of validated
+  portfolio signals (LS1); kept out of the hard deps. (#66)
 
 ### Fixed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,40 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Portfolio config + run_app wiring; resample-on-read daily seam (PR #66)
+
+**Decision.** A portfolio is declarable via `PortfolioStrategyConfig` (universe +
+`SignalRefConfig` + `capital` + daily `DataSourceConfig` + optional `gross_cap` +
+`venue`) on `AppConfig.portfolios`; `run_app`'s `build_portfolio_runners` resolves
+the signal by reference, builds a `PortfolioFeed` + `PortfolioRunner` on the **shared**
+engine, and reports per-coin. **Overlap detection** is widened: no instrument may be
+claimed by two runners — strategy↔strategy (existing), strategy↔portfolio, or
+portfolio↔portfolio — because the shared per-instrument tracker has no attribution. A
+portfolio is exempt from the *intra*-single-instrument `_reject_commingled` (it owns
+its whole universe) but its universe must not intersect any other runner's.
+
+The daily-bars seam: `ResamplingDccdClient` wraps a real dccd client, reads the
+**1-minute** store and aggregates OHLCV to daily (`open=first, high=max, low=min,
+close=last, volume=sum` via `group_by_dynamic(every="1d", closed="left",
+label="left")`), causal — closed days only, the still-forming last day dropped, OHLC
+carried **exact** (no float). It is **injectable, not auto-wrapped** by `run_app`:
+the caller wraps the real client when a daily portfolio reads a 1m store; offline
+tests inject a fake *daily* client directly. `fynance-research` is documented as an
+editable `[triptych]` extra (LS1's signals live there; the engine stays generic).
+
+**Why.** dccd serves only 1m (it does not resample — `read(span=86400)` → 0 rows), so
+a daily consumer must resample, mirroring `fynance_research/data.py`. Making the
+resampler an injectable client keeps `PortfolioFeed`/`run_app` agnostic and the
+offline tests resample-free; auto-wrapping was rejected because `run_app` can't tell
+the store's native span from the requested span without a new config signal — deferred
+until needed. Widened overlap detection prevents two runners silently fighting over
+one instrument's shared position. **Rejected:** resampling inside `PortfolioFeed`
+(couples it to the store's native span); auto-wrapping in `run_app` (needs a
+source-span config field — premature); a hard `fynance-research` dependency (would
+force the research repo on every install).
+
+---
+
 ### 2026-06-29 PortfolioRunner — whole-universe targeting, per-leg failure isolation (PR #65)
 
 **Decision.** `application.PortfolioRunner` mirrors `StrategyRunner` for a whole

--- a/doc/dev/plans/portfolio-strategy/00-plan.md
+++ b/doc/dev/plans/portfolio-strategy/00-plan.md
@@ -65,7 +65,7 @@ shape. It is **0.3.0 work** (post the 0.2.0 release).
 - [x] 01 portfolio-signal — feat/portfolio-signal — medium (→ opus)
 - [x] 02 portfolio-feed — feat/portfolio-feed — medium (→ opus) (depends on 01)
 - [x] 03 portfolio-runner — feat/portfolio-runner — high (→ opus) (depends on 01)
-- [ ] 04 portfolio-config — feat/portfolio-config — medium (→ opus) (depends on 02, 03)
+- [x] 04 portfolio-config — feat/portfolio-config — medium (→ opus) (depends on 02, 03)
 - [ ] 05 ls1-e2e — feat/portfolio-ls1-e2e — high (→ opus) (depends on 04)
 
 ## Dependencies

--- a/doc/dev/plans/portfolio-strategy/04-portfolio-config.md
+++ b/doc/dev/plans/portfolio-strategy/04-portfolio-config.md
@@ -1,12 +1,12 @@
 ---
 plan: portfolio-strategy/04-portfolio-config
 kind: leaf
-status: planned
+status: done
 complexity: medium
 depends: [02, 03]
 parallel: false
 branch: feat/portfolio-config
-pr: ""
+pr: "#66"
 ---
 
 # Portfolio config + wiring into run_app; fynance-research extra

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,10 +35,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# The other two pillars of the triptych. fynance is on PyPI; dccd is installed
-# editable from its sibling repo (kept out of the hard list so `pip install` and
-# CI never try to resolve it from PyPI):
-#   pip install -e ../Download_Crypto_Currencies_Data
+# The other two pillars of the triptych. fynance is on PyPI; dccd and
+# fynance-research are installed editable from their sibling repos (kept out of
+# the hard list so `pip install` and CI never try to resolve them from PyPI):
+#   pip install -e ../Download_Crypto_Currencies_Data   # dccd — market data
+#   pip install -e ../fynance-research                  # LS1 portfolio signals
+# fynance-research provides the live portfolio signal a PortfolioStrategyConfig's
+# `signal` ref imports (e.g. leaf 05's LS1); it is optional, like dccd, so the
+# unit suite skips its real-signal tests when it is absent.
 triptych = [
     "fynance>=1.0.7",
 ]

--- a/trading_bot/application/config.py
+++ b/trading_bot/application/config.py
@@ -46,6 +46,7 @@ from typing import Any, Literal
 import yaml
 from pydantic import BaseModel, Field, field_validator
 
+from trading_bot.domain.instrument import Symbol, parse_kraken_pair
 from trading_bot.domain.money import money
 
 __all__ = [
@@ -54,6 +55,7 @@ __all__ = [
     "SignalRefConfig",
     "StorageConfig",
     "StrategyConfig",
+    "PortfolioStrategyConfig",
     "RiskConfig",
     "AppConfig",
 ]
@@ -230,6 +232,121 @@ class StrategyConfig(BaseModel):
         return v
 
 
+class PortfolioStrategyConfig(BaseModel):
+    """One **multi-asset** strategy the engine should drive — a universe + sizing.
+
+    The portfolio analogue of :class:`StrategyConfig`. Where a
+    :class:`StrategyConfig` names *one* ``symbol`` and an optional fractional
+    ``reference_qty``, a portfolio names a whole ``universe`` of pairs and an
+    explicit ``capital`` base its signal's weight vector is a fraction of (a
+    weight ``w`` for a coin targets a position worth ``w * capital``). The signal
+    is a ``"module:function"`` :class:`SignalRefConfig` resolving to a
+    ``target_weights``-shaped callable (a
+    :data:`~trading_bot.application.portfolio.PortfolioSignalFn`); the data is the
+    dccd dataset the universe's bars come from (daily by default — ``span =
+    86400``). Rebalance cadence is the data's daily ``span``.
+
+    Parameters
+    ----------
+    name : str
+        Logical, config-unique id for the portfolio instance. Must be non-empty.
+    universe : list of str
+        The canonical pairs the portfolio allocates across, ``BASE/QUOTE`` (e.g.
+        ``["BTC/USDT", "ETH/USDT"]``). Must be **non-empty**, every entry must
+        parse to a :class:`~trading_bot.domain.instrument.Symbol`, and the
+        universe must hold **no duplicate** instruments (two spellings of the same
+        pair — e.g. ``"BTC/USDT"`` and ``"XBT/USDT"`` — are caught as the same
+        instrument).
+    signal : SignalRefConfig
+        The weight-vector signal the portfolio evaluates — a ``"module:function"``
+        reference to a :data:`~trading_bot.application.portfolio.PortfolioSignalFn`
+        (there is no builtin portfolio-signal registry yet, so a bare name is
+        rejected at resolution time). **Required**.
+    capital : Decimal
+        The capital base (quote units) the signal's weights are a fraction of.
+        Parsed exactly from a YAML scalar (``str``/``int``) without touching
+        ``float``. Must be **strictly positive**.
+    data : DataSourceConfig
+        The portfolio's bar source (dccd dataset). The same source feeds every
+        coin in the universe (same ``exchange`` / ``span``); ``span`` is the daily
+        ``86400`` for a daily rebalance. **Required**.
+    gross_cap : Decimal or None, optional
+        An optional declared gross-exposure cap (``Σ|w| ≤ gross_cap``), carried
+        through to the
+        :class:`~trading_bot.application.portfolio.PortfolioStrategy` for a
+        signal/runner to honour. The engine does **not** enforce or re-normalise
+        against it. Must be positive when set. ``None`` (default) means uncapped.
+    venue : str, optional
+        The venue key the universe's bars are stored under / rendered for (e.g.
+        ``"binance"``). Defaults to ``"binance"``. Must be non-empty.
+
+    """
+
+    name: str
+    universe: list[str]
+    signal: SignalRefConfig
+    capital: Decimal
+    data: DataSourceConfig
+    gross_cap: Decimal | None = None
+    venue: str = "binance"
+
+    @field_validator("name", "venue")
+    @classmethod
+    def _non_empty(cls, v: str) -> str:
+        """Reject blank portfolio ``name`` / ``venue`` (whitespace-only too)."""
+        if not v or not v.strip():
+            raise ValueError("must be a non-empty string")
+        return v
+
+    @field_validator("universe")
+    @classmethod
+    def _valid_universe(cls, v: list[str]) -> list[str]:
+        """Reject an empty universe, an unparseable pair, or a duplicate coin.
+
+        Each entry must parse to a :class:`~trading_bot.domain.instrument.Symbol`
+        (so a malformed pair is caught at config time), and no two entries may
+        resolve to the **same** normalised :class:`Symbol` — the shared
+        per-instrument tracker has no attribution, so a coin cannot appear twice.
+        """
+        if not v:
+            raise ValueError("universe must be a non-empty list of pairs")
+        seen: dict[Symbol, str] = {}
+        for raw in v:
+            if not raw or not raw.strip():
+                raise ValueError("universe entries must be non-empty pair strings")
+            try:
+                symbol = parse_kraken_pair(raw)
+            except ValueError as exc:
+                raise ValueError(
+                    f"universe entry {raw!r} is not a valid pair: {exc}"
+                ) from exc
+            previous = seen.get(symbol)
+            if previous is not None:
+                raise ValueError(
+                    f"universe has duplicate instrument {raw!r} "
+                    f"(same as {previous!r}): a coin may appear only once "
+                    "(the shared per-instrument tracker has no attribution)"
+                )
+            seen[symbol] = raw
+        return v
+
+    @field_validator("capital")
+    @classmethod
+    def _positive_capital(cls, v: Decimal) -> Decimal:
+        """Reject a non-positive ``capital`` (zero too)."""
+        if v <= 0:
+            raise ValueError(f"capital must be positive, got {v}")
+        return v
+
+    @field_validator("gross_cap")
+    @classmethod
+    def _positive_gross_cap(cls, v: Decimal | None) -> Decimal | None:
+        """Reject a non-positive ``gross_cap`` (``None`` is allowed)."""
+        if v is not None and v <= 0:
+            raise ValueError(f"gross_cap must be positive, got {v}")
+        return v
+
+
 class StorageConfig(BaseModel):
     """Where the engine persists state and finds market data on disk.
 
@@ -317,7 +434,14 @@ class AppConfig(BaseModel):
     brokers : list of BrokerConfig, optional
         The brokers to wire up. Empty by default.
     strategies : list of StrategyConfig, optional
-        The strategies to drive. Empty by default.
+        The single-instrument strategies to drive. Empty by default.
+    portfolios : list of PortfolioStrategyConfig, optional
+        The multi-asset portfolio strategies to drive (each allocates across a
+        whole ``universe`` via a weight-vector signal). Empty by default. A
+        portfolio runs alongside the single-instrument strategies through the same
+        shared engine; no instrument may be claimed by both a portfolio and a
+        single-instrument strategy (or by two portfolios) — see
+        :func:`~trading_bot.application.run_app.build_portfolio_runners`.
     risk : RiskConfig, optional
         Engine-wide risk limits. Defaults to all-unconstrained.
     storage : StorageConfig, optional
@@ -344,6 +468,7 @@ class AppConfig(BaseModel):
     starting_capital: Decimal = Field(default_factory=lambda: money("100000"))
     brokers: list[BrokerConfig] = Field(default_factory=list)
     strategies: list[StrategyConfig] = Field(default_factory=list)
+    portfolios: list[PortfolioStrategyConfig] = Field(default_factory=list)
     risk: RiskConfig = Field(default_factory=RiskConfig)
     storage: StorageConfig = Field(default_factory=StorageConfig)
 

--- a/trading_bot/application/data_provider.py
+++ b/trading_bot/application/data_provider.py
@@ -56,7 +56,20 @@ if TYPE_CHECKING:
 __all__ = [
     "feed_for",
     "DccdClient",
+    "ResamplingDccdClient",
 ]
+
+#: dccd OHLC columns the resampler aggregates over (the source-frame schema).
+_OHLC_COLS: tuple[str, ...] = (
+    "TS",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "quote_volume",
+    "trades",
+)
 
 
 @runtime_checkable
@@ -92,6 +105,198 @@ class DccdClient(Protocol):
     ) -> Any:
         """Drive dccd to collect/store bars for ``exchange``/``symbol``."""
         ...
+
+
+class ResamplingDccdClient:
+    """A dccd client that **resamples** a finer stored span up to a coarser one.
+
+    The live daily-bars seam for the portfolio. dccd's store serves bars at the
+    span they were collected at, and the Binance store the LS1 universe lives in
+    holds only **1-minute** bars — so a plain ``client.read(span=86400)`` against
+    it returns *zero* daily rows (dccd does not resample). Daily bars are a
+    *consumer* responsibility (this mirrors ``fynance_research.data.load_ohlc``,
+    which resamples 1m→1d via polars ``group_by_dynamic(every="1d")``).
+
+    This adapter wraps a real :class:`DccdClient`: a ``read`` for the
+    ``daily_span`` is satisfied by reading the wrapped client at the finer
+    ``source_span`` (default ``60`` = 1m) and aggregating each calendar day's
+    minute bars into one daily OHLCV bar —
+
+    ===========  =========================================================
+    column       aggregation over the day's minute bars
+    ===========  =========================================================
+    ``open``     ``first`` (the day's opening minute)
+    ``high``     ``max``
+    ``low``      ``min``
+    ``close``    ``last`` (the day's closing minute)
+    ``volume``   ``sum``
+    ===========  =========================================================
+
+    via polars ``group_by_dynamic(every="1d")`` on a ``time`` derived from the
+    ``TS`` column. The grouping is **left-closed / left-labelled** (polars'
+    default), so each daily bar is stamped at the **day's open** and aggregates
+    only that day's minutes — never a future minute (the **causality** the whole
+    feed depends on). The **last (still-forming) day is dropped** whenever the
+    source's latest minute does not reach that day's final minute boundary, so a
+    partial day never enters the cross-section; a day whose source data runs to
+    its end is kept. Only the OHLCV columns are aggregated — every price stays the
+    *exact* :class:`~decimal.Decimal`-friendly value dccd reported (no ``float``
+    coercion); only the ``time``/``TS`` math is integer/datetime.
+
+    A read whose ``span`` is **not** the ``daily_span`` is forwarded to the
+    wrapped client unchanged (so the same adapter can serve a mixed config). The
+    adapter is **injectable**: the offline tests pass a fake *daily* client
+    directly and never need it; a live portfolio reading a 1m store wraps its real
+    client in this.
+
+    Parameters
+    ----------
+    inner : DccdClient
+        The wrapped real (or fake) client read at ``source_span``.
+    daily_span : int, optional
+        The coarse span (seconds) a ``read`` for which triggers resampling.
+        Defaults to ``86400`` (one day). A read at any other span is passed
+        through to ``inner`` unchanged.
+    source_span : int, optional
+        The fine span (seconds) the wrapped client is read at and aggregated up
+        from. Defaults to ``60`` (one minute). Must be ``> 0`` and ``<
+        daily_span``.
+    every : str, optional
+        The polars ``group_by_dynamic`` bucket width. Defaults to ``"1d"``
+        (matching the daily ``daily_span``). Override only to resample to a
+        different coarse bar.
+
+    Raises
+    ------
+    ValueError
+        If ``source_span`` is not a positive value strictly smaller than
+        ``daily_span``.
+
+    """
+
+    def __init__(
+        self,
+        inner: DccdClient,
+        *,
+        daily_span: int = 86_400,
+        source_span: int = 60,
+        every: str = "1d",
+    ) -> None:
+        if source_span <= 0:
+            raise ValueError(
+                f"source_span must be positive seconds, got {source_span}"
+            )
+        if source_span >= daily_span:
+            raise ValueError(
+                f"source_span ({source_span}) must be finer than daily_span "
+                f"({daily_span}) to resample up"
+            )
+        self._inner = inner
+        self._daily_span = daily_span
+        self._source_span = source_span
+        self._every = every
+
+    def read(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+    ) -> pl.DataFrame:
+        """Read bars, resampling source→daily when ``span`` is the daily span.
+
+        For ``span == daily_span`` the wrapped client is read at
+        ``source_span`` (forwarding the same ``exchange`` / ``symbol`` /
+        ``data_type`` / ``start_ns`` / ``end_ns`` bounds) and the result is
+        aggregated to daily via :meth:`_resample`. Any other ``span`` is passed
+        straight through to the wrapped client.
+        """
+        if span != self._daily_span:
+            return self._inner.read(
+                exchange, symbol, data_type, span, start_ns, end_ns
+            )
+        raw = self._inner.read(
+            exchange, symbol, data_type, self._source_span, start_ns, end_ns
+        )
+        return self._resample(raw)
+
+    def backfill(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start: str = "last",
+    ) -> object:
+        """Forward a backfill to the wrapped client at the **source** span.
+
+        Backfilling collects the *stored* (fine) bars the resample reads from, so
+        a daily-span backfill request is driven at ``source_span``; any other
+        span is forwarded unchanged.
+        """
+        drive_span = self._source_span if span == self._daily_span else span
+        return self._inner.backfill(exchange, symbol, data_type, drive_span, start)
+
+    def _resample(self, raw: pl.DataFrame) -> pl.DataFrame:
+        """Aggregate fine ``raw`` OHLCV bars up to the coarse bar (causal).
+
+        Groups the source frame by calendar day (``group_by_dynamic`` over a
+        ``time`` derived from ``TS``), taking ``open=first, high=max, low=min,
+        close=last, volume=sum`` over each day's minutes — left-closed /
+        left-labelled so a day's bar is stamped at the day's open and aggregates
+        only that day's minutes (never a future one). The still-forming last day
+        (whose source minutes do not reach the next day boundary) is dropped, so
+        no partial day enters the result. Returns a dccd-shaped OHLC frame (the
+        same column set the source had), sorted oldest→newest. An empty source
+        yields an empty (but correctly-shaped) frame.
+
+        OHLC prices are carried through polars' aggregation without any ``float``
+        coercion — whatever exact value dccd stored is what comes out.
+        """
+        if raw.height == 0:
+            return raw
+
+        every_ns = self._daily_span * 1_000_000_000
+        daily = (
+            raw.with_columns(pl.from_epoch("TS", time_unit="ns").alias("dt"))
+            .group_by_dynamic("dt", every=self._every, closed="left", label="left")
+            .agg(
+                pl.col("open").first(),
+                pl.col("high").max(),
+                pl.col("low").min(),
+                pl.col("close").last(),
+                pl.col("volume").sum(),
+            )
+            .sort("dt")
+            .with_columns(pl.col("dt").dt.timestamp("ns").alias("TS"))
+        )
+
+        # Drop the still-forming last day: keep a day only when the source data
+        # reaches at least its closing boundary (its last source minute is at or
+        # beyond the next day's open). This keeps the cross-section to *closed*
+        # days only — a partial last day is never emitted (causality).
+        # newest source minute's open time (raw is non-empty here)
+        last_ts = int(raw["TS"].max())  # type: ignore[arg-type]
+        daily = daily.filter(
+            (pl.col("TS") + every_ns - self._source_span * 1_000_000_000) <= last_ts
+        )
+
+        # Re-attach the dccd OHLC columns the source carried but we did not
+        # aggregate (quote_volume / trades), zero-filled, so the result keeps the
+        # source schema the normaliser expects. Only ever present if the source
+        # had them.
+        extras: list[pl.Expr] = []
+        if "quote_volume" in raw.columns:
+            extras.append(pl.lit(0.0).alias("quote_volume"))
+        if "trades" in raw.columns:
+            extras.append(pl.lit(0).alias("trades"))
+        if extras:
+            daily = daily.with_columns(extras)
+
+        keep = [c for c in _OHLC_COLS if c in daily.columns]
+        return daily.select(keep)
 
 
 def _resolve_start_ns(start: str | int | None) -> int | None:

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -69,12 +69,18 @@ own (the runners' router/broker and the feed's client do).
 from __future__ import annotations
 
 import itertools
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Mapping
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from trading_bot.application.data_provider import feed_for
 from trading_bot.application.orchestrator import Orchestrator
+from trading_bot.application.portfolio import (
+    PortfolioStrategy,
+    load_portfolio_signal,
+)
+from trading_bot.application.portfolio_feed import PortfolioFeed
+from trading_bot.application.portfolio_runner import PortfolioRunner
 from trading_bot.application.service_factory import Engine, build_engine
 from trading_bot.application.strategy import (
     SignalFn,
@@ -85,13 +91,16 @@ from trading_bot.application.strategy import (
 from trading_bot.application.strategy_runner import StrategyRunner
 from trading_bot.domain.errors import ConfigError
 from trading_bot.domain.instrument import Instrument, Symbol, parse_kraken_pair
-from trading_bot.domain.money import Money, from_float
+from trading_bot.domain.money import Money, from_float, money
 from trading_bot.domain.order import Order, OrderSide, OrderType
 
 if TYPE_CHECKING:
     import polars as pl
 
-    from trading_bot.application.config import AppConfig, StrategyConfig
+    from trading_bot.application.config import (
+        AppConfig,
+        StrategyConfig,
+    )
     from trading_bot.application.data_feed import DataFeed
     from trading_bot.application.data_provider import DccdClient
     from trading_bot.domain.position import Position
@@ -99,7 +108,10 @@ if TYPE_CHECKING:
 __all__ = [
     "RunReport",
     "StrategyReport",
+    "PortfolioReport",
+    "PortfolioCoinReport",
     "build_runners",
+    "build_portfolio_runners",
     "run_app",
 ]
 
@@ -137,6 +149,32 @@ class _CappedFeed:
         return self._inner.latest()
 
 
+class _CappedPortfolioFeed:
+    """A portfolio feed capped to ``max_steps`` causal cross-sections.
+
+    The multi-coin analogue of :class:`_CappedFeed`: wraps a
+    :class:`~trading_bot.application.portfolio_feed.PortfolioFeed` and yields at
+    most ``max_steps`` of its causal per-coin cross-sections, so :func:`run_app`'s
+    ``max_steps`` bounds a :class:`PortfolioRunner` uniformly while it still runs
+    through the orchestrator (which calls ``run`` without a per-runner cap). The
+    wrapped feed's causality is preserved — capping only shortens the prefix
+    sequence. ``asof_ms`` is delegated so the runner's timestamp resolution is
+    unchanged.
+    """
+
+    def __init__(self, inner: PortfolioFeed, max_steps: int) -> None:
+        self._inner = inner
+        self._max_steps = max_steps
+
+    def __iter__(self) -> Iterator[Mapping[Symbol, pl.DataFrame]]:
+        """Yield at most ``max_steps`` causal cross-sections from the wrapped feed."""
+        return itertools.islice(iter(self._inner), self._max_steps)
+
+    def asof_ms(self) -> int | None:
+        """Delegate to the wrapped feed (the latest common date's close, ms)."""
+        return self._inner.asof_ms()
+
+
 @dataclass(frozen=True, slots=True)
 class StrategyReport:
     """One strategy's outcome after a :func:`run_app` run.
@@ -162,34 +200,91 @@ class StrategyReport:
 
 
 @dataclass(frozen=True, slots=True)
+class PortfolioCoinReport:
+    """One coin's outcome within a portfolio after a :func:`run_app` run.
+
+    Attributes
+    ----------
+    instrument : Instrument
+        The coin's instrument (one of the portfolio's universe).
+    position : Position or None
+        The coin's final net position read from the **shared** tracker, or
+        ``None`` if it never filled (no fill for its instrument). The portfolio
+        owns this instrument exclusively (the overlap guard ensures no other
+        runner touches it), so the shared per-instrument position *is* this
+        portfolio coin's position.
+
+    """
+
+    instrument: Instrument
+    position: Position | None
+
+
+@dataclass(frozen=True, slots=True)
+class PortfolioReport:
+    """One portfolio strategy's outcome after a :func:`run_app` run.
+
+    The multi-asset analogue of :class:`StrategyReport`: where a strategy reports
+    one instrument's position, a portfolio reports a per-coin breakdown across its
+    whole universe plus the count of legs its
+    :class:`~trading_bot.application.portfolio_runner.PortfolioRunner` submitted.
+
+    Attributes
+    ----------
+    name : str
+        The portfolio's logical id (its config ``name``).
+    orders_submitted : int
+        Total legs the portfolio's runner submitted across every rebalance
+        (summed over ticks; on-target / refused legs are not counted).
+    coins : list of PortfolioCoinReport
+        One :class:`PortfolioCoinReport` per coin in the portfolio's universe, in
+        universe order — each coin's final position read from the shared tracker.
+
+    """
+
+    name: str
+    orders_submitted: int
+    coins: list[PortfolioCoinReport] = field(default_factory=list)
+
+
+@dataclass(frozen=True, slots=True)
 class RunReport:
     """The summary of a whole-system :func:`run_app` run.
 
     A small, presentation-agnostic record the CLI (or a test) reads to print a
-    per-strategy summary and the aggregate PnL. Money stays exact
+    per-strategy / per-portfolio summary and the aggregate PnL. Money stays exact
     :class:`~decimal.Decimal` (``realised_pnl`` / ``fees_paid``).
 
     Attributes
     ----------
     strategies : list of StrategyReport
-        One :class:`StrategyReport` per declared strategy, in config order.
+        One :class:`StrategyReport` per declared single-instrument strategy, in
+        config order.
+    portfolios : list of PortfolioReport
+        One :class:`PortfolioReport` per declared portfolio strategy, in config
+        order (each with its per-coin breakdown). Empty when no portfolio is
+        declared.
     realised_pnl : Money
-        Aggregate realised PnL across all strategies (net of fees), read from the
-        engine's :class:`~trading_bot.application.performance_service.
-        PerformanceService` — the fill-driven source of truth.
+        Aggregate realised PnL across all strategies *and* portfolios (net of
+        fees), read from the engine's
+        :class:`~trading_bot.application.performance_service.PerformanceService` —
+        the fill-driven source of truth.
     fees_paid : Money
-        Aggregate fees paid across all strategies.
+        Aggregate fees paid across all strategies and portfolios.
 
     """
 
     strategies: list[StrategyReport] = field(default_factory=list)
+    portfolios: list[PortfolioReport] = field(default_factory=list)
     realised_pnl: Money = field(default_factory=lambda: from_float(0.0))
     fees_paid: Money = field(default_factory=lambda: from_float(0.0))
 
     @property
     def total_orders(self) -> int:
-        """Total orders submitted across every strategy."""
-        return sum(s.orders_submitted for s in self.strategies)
+        """Total orders submitted across every strategy **and** portfolio."""
+        return sum(s.orders_submitted for s in self.strategies) + sum(
+            p.orders_submitted for p in self.portfolios
+        )
 
 
 def _resolve_signal_fn(
@@ -289,20 +384,45 @@ def _reject_commingled(config: AppConfig) -> None:
     The real fix — a **per-strategy book** that attributes fills back to the
     strategy that originated them — is deferred future work; until it lands,
     one-instrument-per-strategy is the invariant this guard enforces.
+
+    Portfolios are folded into the **same** claim map (a portfolio *owns* its N
+    instruments): no instrument may be claimed by both a single-instrument
+    strategy and a portfolio, nor by two portfolios — the same shared
+    per-instrument tracker, the same attribution problem. See
+    :func:`_claimed_symbols`.
     """
     seen: dict[Symbol, str] = {}
-    for strategy_cfg in config.strategies:
-        symbol = parse_kraken_pair(strategy_cfg.symbol)
+    for symbol, owner in _claimed_symbols(config):
         previous = seen.get(symbol)
         if previous is not None:
             raise ConfigError(
-                f"strategies {previous!r} and {strategy_cfg.name!r} both trade "
-                f"the same instrument {strategy_cfg.symbol!r}: the shared "
-                "per-instrument tracker/performance view would commingle them "
-                "(no per-strategy attribution today). Give each strategy a "
-                "distinct instrument, or run them as separate systems."
+                f"{previous!r} and {owner} both claim the same instrument "
+                f"{symbol!s}: the shared per-instrument tracker/performance view "
+                "would commingle them (no per-strategy attribution today). Give "
+                "each a distinct instrument, or run them as separate systems."
             )
-        seen[symbol] = strategy_cfg.name
+        seen[symbol] = owner
+
+
+def _claimed_symbols(config: AppConfig) -> Iterator[tuple[Symbol, str]]:
+    """Yield ``(Symbol, owner-label)`` for every instrument the config claims.
+
+    Walks the single-instrument strategies (one symbol each) **and** the
+    portfolios (their whole universe), in config order, normalising each pair to
+    its canonical :class:`~trading_bot.domain.instrument.Symbol` (so two spellings
+    of the same pair collide). The owner label names the claimant for a clear
+    error — ``"strategy 'btc-ma'"`` or ``"portfolio 'ls1' (coin 'BTC/USDT')"`` —
+    so :func:`_reject_commingled` can report exactly who overlaps whom across the
+    whole system (strategy↔strategy, strategy↔portfolio, portfolio↔portfolio).
+    """
+    for strategy_cfg in config.strategies:
+        yield parse_kraken_pair(strategy_cfg.symbol), f"strategy {strategy_cfg.name!r}"
+    for portfolio_cfg in config.portfolios:
+        for raw in portfolio_cfg.universe:
+            yield (
+                parse_kraken_pair(raw),
+                f"portfolio {portfolio_cfg.name!r} (coin {raw!r})",
+            )
 
 
 def build_runners(
@@ -404,6 +524,115 @@ def build_runners(
     return runners
 
 
+def build_portfolio_runners(
+    config: AppConfig,
+    engine: Engine,
+    *,
+    dccd_client: DccdClient | None = None,
+    max_steps: int | None = None,
+) -> list[PortfolioRunner]:
+    """Build one :class:`PortfolioRunner` per declared portfolio, over ``engine``.
+
+    For each :class:`~trading_bot.application.config.PortfolioStrategyConfig` in
+    ``config.portfolios`` this resolves the weight-vector signal
+    (:func:`~trading_bot.application.portfolio.load_portfolio_signal` — a
+    ``"module:function"`` ref), builds a
+    :class:`~trading_bot.application.portfolio_feed.PortfolioFeed` over the
+    declared ``universe`` from the portfolio's ``data`` source, assembles a
+    :class:`~trading_bot.application.portfolio.PortfolioStrategy` (carrying the
+    config's ``capital`` / ``gross_cap``), and wraps it in a runner over the
+    engine's **shared** router / tracker / event bus.
+
+    The dccd ``client`` is threaded into every :class:`PortfolioFeed` so the build
+    is offline-testable. A daily portfolio reading a 1-minute store should inject
+    a :class:`~trading_bot.application.data_provider.ResamplingDccdClient` here
+    (the live daily-bars seam — dccd's store serves 1m, not daily); the offline
+    tests inject a fake *daily* client directly and need no resampling.
+
+    Parameters
+    ----------
+    config : AppConfig
+        The validated system configuration; its ``portfolios`` drive the build.
+    engine : Engine
+        The wired engine whose ``router`` / ``tracker`` / ``bus`` every runner
+        shares.
+    dccd_client : DccdClient or None, optional
+        The dccd client each :class:`PortfolioFeed` reads through. ``None``
+        (default) lets the feed lazily construct a real client; injecting a fake
+        (or a :class:`ResamplingDccdClient` wrapping one) keeps the build offline /
+        serves daily bars off a 1m store.
+    max_steps : int or None, optional
+        Cap each runner at this many rebalance ticks (passed to
+        :meth:`PortfolioRunner.run` by the orchestrating caller — recorded here so
+        the signature mirrors :func:`build_runners`; the cap is applied at run
+        time, not by wrapping the feed). ``None`` (default) drains every feed.
+
+    Returns
+    -------
+    list of PortfolioRunner
+        One runner per declared portfolio, in config order.
+
+    Raises
+    ------
+    ConfigError
+        If a portfolio's signal cannot be resolved (bad ``"module:function"``
+        ref), or — via :func:`_reject_commingled`, called by the system entrypoint
+        — if any instrument is claimed by two runners.
+
+    """
+    runners: list[PortfolioRunner] = []
+    for portfolio_cfg in config.portfolios:
+        signal_fn = load_portfolio_signal(portfolio_cfg.signal.ref)
+
+        universe = tuple(parse_kraken_pair(raw) for raw in portfolio_cfg.universe)
+        gross_cap = (
+            None if portfolio_cfg.gross_cap is None else money(portfolio_cfg.gross_cap)
+        )
+        strategy = PortfolioStrategy(
+            name=portfolio_cfg.name,
+            universe=universe,
+            signal_fn=signal_fn,
+            capital=money(portfolio_cfg.capital),
+            gross_cap=gross_cap,
+        )
+
+        data = portfolio_cfg.data
+        feed = PortfolioFeed(
+            universe,
+            exchange=data.exchange,
+            client=dccd_client,
+            span=data.span,
+            start_ns=_portfolio_start_ns(data.start),
+            data_type=data.data_type,
+            data_path=config.storage.data_path,
+        )
+        capped: object = (
+            feed if max_steps is None else _CappedPortfolioFeed(feed, max_steps)
+        )
+
+        runner = PortfolioRunner(
+            strategy,
+            capped,
+            engine.router,
+            engine.tracker,
+            event_bus=engine.bus,
+        )
+        runners.append(runner)
+    return runners
+
+
+def _portfolio_start_ns(start: str | int | None) -> int | None:
+    """Map a portfolio data source ``start`` to an epoch-ns bound.
+
+    Reuses :func:`~trading_bot.application.data_provider._resolve_start_ns` (the
+    single, audited ``start`` → ``start_ns`` parser) so a portfolio's history
+    start is interpreted identically to a single-instrument strategy's.
+    """
+    from trading_bot.application.data_provider import _resolve_start_ns
+
+    return _resolve_start_ns(start)
+
+
 async def run_app(
     config: AppConfig,
     *,
@@ -415,47 +644,64 @@ async def run_app(
     The triptych entrypoint: assemble the engine
     (:func:`~trading_bot.application.service_factory.build_engine`,
     paper-by-default — the factory enforces it), build a runner per declared
-    strategy (:func:`build_runners`), and run them all **concurrently** through a
-    fresh :class:`~trading_bot.application.orchestrator.Orchestrator`. After the
-    run, build a :class:`RunReport` from the per-runner order counts and the
-    engine's shared tracker / performance service (fills are the PnL source of
-    truth).
+    single-instrument strategy (:func:`build_runners`) **and** per declared
+    portfolio (:func:`build_portfolio_runners`), reject any instrument claimed by
+    two runners (:func:`_reject_commingled`, spanning strategies *and*
+    portfolios), and run them all **concurrently** through a fresh
+    :class:`~trading_bot.application.orchestrator.Orchestrator`. After the run,
+    build a :class:`RunReport` from the per-runner order counts and the engine's
+    shared tracker / performance service (fills are the PnL source of truth).
 
     Parameters
     ----------
     config : AppConfig
-        The validated system configuration (mode, brokers, strategies, risk,
-        storage). The store is created at ``config.storage.db_path`` when set.
+        The validated system configuration (mode, brokers, strategies,
+        portfolios, risk, storage). The store is created at
+        ``config.storage.db_path`` when set.
     dccd_client : DccdClient or None, optional
-        The dccd client every strategy's feed reads through (injected for an
-        offline run). ``None`` (default) lets each feed construct a real client.
+        The dccd client every strategy's / portfolio's feed reads through
+        (injected for an offline run). ``None`` (default) lets each feed construct
+        a real client. A daily portfolio reading a 1-minute store should inject a
+        :class:`~trading_bot.application.data_provider.ResamplingDccdClient`.
     max_steps : int or None, optional
-        Cap each runner at this many feed windows (bounds an otherwise
-        feed-length run; useful for tests / live feeds). ``None`` (default)
-        drains every feed to exhaustion.
+        Cap each runner at this many feed windows / rebalance ticks (bounds an
+        otherwise feed-length run; useful for tests / live feeds). ``None``
+        (default) drains every feed to exhaustion.
 
     Returns
     -------
     RunReport
-        Per-strategy order counts + final positions, and the aggregate realised
-        PnL / fees from the engine's performance service.
+        Per-strategy order counts + final positions, per-portfolio per-coin
+        breakdowns, and the aggregate realised PnL / fees from the engine's
+        performance service.
 
     Raises
     ------
     ConfigError
-        If any strategy is misdeclared (no signal/data, unknown builtin, ...).
+        If any strategy/portfolio is misdeclared (no signal/data, unknown
+        builtin, unresolvable portfolio signal), or any instrument is claimed by
+        two runners (strategy↔strategy, strategy↔portfolio, portfolio↔portfolio).
     BrokerError
         In live mode if the configured venue lacks credentials (the factory
         refuses — never falling back to paper).
 
     """
     engine = build_engine(config, db_path=config.storage.db_path)
+    # Reject any instrument claimed by two runners up front — across both the
+    # single-instrument strategies and the portfolios (the shared per-instrument
+    # tracker has no attribution). build_runners also calls this for the
+    # strategy-only path; calling it here covers the cross-portfolio overlaps too.
+    _reject_commingled(config)
     runners = build_runners(
+        config, engine, dccd_client=dccd_client, max_steps=max_steps
+    )
+    portfolio_runners = build_portfolio_runners(
         config, engine, dccd_client=dccd_client, max_steps=max_steps
     )
 
     orchestrator = Orchestrator(event_bus=engine.bus)
     orchestrator.add_all(runners)
+    orchestrator.add_all(portfolio_runners)  # type: ignore[arg-type]
     results = await orchestrator.run()
 
     strategies: list[StrategyReport] = []
@@ -470,8 +716,32 @@ async def run_app(
             )
         )
 
+    # The orchestrator keys its results by the runner objects it ran (both the
+    # StrategyRunners and the PortfolioRunners added via add_all); its return type
+    # is annotated for the single-instrument runner, so view it as a plain object
+    # map to look up the portfolio runners.
+    results_by_runner = cast("dict[object, int]", results)
+    portfolios: list[PortfolioReport] = []
+    for prunner in portfolio_runners:
+        pstrat = prunner.strategy
+        coins = [
+            PortfolioCoinReport(
+                instrument=Instrument(symbol),
+                position=engine.tracker.position(Instrument(symbol)),
+            )
+            for symbol in pstrat.universe
+        ]
+        portfolios.append(
+            PortfolioReport(
+                name=pstrat.name,
+                orders_submitted=results_by_runner.get(prunner, 0),
+                coins=coins,
+            )
+        )
+
     return RunReport(
         strategies=strategies,
+        portfolios=portfolios,
         realised_pnl=engine.perf.realised_pnl(),
         fees_paid=engine.perf.fees_paid(),
     )

--- a/trading_bot/tests/application/test_portfolio_config.py
+++ b/trading_bot/tests/application/test_portfolio_config.py
@@ -1,0 +1,772 @@
+"""Tests for portfolio config + its wiring into :func:`run_app` (leaf 04).
+
+These prove a **portfolio strategy** is declarable in
+:class:`~trading_bot.application.config.AppConfig` and runnable through
+:func:`~trading_bot.application.run_app.run_app`, alongside the single-instrument
+strategies, fully **offline** — a fake *daily* dccd client serving canned bars
+per coin, the in-repo fake portfolio signal
+(:func:`trading_bot.tests.fixtures.fake_book.fixed_weights`), and the default
+:class:`~trading_bot.brokers.paper.PaperBroker` (the engine's real data path).
+
+What is verified
+----------------
+* **config validators** — a valid ``portfolios:`` entry validates; an empty
+  universe, a duplicate coin in a universe, and a non-positive capital are
+  rejected;
+* **offline end-to-end through run_app** — the per-coin routed orders and final
+  shared-tracker positions match the intended ``weight × capital / price`` target
+  read back from the broker-confirmed fills (the PnL source of truth);
+* **overlap detection** — a portfolio universe sharing a coin with a
+  single-instrument strategy, or with another portfolio, is a clear
+  :class:`~trading_bot.domain.errors.ConfigError`;
+* **backward compat** — a config with no ``portfolios:`` runs exactly as before;
+* **the resample-on-read adapter**
+  (:class:`~trading_bot.application.data_provider.ResamplingDccdClient`) — canned
+  1-minute bars aggregate to causal, OHLCV-correct daily bars (and a real-store
+  ``-m network`` check).
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import polars as pl
+import pytest
+from pydantic import ValidationError
+
+from trading_bot.application.config import AppConfig, PortfolioStrategyConfig
+from trading_bot.application.data_provider import ResamplingDccdClient
+from trading_bot.application.run_app import (
+    PortfolioCoinReport,
+    PortfolioReport,
+    RunReport,
+    build_portfolio_runners,
+    run_app,
+)
+from trading_bot.application.service_factory import build_engine
+from trading_bot.domain.errors import ConfigError
+from trading_bot.domain.fill import Fill
+from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.money import money
+from trading_bot.domain.position import Position
+from trading_bot.tests.fixtures import fake_book
+
+BTC = Symbol("BTC", "USDT")
+ETH = Symbol("ETH", "USDT")
+BTC_USDT = Instrument(BTC)
+ETH_USDT = Instrument(ETH)
+
+_FAKE_SIGNAL = "trading_bot.tests.fixtures.fake_book:fixed_weights"
+
+# --- canned daily bars + a fake daily dccd client -------------------------- #
+
+_DAY_NS = 86_400 * 1_000_000_000
+
+
+def _dccd_ohlc(closes: list[float], *, start_ns: int = 0) -> pl.DataFrame:
+    """A canned **daily** dccd OHLC frame (dccd's column names) from closes.
+
+    Mirrors what a daily dccd ``read`` would return: ``TS`` (ns) one day apart,
+    plus open/high/low/close/volume + the dropped quote_volume/trades. The fake
+    portfolio signal ignores the bars, but the runner reads each coin's latest
+    *close* to size + price its leg, so the closes are what matter.
+    """
+    n = len(closes)
+    return pl.DataFrame(
+        {
+            "TS": [start_ns + _DAY_NS * i for i in range(n)],
+            "open": closes,
+            "high": [c + 1.0 for c in closes],
+            "low": [c - 1.0 for c in closes],
+            "close": closes,
+            "volume": [1.0] * n,
+            "quote_volume": [10.0] * n,
+            "trades": [5] * n,
+        }
+    )
+
+
+class _FakeDailyDccdClient:
+    """A canned daily dccd client keyed by the venue pair string.
+
+    The :class:`~trading_bot.application.portfolio_feed.PortfolioFeed` reads each
+    coin via ``client.read(exchange, venue_pair, ...)``; this fake returns the
+    canned frame for that pair (honouring an ``end_ns`` cutoff) and records the
+    calls. No real dccd / network — it satisfies the
+    :class:`~trading_bot.application.data_provider.DccdClient` protocol
+    structurally. It already serves **daily** bars, so no resampling is needed
+    (the injectable seam: offline tests bypass ``ResamplingDccdClient``).
+    """
+
+    def __init__(self, frames: dict[str, pl.DataFrame]) -> None:
+        self._frames = frames
+        self.reads: list[tuple[str, str, int | None]] = []
+
+    def read(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+    ) -> pl.DataFrame:
+        self.reads.append((exchange, symbol, span))
+        frame = self._frames[symbol]
+        if end_ns is not None:
+            frame = frame.filter(pl.col("TS") <= end_ns)
+        return frame
+
+    def backfill(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start: str = "last",
+    ) -> None:  # pragma: no cover - not exercised (backfill=False)
+        return None
+
+
+def _daily_client(closes_by_pair: dict[str, list[float]]) -> _FakeDailyDccdClient:
+    """A fake daily client serving each venue pair a constant-ish daily series."""
+    return _FakeDailyDccdClient(
+        {pair: _dccd_ohlc(closes) for pair, closes in closes_by_pair.items()}
+    )
+
+
+def _one_portfolio_config(
+    *,
+    universe: list[str] | None = None,
+    capital: str = "100000",
+    extra_strategies: list[dict] | None = None,
+    extra_portfolios: list[dict] | None = None,
+) -> AppConfig:
+    """A paper config with one portfolio (the fake signal, BTC+ETH/USDT, daily)."""
+    portfolio = {
+        "name": "fake-pf",
+        "universe": universe if universe is not None else ["BTC/USDT", "ETH/USDT"],
+        "signal": {"ref": _FAKE_SIGNAL},
+        "capital": capital,
+        "data": {"exchange": "binance", "span": 86400},
+    }
+    return AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "strategies": extra_strategies or [],
+            "portfolios": [portfolio, *(extra_portfolios or [])],
+        }
+    )
+
+
+# --- config validators ----------------------------------------------------- #
+
+
+def test_valid_portfolio_config_validates() -> None:
+    """A well-formed portfolio entry validates with exact-Decimal money."""
+    cfg = _one_portfolio_config(capital="100000")
+    assert len(cfg.portfolios) == 1
+    pf = cfg.portfolios[0]
+    assert isinstance(pf, PortfolioStrategyConfig)
+    assert pf.name == "fake-pf"
+    assert pf.universe == ["BTC/USDT", "ETH/USDT"]
+    assert pf.signal.ref == _FAKE_SIGNAL
+    # Capital parses exactly from the YAML scalar — Decimal, never float.
+    assert pf.capital == Decimal("100000")
+    assert isinstance(pf.capital, Decimal)
+    assert pf.data.span == 86400
+    assert pf.venue == "binance"
+    assert pf.gross_cap is None
+
+
+def test_capital_is_exact_decimal_from_scalar() -> None:
+    """A fractional capital keeps its exact decimal meaning (no float drift)."""
+    cfg = _one_portfolio_config(capital="100000.10")
+    assert cfg.portfolios[0].capital == Decimal("100000.10")
+
+
+def test_empty_universe_rejected() -> None:
+    """An empty universe is a validation error."""
+    with pytest.raises(ValidationError, match="non-empty"):
+        _one_portfolio_config(universe=[])
+
+
+def test_duplicate_coin_in_universe_rejected() -> None:
+    """A duplicate coin within a universe is rejected (even by alias spelling)."""
+    with pytest.raises(ValidationError, match="duplicate instrument"):
+        _one_portfolio_config(universe=["BTC/USDT", "BTC/USDT"])
+
+
+def test_duplicate_coin_by_alias_in_universe_rejected() -> None:
+    """Two spellings of the same coin (BTC vs XBT) collide as a duplicate."""
+    with pytest.raises(ValidationError, match="duplicate instrument"):
+        _one_portfolio_config(universe=["BTC/USDT", "XBT/USDT"])
+
+
+def test_non_positive_capital_rejected() -> None:
+    """A zero / negative capital is rejected."""
+    with pytest.raises(ValidationError, match="capital must be positive"):
+        _one_portfolio_config(capital="0")
+    with pytest.raises(ValidationError, match="capital must be positive"):
+        _one_portfolio_config(capital="-5")
+
+
+def test_non_positive_gross_cap_rejected() -> None:
+    """A non-positive gross_cap is rejected (None is allowed)."""
+    with pytest.raises(ValidationError, match="gross_cap must be positive"):
+        AppConfig.model_validate(
+            {
+                "portfolios": [
+                    {
+                        "name": "p",
+                        "universe": ["BTC/USDT"],
+                        "signal": {"ref": _FAKE_SIGNAL},
+                        "capital": "1000",
+                        "data": {"exchange": "binance", "span": 86400},
+                        "gross_cap": "0",
+                    }
+                ]
+            }
+        )
+
+
+def test_unparseable_universe_pair_rejected() -> None:
+    """A malformed pair string in the universe is caught at config time."""
+    with pytest.raises(ValidationError, match="not a valid pair"):
+        _one_portfolio_config(universe=["NOTAPAIR"])
+
+
+def test_gross_cap_carried_onto_strategy() -> None:
+    """A declared gross_cap reaches the built PortfolioStrategy (exact Decimal)."""
+    cfg = AppConfig.model_validate(
+        {
+            "portfolios": [
+                {
+                    "name": "p",
+                    "universe": ["BTC/USDT", "ETH/USDT"],
+                    "signal": {"ref": _FAKE_SIGNAL},
+                    "capital": "100000",
+                    "data": {"exchange": "binance", "span": 86400},
+                    "gross_cap": "1.5",
+                }
+            ]
+        }
+    )
+    engine = build_engine(cfg, db_path=None)
+    client = _daily_client({"BTCUSDT": [50000.0], "ETHUSDT": [2500.0]})
+    runners = build_portfolio_runners(cfg, engine, dccd_client=client)
+    assert runners[0].strategy.gross_cap == money("1.5")
+
+
+# --- backward compat ------------------------------------------------------- #
+
+
+def test_config_without_portfolios_defaults_empty() -> None:
+    """A config with no portfolios validates and has an empty portfolios list."""
+    cfg = AppConfig.model_validate({"strategies": []})
+    assert cfg.portfolios == []
+
+
+async def test_run_app_no_portfolios_unchanged() -> None:
+    """run_app over a portfolio-free config: report has no portfolios, runs fine."""
+    cfg = AppConfig()  # no strategies, no portfolios
+    report = await run_app(cfg)
+    assert isinstance(report, RunReport)
+    assert report.strategies == []
+    assert report.portfolios == []
+    assert report.total_orders == 0
+    assert report.realised_pnl == money("0")
+
+
+# --- offline end-to-end through run_app ------------------------------------ #
+
+
+async def test_run_app_portfolio_orders_match_intended_targets() -> None:
+    """run_app over one portfolio: per-coin orders/positions == weight×capital/price.
+
+    Verification on real data (offline): the fake signal returns a fixed weight
+    vector; with a flat constant price series the runner rebalances to the target
+    on the first tick and holds, so the final shared-tracker position per coin
+    must equal ``weight × capital / price``. That target is also recomputed
+    independently from the **broker-confirmed fills** (``Position.from_fills``),
+    the PnL source of truth.
+    """
+    # Constant closes == the fake_book reference prices, so target qty is exact:
+    #   BTC: +0.5 * 100000 / 50000 = +1.0 ; ETH: -0.25 * 100000 / 2500 = -10.0
+    btc_price, eth_price = 50000.0, 2500.0
+    n_days = 4
+    cfg = _one_portfolio_config(capital="100000")
+    client = _daily_client(
+        {
+            "BTCUSDT": [btc_price] * n_days,
+            "ETHUSDT": [eth_price] * n_days,
+        }
+    )
+
+    # Build the engine ourselves so we can read the broker's fills back.
+    engine = build_engine(cfg, db_path=None)
+    runners = build_portfolio_runners(cfg, engine, dccd_client=client)
+    assert len(runners) == 1
+
+    from trading_bot.application.orchestrator import Orchestrator
+
+    orch = Orchestrator(event_bus=engine.bus)
+    orch.add_all(runners)  # type: ignore[arg-type]
+    await orch.run()
+
+    # Intended targets (exact Decimal arithmetic, mirroring weights_to_signals).
+    intended = {
+        BTC_USDT: fake_book.WEIGHTS[BTC] * money("100000") / money(str(btc_price)),
+        ETH_USDT: fake_book.WEIGHTS[ETH] * money("100000") / money(str(eth_price)),
+    }
+    assert intended[BTC_USDT] == money("1")
+    assert intended[ETH_USDT] == money("-10")
+
+    # The shared tracker's final per-coin net position == the intended target.
+    for instrument, target in intended.items():
+        tracked = engine.tracker.position(instrument)
+        assert tracked is not None
+        assert tracked.net_qty == target
+
+    # And recomputed independently from the broker-confirmed fills.
+    fills = await engine.broker.fills()
+    assert fills, "the rebalance should have produced fills"
+    by_instrument: dict[Instrument, list[Fill]] = {}
+    for fill in fills:
+        by_instrument.setdefault(fill.instrument, []).append(fill)
+    for instrument, target in intended.items():
+        expected = Position.from_fills(by_instrument[instrument])
+        assert expected.net_qty == target
+        tracked = engine.tracker.position(instrument)
+        assert tracked is not None
+        assert tracked.net_qty == expected.net_qty
+        assert tracked.realised_pnl == expected.realised_pnl
+
+
+async def test_run_app_report_shape_per_portfolio() -> None:
+    """The RunReport carries a PortfolioReport per portfolio with per-coin coins."""
+    cfg = _one_portfolio_config(capital="100000")
+    client = _daily_client({"BTCUSDT": [50000.0] * 4, "ETHUSDT": [2500.0] * 4})
+
+    report = await run_app(cfg, dccd_client=client)
+
+    assert report.strategies == []
+    assert len(report.portfolios) == 1
+    pf = report.portfolios[0]
+    assert isinstance(pf, PortfolioReport)
+    assert pf.name == "fake-pf"
+    # Two legs (BTC long, ETH short) on the first rebalance; held after.
+    assert pf.orders_submitted == 2
+    assert report.total_orders == 2
+    # One coin report per universe member, in universe order, each with a position.
+    assert [c.instrument for c in pf.coins] == [BTC_USDT, ETH_USDT]
+    for coin in pf.coins:
+        assert isinstance(coin, PortfolioCoinReport)
+        assert coin.position is not None
+    assert pf.coins[0].position.net_qty == money("1")  # type: ignore[union-attr]
+    assert pf.coins[1].position.net_qty == money("-10")  # type: ignore[union-attr]
+
+
+async def test_run_app_portfolio_alongside_strategy() -> None:
+    """A portfolio runs alongside a single-instrument strategy (disjoint coins)."""
+    pytest.importorskip("fynance")  # ma_crossover evaluates fynance.sma
+    cfg = _one_portfolio_config(
+        extra_strategies=[
+            {
+                "name": "ltc-ma",
+                "symbol": "LTC/USDT",
+                "data": {"exchange": "binance", "span": 60},
+                "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                "reference_qty": "5",
+                "lookback": 6,
+            }
+        ]
+    )
+    # The portfolio reads BTC/ETH daily; the strategy reads LTC (single-coin feed
+    # keyed by the strategy's symbol string).
+    pf_client = _daily_client({"BTCUSDT": [50000.0] * 30, "ETHUSDT": [2500.0] * 30})
+    # Give the LTC strategy a trending series so it trades; one shared client must
+    # answer both the portfolio reads (BTCUSDT/ETHUSDT) and the strategy read
+    # (LTC/USDT — the raw symbol string feed_for passes).
+    ltc_trend = [100.0 + i for i in range(15)] + [115.0 - i for i in range(1, 16)]
+    pf_client._frames["LTC/USDT"] = _dccd_ohlc(ltc_trend)
+
+    report = await run_app(cfg, dccd_client=pf_client)
+
+    assert len(report.strategies) == 1
+    assert len(report.portfolios) == 1
+    assert report.strategies[0].name == "ltc-ma"
+    assert report.portfolios[0].name == "fake-pf"
+    # Both books traded, disjoint instruments.
+    assert report.portfolios[0].orders_submitted == 2
+    assert report.strategies[0].orders_submitted > 0
+
+
+async def test_run_app_max_steps_caps_portfolio() -> None:
+    """max_steps bounds the portfolio runner's rebalance ticks."""
+    cfg = _one_portfolio_config(capital="100000")
+    client = _daily_client({"BTCUSDT": [50000.0] * 10, "ETHUSDT": [2500.0] * 10})
+
+    # Cap at one tick: the first rebalance opens both legs, then we stop.
+    report = await run_app(cfg, dccd_client=client, max_steps=1)
+    assert report.portfolios[0].orders_submitted == 2
+
+    # Cap at zero ticks: nothing rebalances, no orders.
+    report0 = await run_app(cfg, dccd_client=client, max_steps=0)
+    assert report0.portfolios[0].orders_submitted == 0
+    for coin in report0.portfolios[0].coins:
+        assert coin.position is None
+
+
+# --- overlap detection ----------------------------------------------------- #
+
+
+def test_portfolio_overlaps_strategy_is_config_error() -> None:
+    """A portfolio coin shared with a single-instrument strategy → ConfigError."""
+    cfg = _one_portfolio_config(
+        extra_strategies=[
+            {
+                "name": "btc-ma",
+                "symbol": "BTC/USDT",  # already owned by the portfolio
+                "data": {"exchange": "binance", "span": 60},
+                "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+            }
+        ]
+    )
+    with pytest.raises(ConfigError) as exc_info:
+        # run_app rejects up front; assert via the sync overlap guard.
+        from trading_bot.application.run_app import _reject_commingled
+
+        _reject_commingled(cfg)
+
+    msg = str(exc_info.value)
+    assert "BTC/USDT" in msg
+    assert "btc-ma" in msg
+    assert "fake-pf" in msg
+    assert "commingle" in msg
+
+
+def test_two_portfolios_overlap_is_config_error() -> None:
+    """Two portfolios sharing a coin → ConfigError (same shared tracker)."""
+    cfg = _one_portfolio_config(
+        extra_portfolios=[
+            {
+                "name": "other-pf",
+                "universe": ["ETH/USDT", "LTC/USDT"],  # ETH overlaps fake-pf
+                "signal": {"ref": _FAKE_SIGNAL},
+                "capital": "50000",
+                "data": {"exchange": "binance", "span": 86400},
+            }
+        ]
+    )
+    from trading_bot.application.run_app import _reject_commingled
+
+    with pytest.raises(ConfigError, match="commingle") as exc_info:
+        _reject_commingled(cfg)
+    msg = str(exc_info.value)
+    assert "ETH/USDT" in msg
+    assert "fake-pf" in msg
+    assert "other-pf" in msg
+
+
+async def test_run_app_surfaces_portfolio_strategy_overlap() -> None:
+    """run_app surfaces a portfolio↔strategy overlap as a ConfigError."""
+    cfg = _one_portfolio_config(
+        extra_strategies=[
+            {
+                "name": "eth-ma",
+                "symbol": "ETH/USDT",  # owned by the portfolio
+                "data": {"exchange": "binance", "span": 60},
+                "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+            }
+        ]
+    )
+    with pytest.raises(ConfigError, match="commingle"):
+        await run_app(cfg, dccd_client=_FakeDailyDccdClient({}))
+
+
+def test_disjoint_portfolio_and_strategy_build_fine() -> None:
+    """Disjoint coins across a portfolio + strategy build without error."""
+    cfg = _one_portfolio_config(
+        extra_strategies=[
+            {
+                "name": "ltc-ma",
+                "symbol": "LTC/USDT",  # disjoint from BTC/ETH
+                "data": {"exchange": "binance", "span": 60},
+                "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+            }
+        ]
+    )
+    from trading_bot.application.run_app import _reject_commingled
+
+    _reject_commingled(cfg)  # does not raise
+
+
+# --- the resample-on-read adapter (canned) --------------------------------- #
+
+_MIN_NS = 60 * 1_000_000_000
+_DAY_MIN = 1440
+
+
+def _canned_1m(
+    days: list[dict[str, float]], *, partial_last_minutes: int = 0
+) -> pl.DataFrame:
+    """Build canned 1-minute dccd bars from a per-day OHLCV spec.
+
+    Each ``days`` entry is a full calendar day of 1m bars synthesised so its daily
+    aggregate is known: the day's first minute opens at ``open``, one minute hits
+    ``high``, one hits ``low``, the last minute closes at ``close``, and every
+    minute carries ``vol`` so the daily volume is ``1440 * vol``. An optional
+    ``partial_last_minutes`` appends a trailing *incomplete* day (which the
+    resampler must drop).
+    """
+    ts: list[int] = []
+    o: list[float] = []
+    h: list[float] = []
+    low: list[float] = []
+    c: list[float] = []
+    v: list[float] = []
+    minute = 0
+    for spec in days:
+        for m in range(_DAY_MIN):
+            ts.append(minute * _MIN_NS)
+            # open on first minute, close on last; high/low planted mid-day.
+            o.append(spec["open"] if m == 0 else spec["close"])
+            h.append(spec["high"] if m == 1 else spec["close"])
+            low.append(spec["low"] if m == 2 else spec["close"])
+            c.append(spec["close"])
+            v.append(spec["vol"])
+            minute += 1
+    for m in range(partial_last_minutes):
+        ts.append(minute * _MIN_NS)
+        o.append(999.0)
+        h.append(999.0)
+        low.append(999.0)
+        c.append(999.0)
+        v.append(7.0)
+        minute += 1
+    return pl.DataFrame(
+        {
+            "TS": ts,
+            "open": o,
+            "high": h,
+            "low": low,
+            "close": c,
+            "volume": v,
+            "quote_volume": [0.0] * len(ts),
+            "trades": [1] * len(ts),
+        }
+    )
+
+
+class _InnerFromFrame:
+    """A minimal dccd client returning a fixed 1m frame (honours end_ns)."""
+
+    def __init__(self, frame: pl.DataFrame) -> None:
+        self._frame = frame
+        self.span_seen: int | None = None
+
+    def read(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+    ) -> pl.DataFrame:
+        self.span_seen = span
+        frame = self._frame
+        if end_ns is not None:
+            frame = frame.filter(pl.col("TS") <= end_ns)
+        return frame
+
+    def backfill(self, *a: object, **k: object) -> None:  # pragma: no cover
+        return None
+
+
+def test_resample_daily_ohlcv_is_correct_and_causal() -> None:
+    """Canned 1m → daily: o=first, h=max, l=min, c=last, v=sum; partial day dropped."""
+    days = [
+        {"open": 100.0, "high": 110.0, "low": 90.0, "close": 105.0, "vol": 1.0},
+        {"open": 200.0, "high": 222.0, "low": 188.0, "close": 210.0, "vol": 2.0},
+    ]
+    # Two full days + a 3-minute partial third day (must be dropped).
+    frame = _canned_1m(days, partial_last_minutes=3)
+    inner = _InnerFromFrame(frame)
+    client = ResamplingDccdClient(inner)
+
+    daily = client.read("binance", "BTC-USDT", "ohlc", 86400)
+
+    # The adapter read the *source* (1m) span, not the daily span.
+    assert inner.span_seen == 60
+    # Only the two CLOSED days survive (the partial day is dropped — causality).
+    assert daily.height == 2
+    # OHLCV correctness per day.
+    assert daily["open"].to_list() == [100.0, 200.0]
+    assert daily["high"].to_list() == [110.0, 222.0]
+    assert daily["low"].to_list() == [90.0, 188.0]
+    assert daily["close"].to_list() == [105.0, 210.0]
+    assert daily["volume"].to_list() == [1440.0 * 1.0, 1440.0 * 2.0]
+    # Causal: each daily bar is stamped at the DAY'S OPEN (left-labelled), in ns.
+    assert daily["TS"].to_list() == [0, _DAY_NS]
+    # The dccd OHLC schema is preserved (so the normaliser downstream is happy).
+    assert set(daily.columns) >= {
+        "TS",
+        "open",
+        "high",
+        "low",
+        "close",
+        "volume",
+    }
+
+
+def test_resample_passes_through_non_daily_span() -> None:
+    """A read whose span != daily_span is forwarded unchanged (no resampling)."""
+    frame = _canned_1m(
+        [{"open": 1.0, "high": 2.0, "low": 0.5, "close": 1.5, "vol": 1.0}]
+    )
+    inner = _InnerFromFrame(frame)
+    client = ResamplingDccdClient(inner)
+
+    out = client.read("binance", "BTC-USDT", "ohlc", 60)  # the source span itself
+    assert inner.span_seen == 60
+    # Pass-through returns the raw 1m frame untouched (1440 rows, not aggregated).
+    assert out.height == _DAY_MIN
+
+
+def test_resample_keeps_last_day_when_complete() -> None:
+    """A final day whose 1m data reaches its end is KEPT (not dropped)."""
+    days = [
+        {"open": 100.0, "high": 110.0, "low": 90.0, "close": 105.0, "vol": 1.0},
+        {"open": 200.0, "high": 222.0, "low": 188.0, "close": 210.0, "vol": 2.0},
+    ]
+    frame = _canned_1m(days, partial_last_minutes=0)  # both days complete
+    client = ResamplingDccdClient(_InnerFromFrame(frame))
+    daily = client.read("binance", "BTC-USDT", "ohlc", 86400)
+    assert daily.height == 2  # both kept
+
+
+def test_resample_rejects_bad_source_span() -> None:
+    """source_span must be a positive value finer than daily_span."""
+    inner = _InnerFromFrame(pl.DataFrame())
+    with pytest.raises(ValueError, match="finer"):
+        ResamplingDccdClient(inner, daily_span=86400, source_span=86400)
+    with pytest.raises(ValueError, match="positive"):
+        ResamplingDccdClient(inner, source_span=0)
+
+
+def test_resample_empty_source_yields_empty() -> None:
+    """An empty source frame resamples to an empty (correctly-shaped) frame."""
+    empty = pl.DataFrame(
+        schema={
+            "TS": pl.Int64,
+            "open": pl.Float64,
+            "high": pl.Float64,
+            "low": pl.Float64,
+            "close": pl.Float64,
+            "volume": pl.Float64,
+            "quote_volume": pl.Float64,
+            "trades": pl.Int64,
+        }
+    )
+    client = ResamplingDccdClient(_InnerFromFrame(empty))
+    out = client.read("binance", "BTC-USDT", "ohlc", 86400)
+    assert out.height == 0
+
+
+# --- Verification on real data (opt-in) ------------------------------------ #
+
+
+@pytest.mark.network
+def test_resample_adapter_against_real_binance_1m_store() -> None:
+    """ResamplingDccdClient over the REAL dccd Binance 1m store: daily OHLC sanity.
+
+    Wraps an inner client that reads the real 1-minute parquet for one coin
+    (``BTC-USDT``, year 2024 — fully within the store so every day is closed),
+    resamples to daily via the adapter, and asserts the daily bar count + OHLC
+    sanity (h≥o≥l, h≥c≥l, v>0) and that the resampled daily aggregate matches an
+    **independent** ``group_by_dynamic`` aggregation of the same raw 1m bars
+    (mirroring ``fynance_research.data.load_ohlc``).
+
+    Skips with a clear how-to-sync reason when the store is absent (sync the alt
+    *-USDT 1m pairs via the dccd daemon — see ../fynance-research/DEPLOY_LS1.md
+    §3; they land at ~/data/arthurserver/binance/ohlc/<PAIR>/1m/).
+    """
+    from pathlib import Path
+
+    base = Path.home() / "data" / "arthurserver" / "binance" / "ohlc" / "BTC-USDT" / "1m"
+    files = sorted(base.glob("2024.parquet")) or sorted(base.glob("*.parquet"))
+    if not files:
+        pytest.skip(
+            "no dccd Binance 1m store for BTC-USDT at "
+            "~/data/arthurserver/binance/ohlc/BTC-USDT/1m; sync the *-USDT 1m "
+            "pairs via the dccd daemon (DEPLOY_LS1.md §3)"
+        )
+
+    raw = (
+        pl.concat([pl.read_parquet(f) for f in files])
+        .unique(subset="TS", keep="last")
+        .sort("TS")
+    )
+
+    class _Inner:
+        def read(
+            self,
+            exchange: str,
+            symbol: str,
+            data_type: str = "ohlc",
+            span: int | None = None,
+            start_ns: int | None = None,
+            end_ns: int | None = None,
+        ) -> pl.DataFrame:
+            frame = raw
+            if end_ns is not None:
+                frame = frame.filter(pl.col("TS") <= end_ns)
+            return frame
+
+        def backfill(self, *a: object, **k: object) -> None:  # pragma: no cover
+            return None
+
+    daily = ResamplingDccdClient(_Inner()).read("binance", "BTC-USDT", "ohlc", 86400)
+
+    # Independent reference aggregation (fynance_research-style).
+    ref = (
+        raw.with_columns(pl.from_epoch("TS", time_unit="ns").alias("dt"))
+        .group_by_dynamic("dt", every="1d", closed="left", label="left")
+        .agg(
+            pl.col("open").first(),
+            pl.col("high").max(),
+            pl.col("low").min(),
+            pl.col("close").last(),
+            pl.col("volume").sum(),
+        )
+        .sort("dt")
+    )
+
+    assert daily.height > 300, f"too few daily bars from real 1m: {daily.height}"
+    # Daily count matches the independent reference (or is at most one fewer — the
+    # adapter drops a still-forming final day the naive ref would keep).
+    assert ref.height - daily.height in (0, 1), (
+        f"resampled {daily.height} vs ref {ref.height} daily bars"
+    )
+
+    # OHLC sanity on every resampled daily bar.
+    sane = daily.filter(
+        (pl.col("high") >= pl.col("open"))
+        & (pl.col("open") >= pl.col("low"))
+        & (pl.col("high") >= pl.col("close"))
+        & (pl.col("close") >= pl.col("low"))
+        & (pl.col("volume") > 0)
+    )
+    assert sane.height == daily.height, "some daily bar violated OHLC sanity"
+
+    # Value-for-value match against the reference on the overlapping prefix.
+    n = daily.height
+    for col in ("open", "high", "low", "close", "volume"):
+        assert daily[col][:n].to_list() == ref[col][:n].to_list(), f"{col} mismatch"
+
+    # Causal stamping: each daily TS is midnight UTC (day-open, left-labelled).
+    assert all(ts % _DAY_NS == 0 for ts in daily["TS"].to_list())


### PR DESCRIPTION
## Summary
- `AppConfig.portfolios` + `PortfolioStrategyConfig` (universe + weight-vector signal by reference + capital + daily dccd source + optional `gross_cap` + venue).
- `run_app.build_portfolio_runners` — builds a `PortfolioFeed` + `PortfolioRunner` per declared portfolio on the **shared** engine, alongside single-instrument runners; per-coin `PortfolioReport`.
- **Overlap detection widened**: no instrument claimed by two runners (strategy↔strategy, strategy↔portfolio, portfolio↔portfolio) — `ConfigError`.
- `application.ResamplingDccdClient` — injectable resample-on-read client (reads the 1m store → daily OHLCV via `group_by_dynamic`, causal: closed days only, partial last day dropped, OHLC exact).
- `pyproject.toml` — `fynance-research` documented as an editable `[triptych]` sibling install (LS1 signals; kept out of hard deps).

## Why
dccd serves only 1-minute bars (`read(span=86400)` → 0 rows); a daily consumer must resample (as `fynance_research/data.py` does). The resampler is an **injectable client** so `PortfolioFeed`/`run_app` stay agnostic and offline tests resample-free. Engine stays generic — LS1 lives in config. See ADR.

## Verification on real data
- Offline `run_app` (fake signal + fake daily client): final shared-tracker positions == intended `weight×capital/price` (BTC +1.0, ETH −10.0), and recomputing from broker-confirmed fills (`Position.from_fills`) agrees.
- **ResamplingDccdClient vs the REAL dccd store** (ran): BTC-USDT 2024 1m → **366 daily bars**, OHLC-sane, **value-identical** to a `fynance_research`-style `group_by_dynamic` aggregation; all daily TS at midnight UTC.

## Changes
- `config.py`, `data_provider.py`, `run_app.py`, `pyproject.toml`; `tests/application/test_portfolio_config.py` (new — 24 unit + 1 network).

## Changelog
Added under [Unreleased] (0.3.0): `AppConfig.portfolios`, `ResamplingDccdClient`. Changed: `[triptych]` extra documents `fynance-research`.

## Test plan
- [x] `.venv/bin/python -m pytest` — 686 passed, 9 deselected
- [x] resample network test — passed against the real dccd store
- [x] `.venv/bin/ruff check trading_bot/` — clean
- [x] `.venv/bin/mypy trading_bot/` — clean
- [ ] CI green

Leaf 04 of **portfolio-strategy**. Leaf 05 (LS1 e2e) depends on this.

> Note (out of scope, follow-up): two pre-existing `-m network` tests in `test_data_feed.py`/`test_data_provider.py` fail on a **dccd API drift** (`Client().inventory()` outside `async with`) — unrelated to this epic, network-only (not in CI). Worth a separate fix.