### PR TITLE
feat: LS1 on Kraken (USD) + live tests on both venues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- LS1 runnable on **Kraken (USD)** as well as Binance: `examples/ls1_signal.py` gains
+  `ls1_kraken_signal` (calls `target_weights("kraken")`) + `configs/ls1_kraken.yaml`
+  (the `-USD` universe, dccd Kraken store). Two **live tests** prove the chain on real
+  data: `test_ls1_real_e2e` (Binance) and `test_ls1_kraken_real_e2e` (Kraken — real LS1
+  signal + real dccd bars + a **live Kraken public-ticker** check, routed through the
+  `PaperBroker`: **no real order**, since Kraken has no spot testnet). The Binance order
+  round-trip remains the opt-in **testnet** test. (#69)
 - `BrokerConfig.testnet` — a per-venue **testnet** flag: `mode: live` + `testnet: true`
   (Binance only — Kraken has no public spot testnet) builds an adapter **hard-pinned**
   to the venue's sandbox URL (`testnet.binance.vision`), so it **cannot reach mainnet**

--- a/configs/ls1_kraken.yaml
+++ b/configs/ls1_kraken.yaml
@@ -1,0 +1,61 @@
+# LS1 (Kraken) — a runnable *paper* config for the validated long/short book,
+# the **Kraken USD** variant of configs/ls1.yaml.
+#
+# Same strategy as the Binance config (../fynance-research/DEPLOY_LS1.md): a daily
+# long/short multi-asset book, trend core (BTC/ETH) + cross-sectional momentum
+# overlay, hard-capped at 2x gross — but on **Kraken's USD pairs** (0.26%/side fee
+# vs Binance's 0.10%, which drags the forward Sharpe; Binance stays the recommended
+# venue). `trading_bot` *executes* it — this file wires the signal + data + sizing.
+#
+# Why no live order test on Kraken: **Kraken has no public spot testnet**, so a
+# live test that PLACES orders on Kraken is real money. This config is **paper**
+# (PaperBroker) — a live test runs the real LS1 signal + real dccd Kraken data +
+# real Kraken public prices through the simulator, with NO real order placed.
+# Real-money Kraken live is the deliberate go-live opt-in (doc/dev/09-go-live.md).
+#
+# Prerequisites to evaluate the signal:
+#   * the research package:        pip install -e ../fynance-research
+#   * dccd's Kraken 1m store synced for the 10 *-USD pairs, read daily via a
+#     ResamplingDccdClient (dccd serves 1m, not daily).
+
+mode: paper
+live_enabled: false
+
+starting_capital: "100000"
+
+storage:
+  db_path: ./var/ls1_kraken.sqlite
+  data_path: ./var/dccd
+
+brokers:
+  - name: paper-kraken
+    exchange: paper
+
+portfolios:
+  - name: ls1-kraken
+    venue: kraken
+    # The same 10-coin universe as Binance, USD-quoted (Kraken's `-USD` pairs).
+    universe:
+      - BTC/USD
+      - ETH/USD
+      - BCH/USD
+      - LTC/USD
+      - XRP/USD
+      - XLM/USD
+      - DOGE/USD
+      - DOT/USD
+      - TRX/USD
+      - ZEC/USD
+    # The Kraken weight-vector signal: calls fynance_research ...target_weights("kraken").
+    signal:
+      ref: "examples.ls1_signal:ls1_kraken_signal"
+    capital: "100000"
+    gross_cap: "2"
+    # Daily bars from dccd's Kraken store (read 1m → resample to daily, span 86400).
+    data:
+      exchange: kraken
+      span: 86400
+      data_type: ohlc
+
+risk:
+  max_daily_loss: "5000"

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,42 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 LS1 multi-venue live tests; Kraken is public+PaperBroker (no testnet) (PR #69)
+
+**Decision.** LS1 is now wired for **both venues** by config — `ls1_kraken_signal`
+(calls the research oracle with `venue="kraken"`, USD pairs) alongside the Binance
+`ls1_portfolio_signal`, each a thin `examples/ls1_signal.py` wrapper over the generic
+`as_portfolio_signal` adapter; `configs/ls1_kraken.yaml` mirrors `configs/ls1.yaml`
+on the `-USD` universe + dccd Kraken store. The **live tests** differ by venue because
+the venues differ: **Binance** has a testnet, so its order round-trip is the opt-in
+`network` testnet test (real orders, paper money); **Kraken has no public spot
+testnet**, so its live test (`test_ls1_kraken_real_e2e`) runs the **real** LS1 Kraken
+signal over the **real** dccd Kraken store + a **live Kraken public-ticker** sanity
+check, but routes the rebalance through the **`PaperBroker`** — **no real order is ever
+placed** (the maintainer chose public+PaperBroker over a real-money Kraken order test).
+
+**Why.** A live test on Kraken that *places* orders is real money (no sandbox exists),
+which violates the project's "no real order by accident" posture; running the real
+signal + real data + live public prices through the simulator validates the whole
+chain (data → signal → sizing → delta → routing → risk) bar the venue's order
+acceptance, with zero financial risk. Real Kraken order placement stays the deliberate
+go-live opt-in (`doc/dev/09-go-live.md`). **Rejected:** a real-money Kraken order test
+(footgun — a stray `-m network` run with a real key trades for real); a Kraken testnet
+(does not exist).
+
+**Finding (tracked in `07-roadmap.md`): venue symbol renders are ambiguous to invert.**
+`to_venue_symbol("kraken")` yields `XBTUSD` (which `parse_binance_symbol` mis-reads as
+`XB/TUSD` — the `TUSD` quote) and `TRXUSD` (which `parse_kraken_pair` mis-reads as
+`TR/USD` — the trailing `X` looks like a legacy prefix); no single parser inverts both.
+The test's fake dccd client disambiguates by trying both parsers and picking the
+candidate dir that **exists** in the store — but this exposes that the **production**
+config → real-dccd path has no agreed store-key convention (the default `PortfolioFeed`
+render does not match a hyphen-keyed `BASE-QUOTE` store for either venue; only the test
+client normalises). A real `trading-bot run configs/ls1*.yaml` against a live dccd
+client needs that convention pinned.
+
+---
+
 ### 2026-06-29 Testnet is a third broker path; it bypasses live_enabled by being mainnet-incapable (PR #68)
 
 **Decision.** A `BrokerConfig.testnet: true` selects a venue's **testnet/sandbox**

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -21,6 +21,14 @@ off-by-default opt-in. History in git + `CHANGELOG.md`; see `06-status.md`.
 
 ## Known issues / follow-ups
 
+- [ ] **Portfolio config → real-dccd store-key convention unpinned.** The default
+  `PortfolioFeed` renders pairs via `to_venue_symbol(exchange)` (`BTCUSDT`; Kraken
+  `XBTUSD`/`TRXUSD`), which (a) doesn't match a hyphen-keyed `BASE-QUOTE` dccd store and
+  (b) is ambiguous to invert (`XBTUSD`→`XB/TUSD`, `TRXUSD`→`TR/USD` under the parsers).
+  The LS1 tests' fake dccd client normalises by existence-checking the store; a real
+  `trading-bot run configs/ls1*.yaml` against a live `dccd.Client` needs the convention
+  pinned (a `symbol_for`/store-key field on `PortfolioStrategyConfig`, or a canonical
+  render). Until then LS1 runs are verified via the test harness, not raw `run_app`.
 - [ ] **PaperBroker/engine drain is superlinear (~O(n²)) over accumulated ticks.** A
   full multi-year daily run through `run_app` is slow (≈10 ticks 6.5s → 200 ticks 118s);
   the LS1 real-data tests assert on a single latest-cross-section rebalance instead.

--- a/examples/ls1_signal.py
+++ b/examples/ls1_signal.py
@@ -41,7 +41,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
-from trading_bot.application.portfolio import as_portfolio_signal
+from trading_bot.application.portfolio import (
+    PortfolioSignalFn,
+    as_portfolio_signal,
+)
 from trading_bot.domain.instrument import Symbol
 from trading_bot.domain.money import Money
 
@@ -49,20 +52,33 @@ if TYPE_CHECKING:
     import polars as pl
 
 
-def _target_weights() -> object:
-    """Call the research LS1 oracle, importing ``fynance_research`` lazily.
+def _target_weights(venue: str) -> object:
+    """Call the research LS1 oracle for ``venue``, importing ``fynance_research`` lazily.
 
     Imports ``fynance_research.strategies.ls1_live.target_weights`` only when the
     signal is *evaluated* (not when this module is imported / the config is
     resolved), so the research dependency is needed only to actually run LS1.
-    Returns whatever the oracle returns — a ``{pair: weight}`` mapping or a
-    ``(mapping, asof)`` tuple; the generic adapter handles either shape.
+    ``venue`` selects the book: ``"binance"`` (USDT pairs, the validated default)
+    or ``"kraken"`` (USD pairs). Returns whatever the oracle returns — a
+    ``{pair: weight}`` mapping or a ``(mapping, asof)`` tuple; the generic adapter
+    handles either shape (and normalises the ``BTC-USDT`` / ``BTC-USD`` keys).
     """
     from fynance_research.strategies.ls1_live import (  # noqa: PLC0415
         target_weights,
     )
 
-    return target_weights()
+    return target_weights(venue)
+
+
+def _venue_signal(venue: str) -> PortfolioSignalFn:
+    """Build the adapted, contract-shaped LS1 signal for ``venue`` (lazy oracle).
+
+    The generic :func:`~trading_bot.application.portfolio.as_portfolio_signal`
+    bound to an argument-free closure over :func:`_target_weights` — so the
+    research import stays lazy and the venue's pair keys (USDT or USD) are
+    normalised to canonical :class:`~trading_bot.domain.instrument.Symbol`\\ s.
+    """
+    return as_portfolio_signal(lambda: _target_weights(venue))
 
 
 def ls1_portfolio_signal(
@@ -70,12 +86,12 @@ def ls1_portfolio_signal(
 ) -> Mapping[Symbol, Money]:
     """The LS1 weight-vector signal, as a :data:`PortfolioSignalFn`.
 
-    A module-level, parameter-free
-    :data:`~trading_bot.application.portfolio.PortfolioSignalFn` a portfolio
-    config can resolve by reference. It is the generic
-    :func:`~trading_bot.application.portfolio.as_portfolio_signal` adapter bound
-    to :func:`_target_weights` (the lazily-imported research oracle), so the
-    ``{"BTC-USDT": w}`` pair-string keys are normalised to canonical
+    LS1 on **Binance** (USDT pairs) — the validated default venue. A module-level,
+    parameter-free :data:`~trading_bot.application.portfolio.PortfolioSignalFn` a
+    portfolio config resolves by reference (``configs/ls1.yaml``). The generic
+    :func:`~trading_bot.application.portfolio.as_portfolio_signal` adapter bound to
+    the lazily-imported research oracle, so the ``{"BTC-USDT": w}`` pair-string
+    keys are normalised to canonical
     :class:`~trading_bot.domain.instrument.Symbol`\\ s and the weights to exact
     :class:`~trading_bot.domain.money.Money`.
 
@@ -94,9 +110,24 @@ def ls1_portfolio_signal(
         ``{Symbol: signed fraction of capital}`` with ``Σ|w| ≤ 2``.
 
     """
-    return _ADAPTED(asof_ms, frames)
+    return _ADAPTED_BINANCE(asof_ms, frames)
 
 
-#: The adapted, contract-shaped LS1 signal (built once at import; the research
-#: import inside it stays lazy).
-_ADAPTED = as_portfolio_signal(_target_weights)
+def ls1_kraken_signal(
+    asof_ms: int, frames: Mapping[Symbol, "pl.DataFrame"]
+) -> Mapping[Symbol, Money]:
+    """LS1 on **Kraken** (USD pairs) — same strategy, the original validation venue.
+
+    The Kraken counterpart of :func:`ls1_portfolio_signal`: it calls the research
+    oracle with ``venue="kraken"`` (USD-quoted, ~10 ``-USD`` pairs) and the generic
+    adapter normalises the ``BTC-USD`` keys to canonical ``Symbol``\\ s. A portfolio
+    config resolves it by reference (``configs/ls1_kraken.yaml``). See
+    :func:`ls1_portfolio_signal` for the parameter/return contract.
+    """
+    return _ADAPTED_KRAKEN(asof_ms, frames)
+
+
+#: The adapted, contract-shaped LS1 signals per venue (built once at import; the
+#: research import inside each stays lazy until the signal is evaluated).
+_ADAPTED_BINANCE = _venue_signal("binance")
+_ADAPTED_KRAKEN = _venue_signal("kraken")

--- a/trading_bot/tests/application/test_ls1_e2e.py
+++ b/trading_bot/tests/application/test_ls1_e2e.py
@@ -63,6 +63,7 @@ from trading_bot.domain.instrument import (
     Instrument,
     Symbol,
     parse_binance_symbol,
+    parse_kraken_pair,
 )
 from trading_bot.domain.money import Money, money
 
@@ -70,6 +71,9 @@ from trading_bot.domain.money import Money, money
 
 #: The real dccd Binance store root (1m parquet, dirs keyed "BTC-USDT").
 _STORE = Path.home() / "data" / "arthurserver" / "binance" / "ohlc"
+
+#: The real dccd Kraken store root (1m parquet, dirs keyed "BTC-USD").
+_KRAKEN_STORE = Path.home() / "data" / "arthurserver" / "kraken" / "ohlc"
 
 #: The 10 LS1 coins (all *-USDT, daily) — DEPLOY_LS1.md §2.
 _LS1_COINS = ["BTC", "ETH", "BCH", "LTC", "XRP", "XLM", "DOGE", "DOT", "TRX", "ZEC"]
@@ -114,15 +118,42 @@ class _ParquetSource:
     real 1m→daily resampling code (not a hand-rolled copy) is what the e2e
     exercises. Store dirs are keyed ``"BTC-USDT"`` (hyphen); a requested pair in
     any form (``"BTCUSDT"`` / ``"BTC/USDT"`` / ``"BTC-USDT"``) is normalised to it,
-    so the **default** ``run_app`` feed (which renders ``"BTCUSDT"``) resolves
-    without any config-side ``symbol_for`` hook.
+    so the **default** ``run_app`` feed (which renders ``"BTCUSDT"`` for Binance or
+    ``"XBTUSD"`` for Kraken) resolves without any config-side ``symbol_for`` hook —
+    every spelling normalises back to the canonical ``BASE-QUOTE`` store key.
+
+    Parameters
+    ----------
+    store : Path, optional
+        The venue's OHLC store root (``<root>/<PAIR>/1m/*.parquet``). Defaults to
+        the Binance store; pass :data:`_KRAKEN_STORE` for the Kraken USD pairs.
     """
 
-    @staticmethod
-    def _dir_for(symbol: str) -> str:
-        """Map any pair spelling to the store's hyphen dir key (``"BTC-USDT"``)."""
-        sym = parse_binance_symbol(symbol)
-        return f"{sym.base}-{sym.quote}"
+    def __init__(self, store: Path = _STORE) -> None:
+        self._store = store
+
+    def _dir_for(self, symbol: str) -> str:
+        """Map any venue render to the store's ``BASE-QUOTE`` dir key.
+
+        Venue renders are ambiguous to invert — ``to_venue_symbol("kraken")``
+        gives ``XBTUSD`` (which ``parse_binance_symbol`` mis-reads as ``XB/TUSD``)
+        and ``TRXUSD`` (which ``parse_kraken_pair`` mis-reads as ``TR/USD`` — the
+        ``X`` looks like a legacy prefix). So try **both** canonical parsers and
+        pick the candidate whose dir actually **exists** in this store; fall back
+        to the first parse. Robust for Binance (``BTCUSDT``) and Kraken
+        (``XBTUSD``/``TRXUSD``) renders alike.
+        """
+        candidates: list[str] = []
+        for parse in (parse_kraken_pair, parse_binance_symbol):
+            try:
+                sym = parse(symbol)
+            except ValueError:
+                continue
+            candidates.append(f"{sym.base}-{sym.quote}")
+        for cand in candidates:
+            if (self._store / cand).is_dir():
+                return cand
+        return candidates[0] if candidates else symbol
 
     def read(
         self,
@@ -133,7 +164,7 @@ class _ParquetSource:
         start_ns: int | None = None,
         end_ns: int | None = None,
     ) -> pl.DataFrame:
-        base = _STORE / self._dir_for(symbol) / "1m"
+        base = self._store / self._dir_for(symbol) / "1m"
         files = sorted(base.glob("*.parquet"))
         if not files:
             pytest.skip(f"no 1m parquet for {symbol} under {base}")
@@ -542,6 +573,113 @@ async def test_ls1_real_e2e() -> None:
 
     # Each coin's broker-confirmed net == weightᵢ × capital / priceᵢ on the latest
     # real close (a coin with weight 0 is flat — no position).
+    for sym in universe:
+        want = money(str(weights.get(sym, money("0")) * capital / closes[sym]))
+        pos = engine.tracker.position(Instrument(sym))
+        got = pos.net_qty if pos is not None else money("0")
+        assert got == want, f"{sym}: confirmed {got} != intended {want}"
+
+
+# =========================================================================== #
+# 3a-kraken. LS1 on Kraken (USD) — real signal + real data + LIVE public ticker,
+#            but PaperBroker (NO real order; Kraken has no testnet → real money)
+# =========================================================================== #
+
+
+@pytest.mark.network
+async def test_ls1_kraken_real_e2e() -> None:
+    """The real LS1 signal on **Kraken** (USD) → real dccd Kraken bars → PaperBroker.
+
+    The Kraken counterpart of :func:`test_ls1_real_e2e`. **Kraken has no public
+    spot testnet**, so a live test that *places* orders on Kraken would be real
+    money. This therefore runs the **real** LS1 Kraken book
+    (``fynance_research...target_weights("kraken")`` via ``ls1_kraken_signal``)
+    over the **real dccd Kraken store**, with a **live Kraken public-ticker**
+    sanity check (key-free) — but routes the rebalance through the **PaperBroker**:
+    **no real order is ever placed**. Asserts Σ|w| ≤ 2 and each coin's
+    broker-confirmed position == ``weightᵢ × capital / priceᵢ`` on the latest real
+    Kraken close.
+
+    SKIPS without the research package. To run::
+
+        pip install -e ../fynance-research
+        .venv/bin/python -m pytest \\
+            trading_bot/tests/application/test_ls1_e2e.py::test_ls1_kraken_real_e2e \\
+            -m network -v
+    """
+    pytest.importorskip(
+        "fynance_research",
+        reason="LS1 needs the research package: pip install -e ../fynance-research",
+    )
+    if not _KRAKEN_STORE.is_dir():
+        pytest.skip(
+            "no dccd Kraken store at ~/data/arthurserver/kraken/ohlc; sync the 10 "
+            "LS1 *-USD 1m pairs via the dccd daemon"
+        )
+
+    from examples.ls1_signal import ls1_kraken_signal
+
+    capital = money("100000")
+    gross_cap = money("2")
+    client = ResamplingDccdClient(_ParquetSource(_KRAKEN_STORE))
+    universe = [Symbol(c, "USD") for c in _LS1_COINS]
+
+    # The real Kraken oracle (reads its own store), Σ|w| ≤ 2.
+    weights = ls1_kraken_signal(0, {})
+    assert_gross_within(weights, gross_cap)
+
+    cfg = AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "starting_capital": str(capital),
+            "brokers": [{"name": "paper-kraken", "exchange": "paper"}],
+            "portfolios": [
+                {
+                    "name": "ls1-kraken",
+                    "venue": "kraken",
+                    "universe": [f"{s.base}/{s.quote}" for s in universe],
+                    "signal": {"ref": "examples.ls1_signal:ls1_kraken_signal"},
+                    "capital": str(capital),
+                    "gross_cap": str(gross_cap),
+                    "data": {"exchange": "kraken", "span": 86_400},
+                }
+            ],
+        }
+    )
+
+    from trading_bot.application.portfolio_feed import PortfolioFeed
+    from trading_bot.application.run_app import build_portfolio_runners
+    from trading_bot.application.service_factory import build_engine
+    from trading_bot.brokers.kraken import KrakenBroker
+
+    feed = PortfolioFeed(
+        universe,
+        exchange="kraken",
+        client=client,
+        span=86_400,
+        symbol_for=lambda s: f"{s.base}-{s.quote}",
+    )
+    latest = feed.latest()
+    closes = {sym: money(str(latest[sym]["c"][-1])) for sym in universe}
+
+    # LIVE Kraken public ticker (key-free) — confirm the venue responds live and the
+    # latest dccd daily close is in the same ballpark as the intraday price (a wide
+    # band, since one is a daily close and the other is live intraday).
+    live_btc = await KrakenBroker().ticker(Instrument(Symbol("BTC", "USD")))
+    assert live_btc > 0
+    ratio = live_btc / closes[Symbol("BTC", "USD")]
+    assert money("0.5") < ratio < money("2"), (
+        f"live Kraken BTC/USD {live_btc} far from dccd close "
+        f"{closes[Symbol('BTC', 'USD')]}"
+    )
+
+    # Assemble exactly as run_app does and rebalance ONCE on the latest window —
+    # through the PaperBroker (no real order). Each coin's broker-confirmed net ==
+    # weightᵢ × capital / priceᵢ on the latest real Kraken close.
+    engine = build_engine(cfg, db_path=cfg.storage.db_path)
+    runner = build_portfolio_runners(cfg, engine, dccd_client=client)[0]
+    await runner.rebalance(runner._feed.latest())
+
     for sym in universe:
         want = money(str(weights.get(sym, money("0")) * capital / closes[sym]))
         pos = engine.tracker.position(Instrument(sym))


### PR DESCRIPTION
## Summary
- **LS1 now runs on Kraken (USD) too**, by config: `examples/ls1_signal.py` gains `ls1_kraken_signal` (`target_weights("kraken")`); `configs/ls1_kraken.yaml` mirrors the Binance config on the 10 `-USD` pairs + dccd Kraken store.
- **Live tests on both venues** (real data, real signal):
  - **Binance** — `test_ls1_real_e2e` (real LS1 + real dccd bars → PaperBroker, delta-correct) + the opt-in **testnet** order round-trip.
  - **Kraken** — `test_ls1_kraken_real_e2e`: real LS1 Kraken signal + real dccd Kraken bars + a **live Kraken public-ticker** check, routed through the **PaperBroker** — **no real order** (Kraken has no spot testnet → orders = real money).

## Why (the Kraken safety call)
Kraken has no public spot testnet, so a live test that *places* orders would be real money. Per the maintainer's choice, the Kraken live test is **public data + PaperBroker**: it validates the whole chain (data → signal → sizing → delta → routing → risk) on live data, with zero financial risk. Real Kraken order placement stays the deliberate go-live opt-in. See ADR.

## Verification on real data (ran)
- `LS1 binance`: 10 coins, Σ|w|=0.199 · `LS1 kraken`: 10 coins, Σ|w|=0.153 (asof 2026-06-29).
- **LIVE tickers** (key-free): Kraken BTC/USD = `59696.0`, Binance BTC/USDT = `59810.0`.
- `test_ls1_e2e.py -m network`: **3 passed** (Binance LS1, Kraken LS1, dccd portfolio), 1 skipped (Binance testnet — no key). Each asserts broker-confirmed deltas == `wᵢ × capital / priceᵢ` on real closes.

## Finding (roadmap follow-up)
`to_venue_symbol("kraken")` renders (`XBTUSD`/`TRXUSD`) are ambiguous to invert (no single parser handles both); the test client disambiguates by existence-checking the store, but the **production** config → real-dccd store-key convention is unpinned (added to `07-roadmap.md`).

## Changes
- `examples/ls1_signal.py`, `configs/ls1_kraken.yaml` (new), `tests/application/test_ls1_e2e.py` (+ kraken live test, robust `_dir_for`).

## Test plan
- [x] `.venv/bin/python -m pytest` — 701 passed, 13 deselected
- [x] `-m network` LS1 — 3 passed, 1 skipped (testnet)
- [x] `.venv/bin/ruff check trading_bot/ examples/` + `mypy` — clean
- [ ] CI green