### PR TITLE
feat: LS1 runnable by config + real-data portfolio e2e (portfolio-strategy leaf 05)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (reads the 1-minute store, aggregates OHLCV to daily via `group_by_dynamic`,
   causal: closed days only, partial last day dropped, OHLC carried exact). The live
   daily-bars seam for the portfolio path (dccd serves only 1m). (#66)
+- `application.as_portfolio_signal` — a generic adapter bridging an argument-free
+  research weight oracle (`() -> {pair: weight}`, e.g. `ls1_live.target_weights`) to
+  the `PortfolioSignalFn` contract (normalises pair keys → `Symbol`, weights → exact
+  `Decimal`). **LS1 runnable end-to-end by config**: `configs/ls1.yaml` (paper) wires
+  the 10-coin Binance USDT book via `examples/ls1_signal.py` (lazy `fynance_research`
+  import); delta-correctness verified on **real** dccd Binance bars (resampled 1m→1d),
+  with an opt-in Binance **testnet** rebalance round-trip. Completes the multi-asset
+  / portfolio-strategy epic. (#67)
 
 ### Changed
 

--- a/configs/ls1.yaml
+++ b/configs/ls1.yaml
@@ -1,0 +1,80 @@
+# LS1 — a runnable *paper* config for the validated long/short crypto book.
+#
+# LS1 is the research output of the triptych (see ../fynance-research/DEPLOY_LS1.md):
+# a daily long/short multi-asset book over a 10-coin Binance USDT universe, trend
+# core (BTC/ETH) + cross-sectional momentum overlay, hard-capped at 2x gross.
+# `trading_bot` *executes* it — this file wires the signal + data + sizing.
+#
+# Load + run it (paper) with:
+#     from trading_bot.application import AppConfig
+#     from trading_bot.application.run_app import run_app
+#     cfg = AppConfig.from_yaml("configs/ls1.yaml")
+#     report = await run_app(cfg, dccd_client=ResamplingDccdClient(real_client))
+#
+# Prerequisites to actually evaluate the signal:
+#   * the research package:        pip install -e ../fynance-research
+#   * dccd's Binance 1m store synced for the 10 *-USDT pairs (DEPLOY_LS1.md §3),
+#     read daily via a ResamplingDccdClient (dccd serves 1m, not daily).
+
+# Paper by default — this never trades real money. Going live is a deliberate,
+# multi-step opt-in (mode: live + live_enabled: true + credentials); see
+# doc/dev/09-go-live.md and the "Running LS1" note in doc/dev/09-go-live.md.
+mode: paper
+live_enabled: false
+
+# Anchors the KPI equity curve (equity = starting_capital + cumulative PnL).
+# Set this to LS1's intended capital base; it should match the portfolio capital.
+starting_capital: "100000"
+
+storage:
+  db_path: ./var/ls1.sqlite     # append-only order/fill history + engine state
+  data_path: ./var/dccd         # dccd on-disk OHLC data directory
+
+# The paper simulator sits behind the same Broker port as the live Binance adapter.
+brokers:
+  - name: paper-binance
+    exchange: paper
+
+# The LS1 portfolio: the 10-coin USDT universe, the weight-vector signal, the
+# capital base the weights are a fraction of, and the daily Binance data source.
+portfolios:
+  - name: ls1
+    venue: binance
+    # The validated 10-coin universe (all *-USDT). T1 trend trades BTC/ETH; the
+    # cross-sectional overlay trades all 10. Adding new listings is a fresh
+    # research+validation cycle, not a config flip (DEPLOY_LS1.md §7).
+    universe:
+      - BTC/USDT
+      - ETH/USDT
+      - BCH/USDT
+      - LTC/USDT
+      - XRP/USDT
+      - XLM/USDT
+      - DOGE/USDT
+      - DOT/USDT
+      - TRX/USDT
+      - ZEC/USDT
+    # The weight-vector signal: a "module:function" ref to the LS1 wrapper, which
+    # adapts fynance_research.strategies.ls1_live:target_weights to the
+    # PortfolioSignalFn contract (see examples/ls1_signal.py). Resolved at run
+    # time; fynance_research is imported lazily when the signal is *evaluated*.
+    signal:
+      ref: "examples.ls1_signal:ls1_portfolio_signal"
+    # The capital base each weight is a fraction of (weight w -> w * capital).
+    capital: "100000"
+    # The gross-leverage cap (Sigma|w| <= 2). Enforced inside the signal; carried
+    # here for reference (the engine does not re-normalise against it).
+    gross_cap: "2"
+    # Daily bars from dccd's Binance store. dccd serves the span it collected at
+    # (1m for this store); a daily portfolio reads through a ResamplingDccdClient
+    # (span 86400) so each day's minutes aggregate to one closed daily bar.
+    data:
+      exchange: binance
+      span: 86400               # daily bars (seconds) — the rebalance cadence
+      data_type: ohlc
+
+# Engine-wide risk limits (exact Decimals; null = unconstrained). LS1's gross cap
+# lives in the signal; add per-coin order/position caps and a daily-loss halt to
+# taste before going live (doc/dev/09-go-live.md).
+risk:
+  max_daily_loss: "5000"

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,40 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 LS1 wired by config via a generic weight-oracle adapter (PR #67)
+
+**Decision.** LS1 runs end-to-end **without any LS1 code in the engine**. A generic
+`application.as_portfolio_signal(weights_callable)` bridges an *argument-free*
+research oracle (`() -> {pair: weight}`, optionally `(weights, asof)`) to the
+`PortfolioSignalFn` contract: it **ignores** the passed frames (the oracle reads its
+own store) — the frames still drive the runner's freshness gate and per-leg prices —
+and normalises pair-string keys → canonical `Symbol` (`parse_binance_symbol`,
+hyphen/concat both) and weights → exact `Decimal`. The LS1 glue is a thin
+`examples/ls1_signal.py:ls1_portfolio_signal` that binds
+`fynance_research.strategies.ls1_live:target_weights` through the adapter with a
+**lazy** import (config load + ref resolution need no research dep); `configs/ls1.yaml`
+(paper) points `signal.ref` at it. Real daily bars come from the
+`ResamplingDccdClient` (1m→1d). Real-data verification ran against the live dccd
+Binance store with a deterministic weight vector (asof 2026-06-27, 3-coin book):
+routed per-coin deltas == `wᵢ·capital/priceᵢ` on real closes, broker-confirmed.
+
+**Why.** The triptych split is research → signal, trading_bot → execution; keeping
+the only LS1-aware glue a *generic, parameter-free adapter* loaded by reference means
+the engine never imports the research repo and any future weight oracle plugs in the
+same way. Lazy-importing `fynance_research` keeps the engine installable and the
+offline suite green without it. **Rejected:** an LS1-specific runner/signal in
+`trading_bot` (couples the engine to one strategy); a hard `fynance-research` dep
+(forces the research repo on every install); passing the frames into the oracle (its
+API reads its own store — the frames' role is the gate + prices, not the weights).
+
+**Known follow-ups surfaced by this epic (tracked in `07-roadmap.md`):** (1) the
+PaperBroker/engine drain is **superlinear** (~O(n²)) over accumulated ticks, so a
+full multi-year daily backtest through `run_app` is slow — the real-data tests assert
+on a single latest-cross-section rebalance instead; (2) a **dccd API drift** breaks two
+`-m network` data-feed tests (`Client().inventory()` outside `async with`).
+
+---
+
 ### 2026-06-29 Portfolio config + run_app wiring; resample-on-read daily seam (PR #66)
 
 **Decision.** A portfolio is declarable via `PortfolioStrategyConfig` (universe +

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -27,8 +27,19 @@ venue** behind the `Broker` port (HMAC-SHA256 signing vs Binance's vector; compo
 venue-id for symbol-scoped cancel; `newClientOrderId` idempotency; **testnet-capable**
 with an opt-in real round-trip E2E on `testnet.binance.vision`). Public market data is
 key-free; the private path is mock+vector+testnet-E2E proven. This is the execution
-venue for the upcoming **multi-asset / LS1** epic (next). Mainnet real-key enablement
-stays deferred behind the opt-in.
+venue for the **multi-asset / LS1** epic. Mainnet real-key enablement stays deferred
+behind the opt-in.
+
+**Post-0.2.0 — multi-asset / portfolio-strategy unit shipped:** a native
+`PortfolioStrategy`/`PortfolioRunner` drives a whole universe from a **weight vector**
+(`PortfolioSignalFn` → `weights_to_signals` → N idempotent risk-gated maker-LIMIT legs),
+fed by a common-index, freshness-gated `PortfolioFeed` over the dccd Binance store
+(daily via the resample-on-read `ResamplingDccdClient`). **LS1 is runnable by config**
+(`configs/ls1.yaml` + `examples/ls1_signal.py`, `fynance_research` lazily imported) —
+delta-correctness verified on **real** dccd Binance bars; an opt-in Binance **testnet**
+rebalance round-trip is ready (gated on a testnet key). The engine stays generic (LS1 is
+config + a generic weight-oracle adapter). Two follow-ups are tracked in `07-roadmap.md`
+(engine O(n²) drain; a dccd `inventory()` API drift in two network tests).
 
 **Remaining (maintainer decisions, see `07-roadmap.md`):** the **final project name**
 (kept `trading_bot`), and **real-key live enablement** (validate Kraken private

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -15,17 +15,20 @@ The single source *index* of open work. Each unchecked item is a candidate for
 dashboard; paper-by-default, hardened under fault injection, live behind an explicit
 off-by-default opt-in. History in git + `CHANGELOG.md`; see `06-status.md`.
 
-## Active epics (post-0.2.0)
+**Post-0.2.0 shipped:** the **Binance adapter** (E11, 2nd live venue) and the
+**native multi-asset / portfolio-strategy unit** (LS1 runnable by config —
+`configs/ls1.yaml`, real dccd-data verified). History in `CHANGELOG.md`.
 
-- [ ] **Multi-asset / portfolio strategy unit** (signalé par `fynance-research`). Today a
-  `SignalFn` is `(bars) -> Signal` for **one** instrument; the first validated research
-  strategy, **LS1**, is a **multi-asset long/short book** (a *vector* of target weights over
-  ~10 Binance USDT coins, gross-capped 2×). Add a portfolio-strategy abstraction that consumes
-  a weight vector in one shot (e.g. `fynance_research.strategies.ls1_live.target_weights()` →
-  `{pair: weight}`, fraction of capital, Σ\|w\|≤2) and emits N venue-neutral `Signal`s + the
-  per-coin order routing. **Interim**: deployable now as 10 single-instrument strategies each
-  calling `ls1_live.coin_exposure("<PAIR>")` (works, but recomputes the book 10×). Spec:
-  `fynance-research/DEPLOY_LS1.md`. Daily rebalance; reads bars from the dccd Binance store.
+## Known issues / follow-ups
+
+- [ ] **PaperBroker/engine drain is superlinear (~O(n²)) over accumulated ticks.** A
+  full multi-year daily run through `run_app` is slow (≈10 ticks 6.5s → 200 ticks 118s);
+  the LS1 real-data tests assert on a single latest-cross-section rebalance instead.
+  Profile the per-fill rebuild (tracker/perf/bus) and make the drain linear before any
+  long backtest/live-replay through the engine.
+- [ ] **dccd API drift breaks two `-m network` data-feed tests.** `dccd.Client().inventory()`
+  is now called outside an `async with` in `test_data_feed.py` / `test_data_provider.py`
+  (current dccd rejects it). Network-only (not in CI). Realign the dccd client usage.
 
 ## Open / deferred (maintainer decisions)
 

--- a/doc/dev/09-go-live.md
+++ b/doc/dev/09-go-live.md
@@ -122,6 +122,86 @@ for this repository's automated tests** (which never hit a real venue).
 
 ---
 
+## Running LS1 (the first real portfolio strategy)
+
+**LS1** is the validated long/short crypto book from the research repo — a daily
+multi-asset strategy over a 10-coin Binance USDT universe (trend core on BTC/ETH
++ a cross-sectional momentum overlay, hard-capped at 2× gross). Its full dossier
+— universe, fees, the exact signal recipe, sizing, rebalance and risk rules, and
+the live signal API — is **[`../fynance-research/DEPLOY_LS1.md`](../../../fynance-research/DEPLOY_LS1.md)**.
+Read it before running LS1. `trading_bot` *executes* LS1; it does not define it.
+
+### How LS1 is wired (config + a thin generic adapter — no engine code)
+
+LS1 lands as a **portfolio strategy** (`PortfolioStrategyConfig`), not as bespoke
+engine code:
+
+- **The config:** [`configs/ls1.yaml`](../../configs/ls1.yaml) — paper by default,
+  the 10-coin universe, `capital`, `gross_cap: 2`, and a daily Binance data source
+  (`exchange: binance`, `span: 86400`).
+- **The signal seam:** the config's `signal.ref` points at
+  `examples.ls1_signal:ls1_portfolio_signal`
+  ([`examples/ls1_signal.py`](../../examples/ls1_signal.py)) — a thin wrapper that
+  binds the research oracle `fynance_research.strategies.ls1_live:target_weights`
+  through the **generic** adapter
+  [`as_portfolio_signal`](../../trading_bot/application/portfolio.py). The adapter
+  bridges any argument-free `() -> {pair: weight}` oracle to the engine's
+  `PortfolioSignalFn` contract (`(asof_ms, frames) -> {Symbol: weight}`): it
+  normalises `"BTC-USDT"`-style keys to canonical `Symbol`s and weights to exact
+  `Decimal`, and handles the `{...}`-or-`({...}, asof)` return shapes. It hardcodes
+  no LS1 specifics — `trading_bot` stays generic.
+- **`fynance_research` is imported lazily** (inside the signal), so loading the
+  config and resolving the ref need no research package — only *evaluating* the
+  signal at run time does.
+
+### Data feed — dccd's Binance 1m store, resampled to daily
+
+dccd's Binance store holds **1-minute** bars and `read` does not resample, so a
+daily portfolio reads through a
+[`ResamplingDccdClient`](../../trading_bot/application/data_provider.py) (1m → 1d,
+OHLCV-correct, closed-day only — causal) wrapping the real `dccd.Client`. Sync the
+10 `*-USDT` pairs first (`DEPLOY_LS1.md` §3); they land at
+`~/data/arthurserver/binance/ohlc/<PAIR>/1m/`.
+
+### Prerequisites and how to run the LS1 tests
+
+The portfolio path is proven end-to-end on **real** dccd Binance bars (with a
+deterministic weight vector) in
+[`trading_bot/tests/application/test_ls1_e2e.py`](../../trading_bot/tests/application/test_ls1_e2e.py).
+The LS1-specific and Binance-testnet checks live in the same file, gated:
+
+```bash
+# Real-dccd portfolio e2e (runs whenever the Binance store is present):
+.venv/bin/python -m pytest trading_bot/tests/application/test_ls1_e2e.py -m network -v
+
+# LS1-real e2e — needs the research package:
+pip install -e ../fynance-research
+.venv/bin/python -m pytest \
+  trading_bot/tests/application/test_ls1_e2e.py::test_ls1_real_e2e -m network -v
+
+# Binance testnet rebalance — needs a *testnet* key + the testnet base URL
+# (in a gitignored .env; never a mainnet key):
+export BINANCE_API_KEY=...  BINANCE_API_SECRET=...
+export BINANCE_API_BASE=https://testnet.binance.vision
+.venv/bin/python -m pytest \
+  trading_bot/tests/application/test_ls1_e2e.py::test_binance_testnet_rebalance -m network -v
+```
+
+The testnet test places ONE rebalance with a tiny capital, reads the venue's
+`open_orders()`/`balances()` back, asserts the placed legs match the intended
+deltas, then **cancels** every leg — and refuses to run against mainnet.
+
+### Going live with LS1
+
+Live LS1 follows the **same** gates as any live run (above): `mode: live` +
+`live_enabled: true` + Binance credentials + the real-key sandbox step. LS1's
+`gross_cap` lives in the signal; add per-coin `max_order` / `max_position` and a
+`max_daily_loss` halt in `RiskConfig` before the first live order. Note LS1's
+documented net-long bias and unmodelled funding (`DEPLOY_LS1.md` §7) — budget for
+them separately.
+
+---
+
 ## Disclaimers
 
 - **Paper is the default.** Live is off by default and must be opted into

--- a/doc/dev/plans/portfolio-strategy/00-plan.md
+++ b/doc/dev/plans/portfolio-strategy/00-plan.md
@@ -1,7 +1,7 @@
 ---
 plan: portfolio-strategy
 kind: global
-status: planning
+status: done
 roadmap: "- [ ] **Multi-asset / portfolio strategy unit** (signalé par `fynance-research`). Today a `SignalFn` is `(bars) -> Signal` for **one** instrument; the first validated research strategy, **LS1**, is a **multi-asset long/short book** (a *vector* of target weights over ~10 Binance USDT coins, gross-capped 2×). Add a portfolio-strategy abstraction that consumes a weight vector in one shot (e.g. `fynance_research.strategies.ls1_live.target_weights()` → `{pair: weight}`, fraction of capital, Σ\\|w\\|≤2) and emits N venue-neutral `Signal`s + the per-coin order routing. **Interim**: deployable now as 10 single-instrument strategies each calling `ls1_live.coin_exposure(\"<PAIR>\")` (works, but recomputes the book 10×). Spec: `fynance-research/DEPLOY_LS1.md`. Daily rebalance; reads bars from the dccd Binance store."
 release_on_done: false
 ---
@@ -66,7 +66,7 @@ shape. It is **0.3.0 work** (post the 0.2.0 release).
 - [x] 02 portfolio-feed — feat/portfolio-feed — medium (→ opus) (depends on 01)
 - [x] 03 portfolio-runner — feat/portfolio-runner — high (→ opus) (depends on 01)
 - [x] 04 portfolio-config — feat/portfolio-config — medium (→ opus) (depends on 02, 03)
-- [ ] 05 ls1-e2e — feat/portfolio-ls1-e2e — high (→ opus) (depends on 04)
+- [x] 05 ls1-e2e — feat/portfolio-ls1-e2e — high (→ opus) (depends on 04)
 
 ## Dependencies
 

--- a/doc/dev/plans/portfolio-strategy/05-ls1-e2e.md
+++ b/doc/dev/plans/portfolio-strategy/05-ls1-e2e.md
@@ -1,12 +1,12 @@
 ---
 plan: portfolio-strategy/05-ls1-e2e
 kind: leaf
-status: planned
+status: done
 complexity: high
 depends: [04]
 parallel: false
 branch: feat/portfolio-ls1-e2e
-pr: ""
+pr: "#67"
 ---
 
 # LS1 end-to-end — real dccd Binance bars + opt-in testnet rebalance

--- a/examples/ls1_signal.py
+++ b/examples/ls1_signal.py
@@ -1,0 +1,102 @@
+"""LS1 portfolio signal — the thin config wrapper for the research weight oracle.
+
+This is the *only* LS1-aware glue, and it is tiny: it points the generic
+:func:`trading_bot.application.portfolio.as_portfolio_signal` adapter at the
+research oracle ``fynance_research.strategies.ls1_live.target_weights`` (an
+argument-free callable that reads dccd's Binance store itself and returns
+``{"BTC-USDT": +0.31, "ZEC-USDT": -0.18, ...}``, ``Σ|w| ≤ 2``). See
+``../fynance-research/DEPLOY_LS1.md`` for the strategy, the universe and the live
+signal API.
+
+Why a wrapper module (the config seam)
+--------------------------------------
+``trading_bot`` stays generic — it ships **no** research dependency and **no**
+LS1 code in the engine. A portfolio config names its signal as a safe
+``"module:function"`` reference that
+:func:`trading_bot.application.portfolio.load_portfolio_signal` imports and
+``getattr``\\ s; the resolved callable must already match the
+:data:`~trading_bot.application.portfolio.PortfolioSignalFn` contract
+(``(asof_ms, frames) -> {Symbol: weight}``). The research oracle does **not**
+(it is argument-free and returns pair-strings), so this module exposes a
+module-level :data:`ls1_portfolio_signal` that *is* the adapted, contract-shaped
+callable. ``configs/ls1.yaml`` points its ``signal.ref`` at
+``examples.ls1_signal:ls1_portfolio_signal``.
+
+``fynance_research`` is imported **lazily**, inside the signal, so importing this
+module (and resolving the config) never requires the research package — only
+*evaluating* the signal at run time does. That keeps the offline test suite and
+config validation free of the research dependency; install it editable from the
+sibling repo to actually run LS1::
+
+    pip install -e ../fynance-research
+
+The adapter ignores the frames the runner passes (the oracle reads its own
+store), but those frames still drive the runner's freshness gate and the
+per-leg prices — so the engine remains the authority on *when* and *at what
+price* each leg trades.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TYPE_CHECKING
+
+from trading_bot.application.portfolio import as_portfolio_signal
+from trading_bot.domain.instrument import Symbol
+from trading_bot.domain.money import Money
+
+if TYPE_CHECKING:
+    import polars as pl
+
+
+def _target_weights() -> object:
+    """Call the research LS1 oracle, importing ``fynance_research`` lazily.
+
+    Imports ``fynance_research.strategies.ls1_live.target_weights`` only when the
+    signal is *evaluated* (not when this module is imported / the config is
+    resolved), so the research dependency is needed only to actually run LS1.
+    Returns whatever the oracle returns — a ``{pair: weight}`` mapping or a
+    ``(mapping, asof)`` tuple; the generic adapter handles either shape.
+    """
+    from fynance_research.strategies.ls1_live import (  # noqa: PLC0415
+        target_weights,
+    )
+
+    return target_weights()
+
+
+def ls1_portfolio_signal(
+    asof_ms: int, frames: Mapping[Symbol, "pl.DataFrame"]
+) -> Mapping[Symbol, Money]:
+    """The LS1 weight-vector signal, as a :data:`PortfolioSignalFn`.
+
+    A module-level, parameter-free
+    :data:`~trading_bot.application.portfolio.PortfolioSignalFn` a portfolio
+    config can resolve by reference. It is the generic
+    :func:`~trading_bot.application.portfolio.as_portfolio_signal` adapter bound
+    to :func:`_target_weights` (the lazily-imported research oracle), so the
+    ``{"BTC-USDT": w}`` pair-string keys are normalised to canonical
+    :class:`~trading_bot.domain.instrument.Symbol`\\ s and the weights to exact
+    :class:`~trading_bot.domain.money.Money`.
+
+    Parameters
+    ----------
+    asof_ms : int
+        Ignored — the research oracle reads its own store and the engine's own
+        as-of (from the freshness-gated feed) governs the rebalance timing.
+    frames : Mapping[Symbol, polars.DataFrame]
+        Ignored by the oracle, but the runner still uses them for the freshness
+        gate and the per-leg prices.
+
+    Returns
+    -------
+    Mapping[Symbol, Money]
+        ``{Symbol: signed fraction of capital}`` with ``Σ|w| ≤ 2``.
+
+    """
+    return _ADAPTED(asof_ms, frames)
+
+
+#: The adapted, contract-shaped LS1 signal (built once at import; the research
+#: import inside it stays lazy).
+_ADAPTED = as_portfolio_signal(_target_weights)

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -146,6 +146,7 @@ from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.portfolio import (
     PortfolioSignalFn,
     PortfolioStrategy,
+    as_portfolio_signal,
     load_portfolio_signal,
     weights_to_signals,
 )
@@ -214,6 +215,7 @@ __all__ = [
     "PortfolioSignalFn",
     "weights_to_signals",
     "load_portfolio_signal",
+    "as_portfolio_signal",
     "PortfolioFeed",
     # strategy runner
     "StrategyRunner",

--- a/trading_bot/application/portfolio.py
+++ b/trading_bot/application/portfolio.py
@@ -62,10 +62,14 @@ from __future__ import annotations
 import importlib
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from trading_bot.domain.errors import ConfigError, SignalError
-from trading_bot.domain.instrument import Instrument, Symbol
+from trading_bot.domain.instrument import (
+    Instrument,
+    Symbol,
+    parse_binance_symbol,
+)
 from trading_bot.domain.money import Money, money
 from trading_bot.domain.signal import Signal
 
@@ -77,6 +81,7 @@ __all__ = [
     "PortfolioStrategy",
     "weights_to_signals",
     "load_portfolio_signal",
+    "as_portfolio_signal",
 ]
 
 #: A multi-asset strategy's signal callable: ``(asof_ms, {Symbol: frame})`` →
@@ -271,3 +276,121 @@ def load_portfolio_signal(ref: str) -> PortfolioSignalFn:
             f"{type(fn).__name__}"
         )
     return fn  # type: ignore[no-any-return]
+
+
+def as_portfolio_signal(
+    weights_callable: Callable[[], Any],
+    *,
+    symbol_parse: Callable[[str], Symbol] = parse_binance_symbol,
+) -> PortfolioSignalFn:
+    """Adapt a store-reading ``() -> {pair: weight}`` callable to a :data:`PortfolioSignalFn`.
+
+    The generic bridge between a **research** weight oracle and this package's
+    :data:`PortfolioSignalFn` contract. A research signal like
+    ``fynance_research.strategies.ls1_live.target_weights`` is **argument-free**
+    (it reads its own data store) and returns a plain ``{pair-string: weight}``
+    mapping (e.g. ``{"BTC-USDT": +0.31, "ZEC-USDT": -0.18, ...}``) — sometimes
+    paired with an as-of timestamp as ``(weights, asof)``. The
+    :data:`PortfolioSignalFn` the runner speaks is, by contrast,
+    ``(asof_ms, frames) -> {Symbol: weight}``.
+
+    This adapter returns a :data:`PortfolioSignalFn` that, on each rebalance:
+
+    * **ignores** the passed ``asof_ms`` / ``frames`` (the underlying callable
+      reads its own store) — the frames still drive the runner's freshness gate
+      and the latest closes it prices each leg at, so the engine stays the
+      authority on *when* and *at what price* to trade;
+    * calls ``weights_callable()`` and accepts **either** a bare ``{pair: weight}``
+      mapping **or** a ``(mapping, asof)`` 2-tuple (the as-of is discarded — the
+      engine's own as-of governs), defensively;
+    * **normalises** each pair-string key to a canonical
+      :class:`~trading_bot.domain.instrument.Symbol` via ``symbol_parse`` (default
+      :func:`~trading_bot.domain.instrument.parse_binance_symbol`, so
+      ``"BTC-USDT"`` → ``Symbol("BTC", "USDT")``), and each weight to exact
+      :class:`~trading_bot.domain.money.Money` via ``money(str(...))`` — never
+      ``float``.
+
+    It is the **only** research-aware glue and it is fully generic: it hardcodes
+    no universe, no LS1 specifics, only key-normalisation and the return-shape
+    handling. To wire a concrete research signal by config, expose a parameter-free
+    module-level callable that returns ``as_portfolio_signal(target_weights)`` (or
+    the adapted signal directly) and point the config's ``signal.ref`` at it (see
+    ``examples/ls1_signal.py``).
+
+    Parameters
+    ----------
+    weights_callable : Callable[[], Any]
+        The argument-free weight oracle. Returns either a ``{pair: weight}``
+        mapping or a ``(mapping, asof)`` tuple. Called once per rebalance.
+    symbol_parse : Callable[[str], Symbol], optional
+        How a pair-string key is parsed to a canonical
+        :class:`~trading_bot.domain.instrument.Symbol`. Defaults to
+        :func:`~trading_bot.domain.instrument.parse_binance_symbol` (handles the
+        ``"BTC-USDT"`` hyphen form *and* the bare ``"BTCUSDT"`` form). A
+        :class:`Symbol` key is passed through unchanged (already canonical).
+
+    Returns
+    -------
+    PortfolioSignalFn
+        A ``(asof_ms, frames) -> {Symbol: Money}`` callable.
+
+    Raises
+    ------
+    SignalError
+        If ``weights_callable()`` returns neither a mapping nor a
+        ``(mapping, asof)`` tuple, or a key cannot be parsed to a
+        :class:`Symbol`.
+
+    """
+
+    def _signal(
+        asof_ms: int, frames: Mapping[Symbol, pl.DataFrame]
+    ) -> Mapping[Symbol, Money]:
+        raw = weights_callable()
+        weights = _unwrap_weights(raw)
+        return _normalise_weight_keys(weights, symbol_parse)
+
+    return _signal
+
+
+def _unwrap_weights(raw: Any) -> Mapping[Any, Any]:
+    """Accept a bare ``{pair: weight}`` mapping or a ``(mapping, asof)`` tuple.
+
+    The research oracle may return the weight vector alone or paired with its
+    as-of timestamp; either way the engine's own as-of governs, so the as-of
+    component (when present) is discarded and only the mapping is kept.
+    """
+    if isinstance(raw, Mapping):
+        return raw
+    if isinstance(raw, tuple) and len(raw) == 2 and isinstance(raw[0], Mapping):
+        return raw[0]
+    raise SignalError(
+        "weight oracle must return a {pair: weight} mapping or a "
+        f"(mapping, asof) tuple, got {type(raw).__name__}"
+    )
+
+
+def _normalise_weight_keys(
+    weights: Mapping[Any, Any],
+    symbol_parse: Callable[[str], Symbol],
+) -> dict[Symbol, Money]:
+    """Normalise pair-string keys → canonical :class:`Symbol`, weights → ``Money``.
+
+    A :class:`Symbol` key is passed through (already canonical); a string key is
+    parsed via ``symbol_parse``. Each weight is taken as exact
+    :class:`~trading_bot.domain.money.Money` through ``money(str(...))`` — never
+    ``float``.
+    """
+    out: dict[Symbol, Money] = {}
+    for key, weight in weights.items():
+        if isinstance(key, Symbol):
+            symbol = key
+        else:
+            try:
+                symbol = symbol_parse(str(key))
+            except ValueError as exc:
+                raise SignalError(
+                    f"weight oracle key {key!r} is not a parseable pair: {exc}"
+                ) from exc
+        out[symbol] = money(str(weight))
+    return out

--- a/trading_bot/tests/application/test_ls1_e2e.py
+++ b/trading_bot/tests/application/test_ls1_e2e.py
@@ -1,0 +1,714 @@
+"""LS1 end-to-end — the portfolio path on **real** dccd Binance bars (+ opt-in LS1/testnet).
+
+The mandatory real-data evidence for the portfolio-strategy epic: it proves the
+*whole* multi-asset path — config → resampled daily feed → weight vector → sized
+per-coin targets → idempotent risk-gated routing → broker-confirmed positions —
+on the **real** dccd Binance store, and wires the validated **LS1** strategy
+(``../fynance-research/DEPLOY_LS1.md``) by config + a thin generic adapter only.
+
+Three layers, by what is available in the running environment
+-------------------------------------------------------------
+1. **Adapter unit tests** (always run) — the generic
+   :func:`~trading_bot.application.portfolio.as_portfolio_signal` that bridges a
+   research ``() -> {pair: weight}`` oracle to the
+   :data:`~trading_bot.application.portfolio.PortfolioSignalFn` contract:
+   pair-string key normalisation, the dict-or-``(dict, asof)`` return shapes,
+   and a ``Σ|w| ≤ 2`` gross-cap assertion helper.
+2. **Real-dccd portfolio e2e** (``-m network``; runs whenever the store is
+   present) — a small real universe (``BTC/ETH/BNB-USDT``) fed through the real
+   1m store resampled to daily by the production
+   :class:`~trading_bot.application.data_provider.ResamplingDccdClient`, a
+   *deterministic* fake weight vector, run through :func:`run_app` against the
+   :class:`~trading_bot.brokers.paper.PaperBroker`. Asserts the routed per-coin
+   deltas equal ``weightᵢ × capital / priceᵢ`` on the **real latest closes**, that
+   Σ routed notionals ≤ ``gross_cap × capital``, that the freshness gate holds,
+   and that **broker-confirmed** tracker positions agree. The LS1-specific path
+   is identical — only the signal source differs (the research dep, below).
+3. **LS1-real e2e + Binance testnet rebalance** (gated, skip where the
+   prerequisite is absent) — the *same* path with the real LS1 signal and, opt-in,
+   against the Binance **testnet** broker. Present and correct, ready to run:
+
+   * **LS1-real** needs the research package::
+
+         pip install -e ../fynance-research
+
+   * **testnet** needs a testnet key in the env *and* the testnet base URL::
+
+         BINANCE_API_KEY=...           # a *testnet* key (testnet.binance.vision)
+         BINANCE_API_SECRET=...
+         BINANCE_API_BASE=https://testnet.binance.vision
+
+     It runs ONE rebalance with a tiny capital, reads back ``open_orders()`` /
+     ``balances()``, asserts the placed legs match the intended deltas, then
+     **cancels** every leg in a ``finally``. No mainnet — paper is the default and
+     the testnet test refuses to run against ``api.binance.com``.
+
+Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from decimal import Decimal
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from trading_bot.application.config import AppConfig
+from trading_bot.application.data_provider import ResamplingDccdClient
+from trading_bot.application.portfolio import as_portfolio_signal
+from trading_bot.domain.instrument import (
+    Instrument,
+    Symbol,
+    parse_binance_symbol,
+)
+from trading_bot.domain.money import Money, money
+
+# --- shared constants ------------------------------------------------------- #
+
+#: The real dccd Binance store root (1m parquet, dirs keyed "BTC-USDT").
+_STORE = Path.home() / "data" / "arthurserver" / "binance" / "ohlc"
+
+#: The 10 LS1 coins (all *-USDT, daily) — DEPLOY_LS1.md §2.
+_LS1_COINS = ["BTC", "ETH", "BCH", "LTC", "XRP", "XLM", "DOGE", "DOT", "TRX", "ZEC"]
+
+#: A small real universe for the runs-here e2e (coins present in the store).
+_SMALL_UNIVERSE = [Symbol("BTC", "USDT"), Symbol("ETH", "USDT"), Symbol("BNB", "USDT")]
+
+#: The deterministic fake weight vector for the runs-here e2e (Σ|w| = 1.0 ≤ 2).
+_FAKE_WEIGHTS: dict[Symbol, Money] = {
+    Symbol("BTC", "USDT"): money("0.5"),
+    Symbol("ETH", "USDT"): money("-0.3"),
+    Symbol("BNB", "USDT"): money("0.2"),
+}
+
+
+# --- the Σ|w| ≤ gross_cap helper -------------------------------------------- #
+
+
+def assert_gross_within(weights: Mapping[Symbol, Money], cap: Money) -> Money:
+    """Assert ``Σ|w| ≤ cap`` and return the gross exposure (exact ``Decimal``).
+
+    The gross-leverage gate every portfolio weight vector must respect (LS1's is
+    ``2``). Pure ``Decimal`` arithmetic — never ``float``.
+    """
+    gross = sum((abs(w) for w in weights.values()), money("0"))
+    assert gross <= cap, f"gross exposure {gross} exceeds cap {cap}"
+    return gross
+
+
+# --- a parquet-reading source client over the real store -------------------- #
+
+
+class _ParquetSource:
+    """A minimal sync dccd-shaped client reading the real 1m parquet store.
+
+    The real ``dccd.Client.read`` only runs inside ``async with Client()``; the
+    sync feed path (:class:`~trading_bot.application.data_feed.DccdFeed`) reads
+    synchronously, so — exactly like the ``test_portfolio_feed.py`` network test —
+    this reads the stored 1m parquet directly and returns the dccd OHLC columns.
+    It is wrapped in the **production**
+    :class:`~trading_bot.application.data_provider.ResamplingDccdClient` so the
+    real 1m→daily resampling code (not a hand-rolled copy) is what the e2e
+    exercises. Store dirs are keyed ``"BTC-USDT"`` (hyphen); a requested pair in
+    any form (``"BTCUSDT"`` / ``"BTC/USDT"`` / ``"BTC-USDT"``) is normalised to it,
+    so the **default** ``run_app`` feed (which renders ``"BTCUSDT"``) resolves
+    without any config-side ``symbol_for`` hook.
+    """
+
+    @staticmethod
+    def _dir_for(symbol: str) -> str:
+        """Map any pair spelling to the store's hyphen dir key (``"BTC-USDT"``)."""
+        sym = parse_binance_symbol(symbol)
+        return f"{sym.base}-{sym.quote}"
+
+    def read(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start_ns: int | None = None,
+        end_ns: int | None = None,
+    ) -> pl.DataFrame:
+        base = _STORE / self._dir_for(symbol) / "1m"
+        files = sorted(base.glob("*.parquet"))
+        if not files:
+            pytest.skip(f"no 1m parquet for {symbol} under {base}")
+        raw = (
+            pl.concat([pl.read_parquet(f) for f in files])
+            .unique(subset="TS", keep="last")
+            .sort("TS")
+        )
+        if start_ns is not None:
+            raw = raw.filter(pl.col("TS") >= start_ns)
+        if end_ns is not None:
+            raw = raw.filter(pl.col("TS") <= end_ns)
+        return raw
+
+    def backfill(
+        self,
+        exchange: str,
+        symbol: str,
+        data_type: str = "ohlc",
+        span: int | None = None,
+        start: str = "last",
+    ) -> None:  # pragma: no cover - not exercised (backfill=False)
+        return None
+
+
+def _hyphen_universe() -> list[str]:
+    """The small universe as ``BASE/QUOTE`` pair strings for the config."""
+    return [f"{s.base}/{s.quote}" for s in _SMALL_UNIVERSE]
+
+
+def _real_daily_client() -> ResamplingDccdClient:
+    """The production resampling client over the real 1m parquet store."""
+    return ResamplingDccdClient(_ParquetSource())
+
+
+def _deterministic_signal(weights: Mapping[Symbol, Money]):  # type: ignore[no-untyped-def]
+    """A fixed-weight :data:`PortfolioSignalFn` (frame-agnostic, deterministic)."""
+
+    def _fn(
+        asof_ms: int, frames: Mapping[Symbol, pl.DataFrame]
+    ) -> Mapping[Symbol, Money]:
+        return dict(weights)
+
+    return _fn
+
+
+# =========================================================================== #
+# 1. Adapter unit tests (ALWAYS run — no store / research / network)
+# =========================================================================== #
+
+
+def test_adapter_normalises_hyphen_pair_keys() -> None:
+    """``{"BTC-USDT": 0.3, "ZEC-USDT": -0.1}`` → canonical ``Symbol`` keys."""
+    oracle = lambda: {"BTC-USDT": 0.3, "ZEC-USDT": -0.1}  # noqa: E731
+    signal = as_portfolio_signal(oracle)
+
+    out = signal(0, {})
+
+    assert out == {
+        Symbol("BTC", "USDT"): money("0.3"),
+        Symbol("ZEC", "USDT"): money("-0.1"),
+    }
+    # Weights are exact Decimal, never float.
+    assert all(isinstance(w, Decimal) for w in out.values())
+
+
+def test_adapter_accepts_concatenated_binance_keys() -> None:
+    """The default parse also handles the bare ``"BTCUSDT"`` (no-separator) form."""
+    signal = as_portfolio_signal(lambda: {"BTCUSDT": 1, "ETHUSDT": -1})
+
+    out = signal(0, {})
+
+    assert out == {
+        Symbol("BTC", "USDT"): money("1"),
+        Symbol("ETH", "USDT"): money("-1"),
+    }
+
+
+def test_adapter_accepts_mapping_or_tuple_return_shape() -> None:
+    """The oracle may return ``{pair: w}`` OR ``({pair: w}, asof)`` — both work."""
+    bare = as_portfolio_signal(lambda: {"BTC-USDT": 0.5})
+    tupled = as_portfolio_signal(lambda: ({"BTC-USDT": 0.5}, 1_700_000_000_000))
+
+    expected = {Symbol("BTC", "USDT"): money("0.5")}
+    assert bare(0, {}) == expected
+    assert tupled(0, {}) == expected  # the asof component is discarded
+
+
+def test_adapter_passes_through_symbol_keys() -> None:
+    """A weight vector already keyed by canonical ``Symbol`` is left as-is."""
+    signal = as_portfolio_signal(lambda: {Symbol("BTC", "USDT"): 0.5})
+    assert signal(0, {}) == {Symbol("BTC", "USDT"): money("0.5")}
+
+
+def test_adapter_ignores_frames_and_asof() -> None:
+    """The adapter ignores the passed frames/asof (the oracle reads its own store)."""
+    calls = {"n": 0}
+
+    def _oracle() -> dict[str, float]:
+        calls["n"] += 1
+        return {"BTC-USDT": 0.4}
+
+    signal = as_portfolio_signal(_oracle)
+    # Different frames/asof → same result; the oracle is the sole source.
+    a = signal(111, {Symbol("BTC", "USDT"): pl.DataFrame({"c": [1.0]})})
+    b = signal(999, {})
+    assert a == b == {Symbol("BTC", "USDT"): money("0.4")}
+    assert calls["n"] == 2  # called once per evaluation
+
+
+def test_adapter_rejects_bad_return_shape() -> None:
+    """A non-mapping, non-(mapping, asof) return is a clear SignalError."""
+    from trading_bot.domain.errors import SignalError
+
+    signal = as_portfolio_signal(lambda: [("BTC-USDT", 0.5)])  # a list, not a dict
+    with pytest.raises(SignalError, match="mapping"):
+        signal(0, {})
+
+
+def test_adapter_rejects_unparseable_key() -> None:
+    """A key that cannot be parsed to a Symbol is a clear SignalError."""
+    from trading_bot.domain.errors import SignalError
+
+    signal = as_portfolio_signal(lambda: {"???": 0.5})
+    with pytest.raises(SignalError, match="parseable pair"):
+        signal(0, {})
+
+
+def test_gross_within_helper() -> None:
+    """The Σ|w| ≤ 2 helper accepts a compliant vector and rejects an over-levered one."""
+    ok = {Symbol("BTC", "USDT"): money("1.3"), Symbol("ETH", "USDT"): money("-0.7")}
+    assert assert_gross_within(ok, money("2")) == money("2.0")
+
+    too_much = {Symbol("BTC", "USDT"): money("1.5"), Symbol("ETH", "USDT"): money("-1.0")}
+    with pytest.raises(AssertionError, match="exceeds cap"):
+        assert_gross_within(too_much, money("2"))
+
+
+def test_ls1_config_loads_and_signal_resolves() -> None:
+    """``configs/ls1.yaml`` validates and its signal ref resolves (no research dep).
+
+    The LS1 wrapper imports ``fynance_research`` *lazily* (inside the signal), so
+    loading the config and resolving the ``module:function`` ref work without the
+    research package installed — only *evaluating* the signal needs it. This proves
+    LS1 is wired by config + a thin generic adapter, not engine code.
+    """
+    from trading_bot.application.portfolio import load_portfolio_signal
+
+    cfg = AppConfig.from_yaml("configs/ls1.yaml")
+    assert cfg.mode == "paper"  # paper by default — never live by accident
+    assert len(cfg.portfolios) == 1
+    p = cfg.portfolios[0]
+    assert p.name == "ls1"
+    # The full validated 10-coin universe.
+    assert [f"{s.base}/{s.quote}" for s in (Symbol(c, "USDT") for c in _LS1_COINS)] == [
+        u.replace("XBT", "BTC") for u in p.universe
+    ]
+    assert p.gross_cap == Decimal("2")
+    assert p.data.exchange == "binance" and p.data.span == 86_400
+    assert p.signal.ref == "examples.ls1_signal:ls1_portfolio_signal"
+
+    fn = load_portfolio_signal(p.signal.ref)  # resolves WITHOUT fynance_research
+    assert callable(fn)
+
+
+# =========================================================================== #
+# 2. Real-dccd portfolio e2e (RUNS here — the mandatory real-data evidence)
+# =========================================================================== #
+
+
+@pytest.mark.network
+async def test_real_dccd_portfolio_e2e_delta_correctness() -> None:
+    """Real dccd Binance bars → portfolio runner → deltas == weightᵢ·capital/priceᵢ.
+
+    Builds a 3-coin (BTC/ETH/BNB-USDT) portfolio from a real
+    :class:`AppConfig` with a **deterministic** fake weight vector, fed through the
+    **real** 1m store resampled to daily by the production
+    :class:`ResamplingDccdClient`, assembled exactly as :func:`run_app` does
+    (:func:`build_engine` + :func:`build_portfolio_runners`) against the
+    :class:`PaperBroker`, and rebalanced **once on the latest real cross-section**.
+    Asserts, on the **real latest closes**:
+
+    * each coin's routed/filled net qty from flat == ``weightᵢ × capital / priceᵢ``
+      (exact ``Decimal``);
+    * Σ routed notionals ≤ ``gross_cap × capital`` (the gross gate);
+    * the freshness gate held (all coins share the latest common closed day);
+    * **broker-confirmed** tracker positions equal those targets (not local
+      optimism).
+
+    Rebalancing the *latest* window once (rather than draining the whole ~2300-day
+    feed) keeps the test brisk while exercising the identical real config → real
+    resampled feed → real runner → real paper-broker path; every prior tick would
+    be causal too (proven offline in ``test_portfolio_runner.py``). The
+    LS1-specific path is identical; only the signal source differs (gated below on
+    the research dep). Skips with a how-to-sync reason when the store is absent.
+    """
+    if not _STORE.is_dir():
+        pytest.skip(
+            "no dccd Binance store at ~/data/arthurserver/binance/ohlc; sync the "
+            "Binance *-USDT 1m pairs via the dccd daemon (DEPLOY_LS1.md §3)"
+        )
+
+    from trading_bot.application.portfolio_feed import PortfolioFeed
+    from trading_bot.application.run_app import build_portfolio_runners
+    from trading_bot.application.service_factory import build_engine
+
+    capital = money("100000")
+    gross_cap = money("2")
+    weights = _FAKE_WEIGHTS
+
+    # Σ|w| within the gross cap (the same gate LS1's signal enforces).
+    assert_gross_within(weights, gross_cap)
+
+    client = _real_daily_client()
+
+    # --- the real latest common cross-section (the freshness gate) ----------- #
+    feed = PortfolioFeed(
+        _SMALL_UNIVERSE,
+        exchange="binance",
+        client=client,
+        span=86_400,
+        symbol_for=lambda s: f"{s.base}-{s.quote}",
+    )
+    latest = feed.latest()
+    # Freshness gate: every coin has the same common dates (inner join), > 200.
+    heights = {sym: latest[sym].height for sym in _SMALL_UNIVERSE}
+    assert len(set(heights.values())) == 1, f"unequal common dates: {heights}"
+    common = next(iter(latest.values()))["time"].to_list()
+    assert len(common) > 200, f"too few common daily dates: {len(common)}"
+    asof_ns = common[-1]
+    closes: dict[Symbol, Money] = {
+        sym: money(str(latest[sym]["c"][-1])) for sym in _SMALL_UNIVERSE
+    }
+
+    # The config: paper, the 3-coin universe, daily Binance data, a deterministic
+    # signal injected by an importable module:function ref (never exec'd).
+    cfg = AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "starting_capital": str(capital),
+            "brokers": [{"name": "paper-binance", "exchange": "paper"}],
+            "portfolios": [
+                {
+                    "name": "fake-book",
+                    "venue": "binance",
+                    "universe": _hyphen_universe(),
+                    "signal": {
+                        "ref": (
+                            "trading_bot.tests.application.test_ls1_e2e:"
+                            "_fake_book_signal"
+                        )
+                    },
+                    "capital": str(capital),
+                    "gross_cap": str(gross_cap),
+                    "data": {"exchange": "binance", "span": 86_400},
+                }
+            ],
+        }
+    )
+
+    # --- assemble the engine + runner (the run_app wiring) and rebalance ------ #
+    # build_portfolio_runners builds its own PortfolioFeed (default symbol render
+    # "BTCUSDT"); the parquet source normalises any spelling to the hyphen dir, so
+    # it reads the same store and resamples identically. We rebalance ONCE on the
+    # runner's latest window — the same code run_app drives per tick.
+    engine = build_engine(cfg, db_path=cfg.storage.db_path)
+    runner = build_portfolio_runners(cfg, engine, dccd_client=client)[0]
+    runner_feed = runner._feed  # the real PortfolioFeed built from the config
+    latest_window = runner_feed.latest()
+    result = await runner.rebalance(latest_window)
+
+    assert result.failed == 0, f"legs failed: {result.failures}"
+    assert result.submitted == 3  # all three weights non-zero → 3 legs from flat
+
+    # --- broker-confirmed positions == weightᵢ × capital / priceᵢ ------------ #
+    gross_notional = money("0")
+    intended: dict[Symbol, Money] = {}
+    confirmed: dict[Symbol, Money] = {}
+    for sym in _SMALL_UNIVERSE:
+        pos = engine.tracker.position(Instrument(sym))
+        assert pos is not None, f"{sym} never filled"
+        want = money(str(weights[sym] * capital / closes[sym]))
+        got = pos.net_qty
+        assert got == want, (
+            f"{sym}: broker-confirmed {got} != intended {want} "
+            f"(close={closes[sym]}, weight={weights[sym]})"
+        )
+        intended[sym] = want
+        confirmed[sym] = got
+        gross_notional += abs(got) * closes[sym]
+
+    # Σ routed notionals ≤ gross_cap × capital (the gross gate on real closes).
+    assert gross_notional <= gross_cap * capital, (
+        f"gross notional {gross_notional} exceeds cap {gross_cap * capital}"
+    )
+
+    # Emit the evidence to the captured test log (run with -s to see it live).
+    print("\n=== real-dccd portfolio e2e evidence ===")
+    print(f"asof (latest common closed day, ns): {asof_ns}")
+    print(f"capital: {capital}  gross_cap: {gross_cap}")
+    for sym in _SMALL_UNIVERSE:
+        print(
+            f"  {sym}: weight={weights[sym]}  close={closes[sym]}  "
+            f"intended={intended[sym]}  routed/confirmed={confirmed[sym]}"
+        )
+    print(f"gross notional: {gross_notional}  (cap {gross_cap * capital})")
+
+
+def _fake_book_signal(
+    asof_ms: int, frames: Mapping[Symbol, pl.DataFrame]
+) -> Mapping[Symbol, Money]:
+    """Module-level deterministic weight vector for the real-dccd e2e config ref.
+
+    A :data:`~trading_bot.application.portfolio.PortfolioSignalFn` the e2e config
+    resolves by ``module:function`` reference (importable, never exec'd). Returns
+    the fixed :data:`_FAKE_WEIGHTS` regardless of inputs — the deterministic stand
+    -in for the LS1 oracle so the real-data path runs without the research dep.
+    """
+    return dict(_FAKE_WEIGHTS)
+
+
+# =========================================================================== #
+# 3a. LS1-real e2e (GATED on fynance_research — SKIPS here)
+# =========================================================================== #
+
+
+@pytest.mark.network
+async def test_ls1_real_e2e() -> None:
+    """The *real* LS1 signal over the 10-coin universe → run_app → delta check.
+
+    Identical to the real-dccd e2e above but with the **real** LS1 weight oracle
+    (``fynance_research.strategies.ls1_live.target_weights`` via the
+    ``examples.ls1_signal:ls1_portfolio_signal`` wrapper). Asserts Σ|w| ≤ 2 on the
+    oracle's own output and that each coin's broker-confirmed position equals
+    ``weightᵢ × capital / priceᵢ`` on the latest real close.
+
+    SKIPS here — ``fynance_research`` is not installed. To run::
+
+        pip install -e ../fynance-research
+        .venv/bin/python -m pytest \\
+            trading_bot/tests/application/test_ls1_e2e.py::test_ls1_real_e2e \\
+            -m network -v
+    """
+    pytest.importorskip(
+        "fynance_research",
+        reason=(
+            "LS1 needs the research package: pip install -e ../fynance-research"
+        ),
+    )
+    if not _STORE.is_dir():
+        pytest.skip(
+            "no dccd Binance store at ~/data/arthurserver/binance/ohlc; sync the "
+            "10 LS1 *-USDT 1m pairs via the dccd daemon (DEPLOY_LS1.md §3)"
+        )
+
+    from examples.ls1_signal import ls1_portfolio_signal
+
+    capital = money("100000")
+    gross_cap = money("2")
+    client = _real_daily_client()
+    universe = [Symbol(c, "USDT") for c in _LS1_COINS]
+
+    # Evaluate the real oracle once (it reads its own store) and check Σ|w| ≤ 2.
+    weights = ls1_portfolio_signal(0, {})
+    assert_gross_within(weights, gross_cap)
+
+    cfg = AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "starting_capital": str(capital),
+            "brokers": [{"name": "paper-binance", "exchange": "paper"}],
+            "portfolios": [
+                {
+                    "name": "ls1",
+                    "venue": "binance",
+                    "universe": [f"{s.base}/{s.quote}" for s in universe],
+                    "signal": {"ref": "examples.ls1_signal:ls1_portfolio_signal"},
+                    "capital": str(capital),
+                    "gross_cap": str(gross_cap),
+                    "data": {"exchange": "binance", "span": 86_400},
+                }
+            ],
+        }
+    )
+
+    # Latest real closes per coin (the freshness-gated cross-section).
+    from trading_bot.application.portfolio_feed import PortfolioFeed
+    from trading_bot.application.run_app import build_portfolio_runners
+    from trading_bot.application.service_factory import build_engine
+
+    feed = PortfolioFeed(
+        universe,
+        exchange="binance",
+        client=client,
+        span=86_400,
+        symbol_for=lambda s: f"{s.base}-{s.quote}",
+    )
+    latest = feed.latest()
+    closes = {sym: money(str(latest[sym]["c"][-1])) for sym in universe}
+
+    # Assemble exactly as run_app does and rebalance ONCE on the latest window
+    # (a full drain would recompute the whole LS1 book per tick over ~2300 days).
+    engine = build_engine(cfg, db_path=cfg.storage.db_path)
+    runner = build_portfolio_runners(cfg, engine, dccd_client=client)[0]
+    await runner.rebalance(runner._feed.latest())
+
+    # Each coin's broker-confirmed net == weightᵢ × capital / priceᵢ on the latest
+    # real close (a coin with weight 0 is flat — no position).
+    for sym in universe:
+        want = money(str(weights.get(sym, money("0")) * capital / closes[sym]))
+        pos = engine.tracker.position(Instrument(sym))
+        got = pos.net_qty if pos is not None else money("0")
+        assert got == want, f"{sym}: confirmed {got} != intended {want}"
+
+
+# =========================================================================== #
+# 3b. Binance testnet rebalance (GATED on creds — SKIPS here)
+# =========================================================================== #
+
+
+@pytest.mark.network
+async def test_binance_testnet_rebalance() -> None:
+    """ONE real rebalance against the Binance **testnet**; legs cancelled after.
+
+    Points the engine at a :class:`~trading_bot.brokers.binance.BinanceBroker`
+    on the **testnet** base URL (``https://testnet.binance.vision``), runs ONE
+    rebalance with a *tiny* capital over a 2-coin universe, reads back
+    ``open_orders()`` / ``balances()``, asserts the placed legs match the intended
+    per-coin deltas, then **cancels** every leg in a ``finally``. Refuses to run
+    against mainnet (``api.binance.com``) — no real-money order is ever sent.
+
+    SKIPS here — no testnet credentials in the env. To run::
+
+        # in a gitignored .env (a *testnet* key from testnet.binance.vision):
+        export BINANCE_API_KEY=...  BINANCE_API_SECRET=...
+        export BINANCE_API_BASE=https://testnet.binance.vision
+        .venv/bin/python -m pytest \\
+            trading_bot/tests/application/test_ls1_e2e.py::test_binance_testnet_rebalance \\
+            -m network -v
+    """
+    from trading_bot.application.events import EventBus
+    from trading_bot.application.order_router import OrderRouter
+    from trading_bot.application.portfolio import PortfolioStrategy
+    from trading_bot.application.portfolio_runner import PortfolioRunner
+    from trading_bot.application.position_tracker import PositionTracker
+    from trading_bot.brokers.binance import TESTNET_API_BASE, BinanceBroker
+
+    api_key = os.environ.get("BINANCE_API_KEY", "")
+    api_secret = os.environ.get("BINANCE_API_SECRET", "")
+    base_url = os.environ.get("BINANCE_API_BASE", "")
+    if not (api_key and api_secret):
+        pytest.skip(
+            "no Binance testnet credentials; set BINANCE_API_KEY / "
+            "BINANCE_API_SECRET (a *testnet* key from testnet.binance.vision) "
+            "and BINANCE_API_BASE=https://testnet.binance.vision"
+        )
+    # Safety: never run this against mainnet — testnet base URL is mandatory.
+    if "testnet" not in base_url:
+        pytest.skip(
+            "BINANCE_API_BASE is not the testnet "
+            f"({base_url!r}); refusing to place orders against mainnet. Set "
+            "BINANCE_API_BASE=https://testnet.binance.vision"
+        )
+
+    btc, eth = Symbol("BTC", "USDT"), Symbol("ETH", "USDT")
+    universe = (btc, eth)
+    broker = BinanceBroker(
+        api_key=api_key,
+        api_secret=api_secret,
+        base_url=base_url or TESTNET_API_BASE,
+        symbols=universe,
+    )
+
+    # A modest capital + small weights so each leg clears Binance's MIN_NOTIONAL
+    # (~$10) without risking much; the legs rest unfilled at a deliberately-off
+    # price so we can read them back from open_orders and cancel them.
+    capital = money("4000")
+    weights = {btc: money("0.01"), eth: money("0.01")}  # ~$40 notional/leg
+
+    # Live current prices to size against, with instrument precision so the venue
+    # accepts the quantities.
+    btc_inst = await broker.instrument(btc)
+    eth_inst = await broker.instrument(eth)
+    insts = {btc: btc_inst, eth: eth_inst}
+    btc_px = await broker.ticker(btc_inst)
+    eth_px = await broker.ticker(eth_inst)
+    closes = {btc: btc_px, eth: eth_px}
+
+    def _quantize(qty: Money, precision: int | None) -> Money:
+        """Round a quantity down to the venue's qty precision (so it is accepted)."""
+        if precision is None:
+            return qty
+        return qty.quantize(money("1") / (money("10") ** precision))
+
+    # The intended per-coin net qty (quantized to the venue's qty precision so the
+    # placed leg matches exactly what we assert against open_orders).
+    intended = {
+        sym: _quantize(
+            money(str(weights[sym] * capital / closes[sym])),
+            insts[sym].qty_precision,
+        )
+        for sym in universe
+    }
+
+    bus = EventBus()
+    tracker = PositionTracker(event_bus=bus)
+    router = OrderRouter(broker, bus)
+    strategy = PortfolioStrategy(
+        name="testnet-ls1",
+        universe=universe,
+        signal_fn=_deterministic_signal(weights),
+        capital=capital,
+    )
+
+    # A LIMIT factory at ~half the market price (BUY) so the leg rests open
+    # (unfilled); qty + price are quantized to the instrument's venue precision.
+    from trading_bot.domain.order import Order, OrderSide, OrderType
+
+    def _resting_factory(strat, instrument, delta, close):  # type: ignore[no-untyped-def]
+        side = OrderSide.BUY if delta > 0 else OrderSide.SELL
+        # The runner builds a bare Instrument(symbol) with no precision; look the
+        # venue precision up from the exchangeInfo-built instruments.
+        venue_inst = insts[instrument.symbol]
+        # Buys far below / sells far above market → rests unfilled.
+        raw_price = close / money("2") if side is OrderSide.BUY else close * money("2")
+        return Order(
+            client_order_id="pending",
+            instrument=instrument,
+            side=side,
+            qty=_quantize(abs(delta), venue_inst.qty_precision),
+            type=OrderType.LIMIT,
+            limit_price=_quantize(raw_price, venue_inst.price_precision),
+        )
+
+    frames = {
+        sym: pl.DataFrame(
+            {"time": [1], "o": [float(closes[sym])], "h": [float(closes[sym])],
+             "l": [float(closes[sym])], "c": [float(closes[sym])], "v": [1.0]}
+        )
+        for sym in universe
+    }
+
+    runner = PortfolioRunner(
+        strategy,
+        [frames],
+        router,
+        tracker,
+        event_bus=bus,
+        order_factory=_resting_factory,
+    )
+
+    placed: list[str] = []
+    try:
+        result = await runner.rebalance(frames)
+        assert result.failed == 0, f"testnet legs failed: {result.failures}"
+
+        # Read back the venue's open orders and confirm the placed legs match the
+        # intended per-coin deltas (qty + side).
+        open_orders = await broker.open_orders()
+        by_pair = {o.instrument.symbol: o for o in open_orders}
+        placed = [o.venue_order_id for o in open_orders if o.venue_order_id]
+        for sym in universe:
+            assert sym in by_pair, f"{sym} leg not found in testnet open orders"
+            o = by_pair[sym]
+            assert o.qty == intended[sym], (
+                f"{sym}: testnet qty {o.qty} != intended {intended[sym]}"
+            )
+
+        # balances() is reachable (the account read works on the testnet key).
+        balances = await broker.balances()
+        assert isinstance(balances, dict)
+    finally:
+        # Always cancel every placed leg — leave no resting order on the testnet.
+        for venue_id in placed:
+            try:
+                await broker.cancel_order(venue_id)
+            except Exception:  # noqa: BLE001 - best-effort cleanup
+                pass


### PR DESCRIPTION
## Summary
- `application.as_portfolio_signal` — a **generic** adapter bridging an argument-free research weight oracle (`() -> {pair: weight}`) to the `PortfolioSignalFn` contract (ignores frames — the oracle reads its own store; frames still drive the gate + prices; keys → `Symbol`, weights → exact `Decimal`).
- **LS1 runnable by config**: `configs/ls1.yaml` (paper) + `examples/ls1_signal.py` (`fynance_research.strategies.ls1_live:target_weights`, **lazily** imported) over the 10-coin Binance USDT book, `gross_cap: 2`.
- `doc/dev/09-go-live.md` — a "Running LS1" section.
- **Closes the multi-asset / portfolio-strategy epic** — removes its roadmap line.

## Why
Triptych split: research → signal, trading_bot → execution. The only LS1-aware glue is a generic, parameter-free adapter loaded by reference — the engine never imports the research repo, and any future weight oracle plugs in identically. Lazy import keeps the engine installable + the offline suite green without `fynance_research`. See ADR.

## Verification on real data (ran)
Real dccd Binance store (resampled 1m→1d), deterministic 3-coin weight vector, asof **2026-06-27**:

| coin | weight | real close | intended w·cap/price | routed = broker-confirmed |
|---|--:|--:|--:|:--:|
| BTC/USDT | +0.5 | 60029.0 | 0.83293075… | ✅ == |
| ETH/USDT | −0.3 | 1573.99 | −19.05984155… | ✅ == |
| BNB/USDT | +0.2 | 557.2 | 35.89375449… | ✅ == |

Σ routed notionals ≤ gross_cap×capital; freshness gate held; positions broker-confirmed off the shared tracker.

**Gated/skipped here (how to run):**
- `test_ls1_real_e2e` — needs `pip install -e ../fynance-research`.
- `test_binance_testnet_rebalance` — needs a testnet key in `.env` + `BINANCE_API_BASE=https://testnet.binance.vision` (places one tiny rebalance, cancels every leg in `finally`; refuses mainnet).

## Follow-ups surfaced (tracked in roadmap)
- PaperBroker/engine **O(n²)** drain over accumulated ticks (long backtests slow).
- dccd **API drift** breaks two `-m network` data-feed tests (`inventory()` outside `async with`).

## Test plan
- [x] `.venv/bin/python -m pytest` — 695 passed, 12 deselected
- [x] `-m network` LS1 e2e — 1 passed (real dccd), 2 skipped (LS1 dep / testnet creds)
- [x] `.venv/bin/ruff check` + `mypy` — clean
- [ ] CI green

Last leaf of **portfolio-strategy**. Epic complete → ready for a 0.3.0 release.