### PR TITLE
fix: wire reconcile-on-startup into run_app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Reconcile-on-startup is now wired** into the run loop. `run_app` calls
+  `reconcile(broker, router, tracker)` right after `build_engine` (before any runner
+  starts; opt-out `reconcile_on_start=False`), so a restart converges the engine's
+  empty maps to the venue's truth — ingesting venue-open orders, closing orphans, and
+  rebuilding positions from confirmed fills — **before the first order**. The
+  *reconcile, don't assume* invariant was implemented + hardening-tested but had **no
+  production caller**; it is now enforced on every start (a no-op on a fresh
+  `PaperBroker`; the safety backstop on a live/testnet venue). (#71)
+
 ### Deprecated
 
 ### Removed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,30 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Reconcile-on-startup is wired into `run_app` (PR #71)  [accepted]
+
+**Choice.** `run_app` calls `reconcile(broker, router, tracker, event_bus=…)`
+immediately after `build_engine`, before any runner starts (new opt-out
+`reconcile_on_start: bool = True`). A freshly-built engine has **empty** local maps;
+the venue may already hold open orders + a fill history (a restart). Reconciling first
+ingests venue-open orders, closes orphans, and rebuilds positions from confirmed fills,
+so the engine never re-submits a venue-held order or trades a stale (zero) position.
+A no-op on a fresh `PaperBroker`; the safety backstop on a live/testnet venue.
+
+**Why.** A pre-production audit found the *reconcile, don't assume* invariant was fully
+implemented and hardening-tested but had **zero production callers** — it was inert.
+The single system entrypoint, before the orchestrator runs, is the lowest-risk wiring
+point and keeps every caller (CLI, daemon, tests) converging identically.
+
+**Rejected alternatives.** Reconcile inside `build_engine` (the factory is sync and
+does no I/O — keep it pure); reconcile per-runner (the engine/broker is shared, one
+pass suffices). The **post-disconnect** half of the invariant (reconcile on a WS
+reconnect) is **deferred**: the private fill WS is not wired into the run loop yet, so
+there is no reconnect to hook — it lands with live fill streaming (tracked in the
+roadmap).
+
+---
+
 ### 2026-06-29 Strategies are local-only — never committed to the engine repo (PR #70)
 
 **Decision.** Concrete **strategies** — the signal wrapper, the strategy config(s),

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -22,6 +22,13 @@ the gitignored `strategies/`, real dccd-data verified). History in `CHANGELOG.md
 
 ## Known issues / follow-ups
 
+- [ ] **Live fill streaming + post-disconnect reconcile.** Reconcile is now wired
+  **on startup** (`run_app` converges the engine to the venue before the first order),
+  but the **after-disconnect** half of *reconcile, don't assume* is not: the private
+  fill WS (`KrakenPrivateWS`) is not wired into the run loop, so there is no reconnect
+  to trigger a reconcile pass on, and live fills are not streamed onto the bus. Wire
+  the private fill WS into the engine and trigger `reconcile` on each reconnect (and
+  land fill-id dedup — see below — before that stream feeds the tracker).
 - [ ] **Portfolio config → real-dccd store-key convention unpinned.** The default
   `PortfolioFeed` renders pairs via `to_venue_symbol(exchange)` (`BTCUSDT`; Kraken
   `XBTUSD`/`TRXUSD`), which (a) doesn't match a hyphen-keyed `BASE-QUOTE` dccd store and

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -81,6 +81,7 @@ from trading_bot.application.portfolio import (
 )
 from trading_bot.application.portfolio_feed import PortfolioFeed
 from trading_bot.application.portfolio_runner import PortfolioRunner
+from trading_bot.application.reconcile import reconcile
 from trading_bot.application.service_factory import Engine, build_engine
 from trading_bot.application.strategy import (
     SignalFn,
@@ -638,12 +639,15 @@ async def run_app(
     *,
     dccd_client: DccdClient | None = None,
     max_steps: int | None = None,
+    reconcile_on_start: bool = True,
 ) -> RunReport:
     """Run the whole declared system from one config and return a summary.
 
     The triptych entrypoint: assemble the engine
     (:func:`~trading_bot.application.service_factory.build_engine`,
-    paper-by-default — the factory enforces it), build a runner per declared
+    paper-by-default — the factory enforces it), **reconcile** the freshly-built
+    engine's local state to the broker's truth before any order is placed (the
+    *reconcile, don't assume* invariant — see below), build a runner per declared
     single-instrument strategy (:func:`build_runners`) **and** per declared
     portfolio (:func:`build_portfolio_runners`), reject any instrument claimed by
     two runners (:func:`_reject_commingled`, spanning strategies *and*
@@ -651,6 +655,26 @@ async def run_app(
     :class:`~trading_bot.application.orchestrator.Orchestrator`. After the run,
     build a :class:`RunReport` from the per-runner order counts and the engine's
     shared tracker / performance service (fills are the PnL source of truth).
+
+    Reconcile-on-startup (carried into the ADR)
+    -------------------------------------------
+    A freshly-built :class:`~trading_bot.application.service_factory.Engine` has
+    **empty** local maps (the router tracks no orders, the tracker holds no
+    positions), but the venue may already hold open orders and a fill history
+    from a previous session/restart. Running blind would risk re-submitting an
+    order the venue already has or trading against a stale (zero) position. So
+    before the first order, :func:`~trading_bot.application.reconcile.reconcile`
+    pulls the broker's open orders / balances / fills **once** and converges the
+    router + tracker to them (ingest unknown live orders, close orphans, rebuild
+    positions from confirmed fills). On a fresh
+    :class:`~trading_bot.brokers.paper.PaperBroker` this is a harmless no-op (no
+    open orders, no fills); on a live/testnet venue it is the safety backstop that
+    recovers state after a restart. The pass emits one
+    :class:`~trading_bot.application.events.LogEvent` on the engine bus.
+
+    Reconciling **after a disconnect** (the WS-reconnect half of the invariant)
+    attaches to the private fill stream, which is not yet wired into this run
+    loop; that lands with live fill streaming (tracked in the roadmap).
 
     Parameters
     ----------
@@ -667,6 +691,10 @@ async def run_app(
         Cap each runner at this many feed windows / rebalance ticks (bounds an
         otherwise feed-length run; useful for tests / live feeds). ``None``
         (default) drains every feed to exhaustion.
+    reconcile_on_start : bool, optional
+        Whether to reconcile the engine to the broker before running (default
+        ``True``, enforcing the startup invariant). Pass ``False`` only to skip
+        the pass in a test/offline context where the broker reads are irrelevant.
 
     Returns
     -------
@@ -687,6 +715,14 @@ async def run_app(
 
     """
     engine = build_engine(config, db_path=config.storage.db_path)
+    # Reconcile, don't assume: converge the fresh engine's empty maps to the
+    # broker's truth (open orders + fills) before the first order is placed, so a
+    # restart never re-submits a venue-held order or trades a stale position. A
+    # no-op on a fresh PaperBroker; the safety backstop on a live/testnet venue.
+    if reconcile_on_start:
+        await reconcile(
+            engine.broker, engine.router, engine.tracker, event_bus=engine.bus
+        )
     # Reject any instrument claimed by two runners up front — across both the
     # single-instrument strategies and the portfolios (the shared per-instrument
     # tracker has no attribution). build_runners also calls this for the

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -460,3 +460,133 @@ def test_run_app_empty_config_runs_no_strategies() -> None:
     assert report.strategies == []
     assert report.total_orders == 0
     assert report.realised_pnl == money("0")
+
+
+# --- reconcile-on-startup (the "reconcile, don't assume" invariant) -------- #
+
+
+async def test_run_app_reconciles_on_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """`run_app` reconciles the engine to the broker before running.
+
+    Spies the ``reconcile`` the entrypoint calls and asserts it is awaited exactly
+    once with the engine's own broker / router / tracker (the wired collaborators)
+    — so a restart converges to the venue's truth *before* the first order.
+    ``reconcile``'s actual convergence is proven in ``tests/hardening/``; this
+    asserts the wiring.
+    """
+    import importlib
+
+    run_app_mod = importlib.import_module("trading_bot.application.run_app")
+    from trading_bot.application.order_router import OrderRouter
+    from trading_bot.application.position_tracker import PositionTracker
+    from trading_bot.application.reconcile import ReconResult
+    from trading_bot.brokers.paper import PaperBroker
+
+    calls: list[tuple[object, object, object]] = []
+
+    async def _spy(broker, router, tracker, *, since_ms=None, event_bus=None):  # noqa: ANN001, ANN202
+        calls.append((broker, router, tracker))
+        return ReconResult(0, 0, 0, 0, 0)
+
+    monkeypatch.setattr(run_app_mod, "reconcile", _spy)
+
+    await run_app(AppConfig())  # paper, no strategies
+
+    assert len(calls) == 1
+    broker, router, tracker = calls[0]
+    assert isinstance(broker, PaperBroker)
+    assert isinstance(router, OrderRouter)
+    assert isinstance(tracker, PositionTracker)
+
+
+async def test_run_app_can_skip_reconcile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``reconcile_on_start=False`` skips the startup reconcile (opt-out honoured)."""
+    import importlib
+
+    run_app_mod = importlib.import_module("trading_bot.application.run_app")
+
+    calls: list[object] = []
+
+    async def _spy(*a: object, **k: object) -> None:
+        calls.append(a)
+
+    monkeypatch.setattr(run_app_mod, "reconcile", _spy)
+
+    await run_app(AppConfig(), reconcile_on_start=False)
+    assert calls == []
+
+
+async def test_run_app_startup_reconcile_converges_to_venue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: a restart (empty engine, venue ahead) converges via ``run_app``.
+
+    Verification on real broker state: a :class:`PaperBroker` is left holding an
+    open, partially-filled order whose fill the freshly-built tracker never saw
+    (the order is placed **directly** on the broker, before the tracker subscribes
+    — modelling a restart where the engine maps are empty but the venue is ahead).
+    With the default ``reconcile_on_start=True``, ``run_app`` must ingest the
+    venue-open order into the router and rebuild the BTC position from the venue's
+    confirmed fill before the (strategy-less) run.
+    """
+    import importlib
+
+    run_app_mod = importlib.import_module("trading_bot.application.run_app")
+    from trading_bot.application.events import EventBus
+    from trading_bot.application.order_router import OrderRouter
+    from trading_bot.application.performance_service import PerformanceService
+    from trading_bot.application.position_tracker import PositionTracker
+    from trading_bot.application.risk import RiskManager
+    from trading_bot.application.service_factory import Engine
+    from trading_bot.brokers.paper import PaperBroker
+    from trading_bot.domain.order import Order, OrderSide, OrderType
+
+    bus = EventBus()
+    broker = PaperBroker(
+        prices={BTC_USD: money("30000")},
+        starting_balances={"USD": money("100000000")},
+        event_bus=bus,
+    )
+    # Leave an open, partially-filled order ON THE VENUE — placed directly on the
+    # broker so the not-yet-built engine tracker never sees its fill.
+    broker.arm_partial(money("0.5"))
+    await broker.place_order(
+        Order(
+            client_order_id="pre-existing",
+            instrument=BTC_USD,
+            side=OrderSide.BUY,
+            qty=money("4"),
+            type=OrderType.LIMIT,
+            limit_price=money("30000"),
+        )
+    )
+
+    # Now wire a FRESH (empty) engine over that same broker/bus — the restart: the
+    # tracker subscribes only now, after the fill above was already emitted.
+    config = AppConfig()
+    tracker = PositionTracker(event_bus=bus)
+    perf = PerformanceService(v0=config.starting_capital, event_bus=bus)
+    risk = RiskManager(config.risk, position_tracker=tracker)
+    router = OrderRouter(broker, bus, risk_manager=risk)
+    engine = Engine(
+        config=config,
+        bus=bus,
+        broker=broker,
+        router=router,
+        tracker=tracker,
+        perf=perf,
+        risk=risk,
+        store=None,
+    )
+    assert router.tracked_orders() == {}
+    assert tracker.all_positions() == {}
+
+    monkeypatch.setattr(
+        run_app_mod, "build_engine", lambda cfg, db_path=None: engine
+    )
+    await run_app(config)  # reconcile_on_start defaults True
+
+    # The venue-open order is now tracked (ingested), and the BTC position was
+    # rebuilt from the venue's confirmed fill — the engine converged to the venue.
+    assert router.get("pre-existing") is not None
+    assert BTC_USD in tracker.all_positions()


### PR DESCRIPTION
## Summary
- `run_app` now calls `reconcile(broker, router, tracker)` right after `build_engine`, before any runner starts (opt-out `reconcile_on_start=False`).
- A restart converges the engine's empty maps to the venue's truth — ingest venue-open orders, close orphans, rebuild positions from confirmed fills — **before the first order**.

## Why
- A pre-production audit found the *reconcile, don't assume* invariant was fully implemented + hardening-tested but had **zero production callers** — it was inert. This wires it at the single system entrypoint (lowest-risk seam; every caller converges identically).
- No-op on a fresh `PaperBroker`; the safety backstop on a live/testnet venue.

## Changes
- `application/run_app.py`: import `reconcile`; new `reconcile_on_start: bool = True` param; reconcile call after `build_engine`; docstring (ADR rationale).
- `tests/application/test_run_app.py`: wiring spy (reconcile awaited once with the engine's broker/router/tracker), opt-out test, and an **end-to-end convergence** test (real `PaperBroker` left ahead of an empty engine → `run_app` ingests the venue-open order + rebuilds the position).
- ADR + CHANGELOG (Fixed) + roadmap follow-up for the deferred post-disconnect/private-WS half.

## Test plan
- [x] `pytest` — 702 passed, 9 deselected
- [x] `ruff check trading_bot/` clean
- [x] `mypy trading_bot/` clean
- [x] reconcile convergence proven (run_app e2e + `tests/hardening/test_reconciliation.py`)
- [ ] CI green