### PR TITLE
feat: per-venue testnet config (safe engine-path testnet)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `BrokerConfig.testnet` — a per-venue **testnet** flag: `mode: live` + `testnet: true`
+  (Binance only — Kraken has no public spot testnet) builds an adapter **hard-pinned**
+  to the venue's sandbox URL (`testnet.binance.vision`), so it **cannot reach mainnet**
+  and is therefore **exempt from the `live_enabled` opt-in** (still needs testnet
+  credentials). The safe, low-ceremony way to live-test orders on the engine path
+  without juggling `live_enabled`/`BINANCE_API_BASE`. Paper mode ignores it.
+  `BinanceBroker` gains `base_url` / `is_testnet` introspection. (#68)
+
 - `application.portfolio` — the multi-asset `PortfolioSignalFn` contract
   (`(asof_ms, frames) -> {Symbol: weight}`, weight = signed fraction of capital),
   a frozen `PortfolioStrategy` (universe + signal + capital + optional gross cap),

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,34 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Testnet is a third broker path; it bypasses live_enabled by being mainnet-incapable (PR #68)
+
+**Decision.** A `BrokerConfig.testnet: true` selects a venue's **testnet/sandbox**
+(paper money on the real testnet venue) as a path distinct from both paper (the
+in-process simulator) and live (real mainnet). Under `mode: live`, a `testnet: true`
+broker builds the venue adapter **hard-pinned** to the testnet URL — the base URL is
+passed explicitly (`BinanceBroker(base_url=TESTNET_API_BASE)`), overriding any
+`BINANCE_API_BASE` env — so it is structurally incapable of reaching mainnet. Because
+it cannot touch real money, this path is **exempt from the `live_enabled` opt-in**
+(checked *before* that gate); it still requires (testnet) credentials. Only venues with
+a testnet qualify (`_TESTNET_VENUES = ("binance",)`); **Kraken raises** (no public spot
+sandbox). Paper mode still wins (testnet ignored). `BinanceBroker` gained `base_url`/
+`is_testnet` read-only introspection.
+
+**Why.** The maintainer wanted to live-test orders on the engine path *safely and
+without ceremony*. The previous route — `mode: live` + `live_enabled: true` + setting
+`BINANCE_API_BASE` to the testnet — overloaded the real-money opt-in for a paper-money
+sandbox and risked **mainnet by omission** (the base URL defaults to mainnet, so a
+forgotten env var trades for real). Pinning the URL from the flag makes "testnet
+cannot become mainnet" structural, which is precisely what justifies skipping
+`live_enabled` — the gate exists to prevent *real-money* accidents, and there are none
+here. **Rejected:** a separate `mode: "testnet"` (more surface; the venue, not the
+mode, is what has a sandbox); honouring `BINANCE_API_BASE` under the flag (re-opens the
+mainnet-by-omission hole); making testnet require `live_enabled` (the friction the
+request set out to remove). Kraken testnet was rejected because it does not exist.
+
+---
+
 ### 2026-06-29 LS1 wired by config via a generic weight-oracle adapter (PR #67)
 
 **Decision.** LS1 runs end-to-end **without any LS1 code in the engine**. A generic

--- a/doc/dev/09-go-live.md
+++ b/doc/dev/09-go-live.md
@@ -191,6 +191,26 @@ The testnet test places ONE rebalance with a tiny capital, reads the venue's
 `open_orders()`/`balances()` back, asserts the placed legs match the intended
 deltas, then **cancels** every leg — and refuses to run against mainnet.
 
+### Testnet on the engine path (the safe, low-ceremony way)
+
+To live-test orders through the **engine** (`trading-bot run` / `build_engine`)
+rather than the test, set **`testnet: true`** on the broker — do **not** flip
+`live_enabled` or `BINANCE_API_BASE`:
+
+```yaml
+mode: live
+# live_enabled NOT needed — testnet cannot reach mainnet (paper money)
+brokers:
+  - { name: binance, exchange: binance, testnet: true }
+```
+
+With testnet credentials in `.env`, the factory builds a `BinanceBroker`
+**hard-pinned** to `testnet.binance.vision` (the URL is forced from the flag, so a
+stray `BINANCE_API_BASE` pointing at mainnet is ignored) — it is structurally
+incapable of trading real money, which is why it is exempt from the `live_enabled`
+opt-in. Only Binance qualifies; `testnet: true` on Kraken raises (no public spot
+testnet). **Real mainnet** still requires `live_enabled: true` + a real key (above).
+
 ### Going live with LS1
 
 Live LS1 follows the **same** gates as any live run (above): `mode: live` +

--- a/trading_bot/application/config.py
+++ b/trading_bot/application/config.py
@@ -72,11 +72,20 @@ class BrokerConfig(BaseModel):
     exchange : str
         The venue key the broker adapter is resolved by (e.g. ``"kraken"``).
         Must be non-empty.
+    testnet : bool, optional
+        Route this venue to its **testnet / sandbox** (paper money on the real
+        venue) instead of production. Defaults to ``False``. When ``True`` (only
+        venues that *have* a testnet, e.g. ``"binance"`` →
+        ``testnet.binance.vision``), the adapter is **hard-pinned** to the testnet
+        endpoint — it cannot reach mainnet — so it does **not** require the
+        ``live_enabled`` opt-in (it still needs testnet credentials). Ignored in
+        paper mode (the simulator). A venue with no testnet (``"kraken"``) raises.
 
     """
 
     name: str
     exchange: str
+    testnet: bool = False
 
     @field_validator("name", "exchange")
     @classmethod

--- a/trading_bot/application/service_factory.py
+++ b/trading_bot/application/service_factory.py
@@ -59,7 +59,7 @@ from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.risk import RiskManager
 from trading_bot.brokers.base import Broker
-from trading_bot.brokers.binance import BinanceBroker
+from trading_bot.brokers.binance import TESTNET_API_BASE, BinanceBroker
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.paper import PaperBroker
 from trading_bot.domain.errors import BrokerError, LiveTradingNotEnabled
@@ -69,6 +69,9 @@ __all__ = ["Engine", "build_engine"]
 
 #: Venue keys recognised as live (non-simulated) adapters.
 _LIVE_VENUES = ("kraken", "binance")
+#: Venue keys that offer a testnet/sandbox (paper money on the real venue).
+#: Kraken has no public spot testnet, so it is deliberately absent.
+_TESTNET_VENUES = ("binance",)
 #: The venue key for the in-process simulator.
 _PAPER_VENUE = "paper"
 #: The go-live runbook the live-opt-in refusals point users at.
@@ -226,12 +229,35 @@ def _build_broker(config: AppConfig, bus: EventBus) -> Broker:
     real money). Refuses (raises
     :class:`~trading_bot.domain.errors.BrokerError`) rather than falling back to
     paper for a live venue that cannot trade.
+
+    **Testnet** is a third path between paper and live: a broker with
+    ``testnet: true`` (a venue that has a sandbox — Binance, not Kraken) builds an
+    adapter **hard-pinned** to the venue's testnet URL. Because it structurally
+    cannot reach mainnet (paper money), it is exempt from the ``live_enabled``
+    opt-in — but it still requires (testnet) credentials. Checked *before* the
+    ``live_enabled`` gate; ignored in paper mode (the simulator wins).
     """
     venue = _selected_venue(config)
 
     if config.mode == "paper" or venue == _PAPER_VENUE:
         # Paper-by-default: the simulator, wired to the bus so its fills fan out.
         return PaperBroker(event_bus=bus)
+
+    # Testnet path: a venue's sandbox (paper money on the real testnet venue). The
+    # adapter is **hard-pinned** to the testnet endpoint (it cannot reach mainnet),
+    # so it does NOT need the `live_enabled` opt-in — checked *before* that gate.
+    # It still requires (testnet) credentials. `testnet: true` on the selected
+    # broker is what opts in; a venue with no testnet raises.
+    first: BrokerConfig | None = config.brokers[0] if config.brokers else None
+    if first is not None and first.testnet:
+        broker = _build_testnet_venue(venue)
+        if not broker.has_credentials:
+            raise BrokerError(
+                f"testnet for venue {venue!r} requires credentials; set the "
+                "venue's (testnet) API key/secret in the environment "
+                "(refusing to trade without credentials)"
+            )
+        return broker
 
     # mode == "live" with a non-paper venue. Live is OFF by default: require the
     # explicit opt-in *before* even looking at credentials, so flipping `mode`
@@ -294,3 +320,24 @@ def _build_live_venue(venue: str) -> _LiveBroker:
         return BinanceBroker()
     # Unreachable: callers gate on ``_LIVE_VENUES`` first. Defensive only.
     raise BrokerError(f"no live adapter for venue {venue!r}")
+
+
+def _build_testnet_venue(venue: str) -> _LiveBroker:
+    """Construct a venue's **testnet** adapter, hard-pinned to its sandbox URL.
+
+    Only venues in :data:`_TESTNET_VENUES` have a testnet. The base URL is forced
+    to the venue's testnet endpoint (passed explicitly, so any ``BINANCE_API_BASE``
+    env value is overridden) — the adapter can therefore never reach mainnet, which
+    is why the caller skips the ``live_enabled`` opt-in for it. Credentials are
+    still read from the environment (testnet keys). A venue with no testnet (e.g.
+    Kraken, which has no public spot sandbox) raises.
+    """
+    if venue == "binance":
+        # Hard-pin the testnet base URL (explicit arg overrides the env default),
+        # so this adapter is structurally incapable of hitting api.binance.com.
+        return BinanceBroker(base_url=TESTNET_API_BASE)
+    raise BrokerError(
+        f"venue {venue!r} has no testnet/sandbox; testnet is available for "
+        f"{sorted(_TESTNET_VENUES)!r} only (Kraken has no public spot testnet — "
+        "use paper, or real-money live behind the go-live runbook)"
+    )

--- a/trading_bot/brokers/binance.py
+++ b/trading_bot/brokers/binance.py
@@ -296,6 +296,20 @@ class BinanceBroker(Broker):
         """Whether both API key and secret are present (private calls possible)."""
         return bool(self._api_key) and bool(self._api_secret)
 
+    @property
+    def base_url(self) -> str:
+        """The REST base URL this adapter targets (mainnet or testnet).
+
+        Read-only introspection — useful to confirm a testnet-pinned adapter
+        (:data:`TESTNET_API_BASE`) can never reach mainnet.
+        """
+        return self._base_url
+
+    @property
+    def is_testnet(self) -> bool:
+        """Whether this adapter is pinned to Binance's spot **testnet**."""
+        return self._base_url == TESTNET_API_BASE
+
     def _require_credentials(self) -> None:
         """Raise :class:`BrokerError` if a private call lacks credentials."""
         if not self.has_credentials:

--- a/trading_bot/tests/application/test_service_factory.py
+++ b/trading_bot/tests/application/test_service_factory.py
@@ -26,6 +26,7 @@ from trading_bot.application.performance_service import PerformanceService
 from trading_bot.application.position_tracker import PositionTracker
 from trading_bot.application.risk import RiskManager
 from trading_bot.application.service_factory import Engine, build_engine
+from trading_bot.brokers.binance import TESTNET_API_BASE, BinanceBroker
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.paper import PaperBroker
 from trading_bot.domain.errors import BrokerError, LiveTradingNotEnabled
@@ -318,3 +319,81 @@ async def test_engine_is_live_end_to_end() -> None:
     # And to the performance service: a fee was charged (realised PnL net of it).
     assert engine.perf.fees_paid() > money("0")
     assert len(engine.perf.equity_curve()) == 1
+
+
+# --- testnet path: a venue sandbox between paper and live -------------------- #
+
+
+def test_testnet_binance_builds_pinned_adapter_without_live_enabled(
+    monkeypatch,
+) -> None:
+    """``testnet: true`` builds the venue's testnet adapter — no ``live_enabled``.
+
+    Binance has a spot testnet. A broker with ``testnet: true`` + credentials
+    builds a :class:`BinanceBroker` **hard-pinned** to the testnet URL, *without*
+    requiring the ``live_enabled`` opt-in (it cannot reach mainnet — paper money).
+    Constructing the adapter sends no order.
+    """
+    monkeypatch.setenv("BINANCE_API_KEY", "tk")
+    monkeypatch.setenv("BINANCE_API_SECRET", "ts")
+    cfg = AppConfig(
+        mode="live",
+        live_enabled=False,  # NOT set — testnet does not need it
+        brokers=[BrokerConfig(name="bn", exchange="binance", testnet=True)],
+    )
+    engine = build_engine(cfg)
+    assert isinstance(engine.broker, BinanceBroker)
+    assert engine.broker.is_testnet
+    assert engine.broker.base_url == TESTNET_API_BASE
+
+
+def test_testnet_hard_pins_url_ignoring_mainnet_env(monkeypatch) -> None:
+    """``testnet: true`` forces the testnet URL even if env points at mainnet."""
+    monkeypatch.setenv("BINANCE_API_KEY", "tk")
+    monkeypatch.setenv("BINANCE_API_SECRET", "ts")
+    # A stray env var pointing at mainnet must NOT leak through the testnet flag.
+    monkeypatch.setenv("BINANCE_API_BASE", "https://api.binance.com")
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="bn", exchange="binance", testnet=True)],
+    )
+    engine = build_engine(cfg)
+    assert isinstance(engine.broker, BinanceBroker)
+    assert engine.broker.base_url == TESTNET_API_BASE  # env override ignored
+
+
+def test_testnet_without_credentials_refuses(monkeypatch) -> None:
+    """Testnet still needs (testnet) credentials → ``BrokerError`` without them."""
+    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="bn", exchange="binance", testnet=True)],
+    )
+    with pytest.raises(BrokerError, match="credentials"):
+        build_engine(cfg)
+
+
+def test_testnet_kraken_refuses() -> None:
+    """Kraken has no public spot testnet → ``testnet: true`` raises clearly."""
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="kr", exchange="kraken", testnet=True)],
+    )
+    with pytest.raises(BrokerError, match="no testnet"):
+        build_engine(cfg)
+
+
+def test_paper_mode_ignores_testnet() -> None:
+    """Paper is the default and wins: ``testnet: true`` under paper → simulator."""
+    cfg = AppConfig(
+        mode="paper",
+        brokers=[BrokerConfig(name="bn", exchange="binance", testnet=True)],
+    )
+    engine = build_engine(cfg)
+    assert isinstance(engine.broker, PaperBroker)
+
+
+def test_brokerconfig_testnet_defaults_false() -> None:
+    """``testnet`` defaults to False (a plain broker is mainnet/live)."""
+    assert BrokerConfig(name="bn", exchange="binance").testnet is False


### PR DESCRIPTION
## Summary
- `BrokerConfig.testnet: bool = False` — a per-venue testnet flag. `mode: live` + `testnet: true` (Binance only) builds an adapter **hard-pinned** to the venue's sandbox URL (`testnet.binance.vision`), structurally **incapable of reaching mainnet** → **exempt from the `live_enabled` opt-in** (still needs testnet credentials). Paper mode ignores it; Kraken `testnet: true` raises (no public spot testnet).
- `BinanceBroker.base_url` / `is_testnet` read-only introspection.
- Go-live runbook: a "testnet on the engine path" section.

## Why
The previous way to testnet via the engine overloaded the real-money opt-in (`live_enabled: true` + `BINANCE_API_BASE`) and risked **mainnet by omission** (base URL defaults to mainnet — a forgotten env var trades for real). Forcing the testnet URL from the flag makes "testnet cannot become mainnet" structural, which is exactly what justifies skipping `live_enabled` (that gate guards *real-money* accidents — there are none here). See ADR.

```yaml
mode: live
brokers:
  - { name: binance, exchange: binance, testnet: true }   # no live_enabled needed
```

## Safety
- The base URL is passed explicitly (`BinanceBroker(base_url=TESTNET_API_BASE)`), overriding any `BINANCE_API_BASE` env → tested: a stray mainnet env is ignored.
- Still requires testnet credentials (no-creds → `BrokerError`).
- Paper stays the absolute default; real mainnet still requires `live_enabled: true` + a real key.

## Changes
- `config.py` (`BrokerConfig.testnet`), `service_factory.py` (testnet path + `_build_testnet_venue` + `_TESTNET_VENUES`), `binance.py` (`base_url`/`is_testnet`).
- `tests/application/test_service_factory.py` — 6 new tests (pinned-without-live_enabled, env-override-ignored, no-creds refuse, Kraken refuse, paper-wins, default).

## Changelog
Added under [Unreleased] (0.3.0): `BrokerConfig.testnet`.

## Test plan
- [x] `.venv/bin/python -m pytest` — 701 passed, 12 deselected
- [x] `.venv/bin/ruff check trading_bot/` — clean
- [x] `.venv/bin/mypy trading_bot/` — clean
- [ ] CI green

Small 0.3.x enhancement (companion to the multi-asset epic) — makes Binance testnet order-testing safe on the engine path.