### PR TITLE
fix: wire the daily-loss circuit breaker to live PnL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Daily-loss circuit breaker is now wired.** `build_engine` feeds the `RiskManager`
+  the live signed realised PnL (`daily_pnl_provider=perf.realised_pnl`) — previously it
+  saw a constant zero, so `max_daily_loss` never engaged. Reaching the limit now refuses
+  every new order, and a `max_daily_loss` breach **escalates to the kill-switch** in the
+  `OrderRouter` (cancel resting orders + trip the halt), since the limit is the day's
+  *halt* threshold, not a one-order cap. (#72)
 - **Reconcile-on-startup is now wired** into the run loop. `run_app` calls
   `reconcile(broker, router, tracker)` right after `build_engine` (before any runner
   starts; opt-out `reconcile_on_start=False`), so a restart converges the engine's

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,27 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Daily-loss limit is wired to live PnL and escalates to the kill-switch (PR #72)  [accepted]
+
+**Choice.** `build_engine` passes `daily_pnl_provider=perf.realised_pnl` to the
+`RiskManager`, and the `OrderRouter` escalates a `max_daily_loss` breach to
+`RiskManager.kill(router=self)` — cancel resting orders + trip — before re-raising.
+
+**Why.** A pre-production audit found `max_daily_loss` was inert: the factory wired no
+provider, so the gate read a constant zero and never halted; and `kill()` / `trip()`
+had no production trigger. `max_daily_loss` is documented as the day's *halt* threshold
+("trading halts for the day"), so reaching it must stop the whole book, not merely
+refuse the one breaching order.
+
+**Rejected alternatives.** Tripping inside `RiskManager.check` (it is synchronous and
+holds no router/broker, so it cannot cancel resting orders — the async escalation
+belongs in the router, which owns the broker handle); a separate fill-stream monitor
+(more moving parts; the breach is already observed at the gate on the next order).
+"Daily" is the run session (the manager owns no clock); a multi-day reset wires
+`reset_day` / a perf reset to a scheduler — deferred.
+
+---
+
 ### 2026-06-29 Reconcile-on-startup is wired into `run_app` (PR #71)  [accepted]
 
 **Choice.** `run_app` calls `reconcile(broker, router, tracker, event_bus=…)`

--- a/trading_bot/application/order_router.py
+++ b/trading_bot/application/order_router.py
@@ -63,7 +63,12 @@ from typing import TYPE_CHECKING
 
 from trading_bot.application.events import EventBus, OrderEvent
 from trading_bot.brokers.base import Broker, Capability, require
-from trading_bot.domain.errors import BrokerError, MissingOrder, OrderError
+from trading_bot.domain.errors import (
+    BrokerError,
+    MissingOrder,
+    OrderError,
+    RiskLimitBreached,
+)
 from trading_bot.domain.order import Order, OrderStatus
 
 if TYPE_CHECKING:
@@ -242,11 +247,32 @@ class OrderRouter:
         so it leaves no ``REJECTED`` record and the dedup map is unchanged (a
         subsequent submit of the same id is a fresh attempt, not a deduped
         replay).
+
+        One breach is escalated rather than merely refused: ``max_daily_loss`` is
+        the day's *halt* threshold (not a one-order cap), so when the gate raises
+        it the router first calls :meth:`~trading_bot.application.risk.RiskManager
+        .kill` (cancel every resting order + trip the switch) and *then* re-raises
+        — the whole book halts for the day, not just this order.
         """
         if self._risk is not None:
             # Pre-trade gate: raises RiskLimitBreached before the broker is ever
-            # touched. Left to propagate untracked (see the docstring).
-            self._risk.check(order)
+            # touched. Left to propagate untracked (see the docstring). A
+            # ``max_daily_loss`` breach is special: that limit is the day's *halt*
+            # threshold, not a one-order cap, so reaching it must stop trading for
+            # the day — the router escalates to the kill-switch (cancel resting
+            # orders + trip) before re-raising. Other breaches propagate unchanged.
+            try:
+                self._risk.check(order)
+            except RiskLimitBreached as breach:
+                if breach.limit == "max_daily_loss" and not self._risk.tripped:
+                    await self._risk.kill(
+                        router=self,
+                        reason=(
+                            f"max_daily_loss breached: daily loss {breach.value} "
+                            f">= {breach.threshold} — halting for the day"
+                        ),
+                    )
+                raise
         try:
             venue_id = await self._broker.place_order(order)
             order.submit()

--- a/trading_bot/application/service_factory.py
+++ b/trading_bot/application/service_factory.py
@@ -195,7 +195,18 @@ def build_engine(
     # ratios are computed over a strictly-positive account value (the curve does
     # not sign-cross), making Sharpe/Sortino/Calmar over a real run meaningful.
     perf = PerformanceService(v0=config.starting_capital, event_bus=bus)
-    risk = RiskManager(config.risk, position_tracker=tracker)
+    # Wire the daily-loss circuit breaker to the live PnL: the risk manager reads
+    # the day's *signed realised PnL* (a loss is negative) straight off the
+    # performance service. Without this, ``max_daily_loss`` saw a constant zero and
+    # never engaged; with it, once the day's realised loss reaches the limit the
+    # gate refuses every new order (and the router escalates to the kill-switch —
+    # cancelling resting orders + halting — on that breach). "Daily" here is the run
+    # session (no clock); a multi-day reset wires ``reset_day`` to a scheduler.
+    risk = RiskManager(
+        config.risk,
+        position_tracker=tracker,
+        daily_pnl_provider=perf.realised_pnl,
+    )
     router = OrderRouter(broker, bus, risk_manager=risk)
 
     store: SqliteStore | None = None

--- a/trading_bot/tests/application/test_order_router.py
+++ b/trading_bot/tests/application/test_order_router.py
@@ -36,6 +36,7 @@ from trading_bot.domain import (
     OrderSide,
     OrderStatus,
     OrderType,
+    RiskLimitBreached,
     Symbol,
     money,
 )
@@ -323,3 +324,55 @@ async def test_real_paperbroker_concurrent_duplicate_one_order() -> None:
 
     assert a is b
     assert len(await broker.fills()) == 1, "one paper fill despite two submits"
+
+
+# --- daily-loss circuit breaker (router escalates to the kill-switch) ------ #
+
+
+async def test_daily_loss_breach_escalates_to_kill_switch_and_cancels_resting() -> None:
+    """A ``max_daily_loss`` breach trips the switch and cancels resting orders.
+
+    ``max_daily_loss`` is the day's *halt* threshold, not a one-order cap: reaching
+    it must stop trading for the day. So when ``risk.check`` raises it, the router
+    escalates to ``RiskManager.kill`` — cancel every resting order **and** trip the
+    switch — before re-raising. After the breach the previously-open order is
+    ``CANCELLED`` and any further order is refused as the kill-switch, not merely
+    the per-order limit.
+    """
+    from trading_bot.application.config import RiskConfig
+    from trading_bot.application.risk import RiskManager
+
+    bus = EventBus()
+    # A partial fill leaves the first order OPEN (resting) with a venue id to cancel.
+    broker = PaperBroker(fill_model="partial", partial_fill_ratio=money("0.5"))
+    pnl = {"v": money("0")}  # the day's signed realised PnL the provider reads
+    risk = RiskManager(
+        RiskConfig(max_daily_loss=money("100")),
+        daily_pnl_provider=lambda: pnl["v"],
+    )
+    router = OrderRouter(broker, bus, risk_manager=risk)
+
+    # No loss yet → the first order places and rests OPEN on the venue.
+    resting = await router.submit(_order("rest-1", qty="4"))
+    assert resting.status is OrderStatus.OPEN
+    assert resting.venue_order_id is not None
+    assert risk.tripped is False
+
+    # The day's realised loss now exceeds the cap.
+    pnl["v"] = money("-150")
+
+    # The next order breaches max_daily_loss → the router escalates to kill().
+    with pytest.raises(RiskLimitBreached) as excinfo:
+        await router.submit(_order("blocked-1"))
+    assert excinfo.value.limit == "max_daily_loss"
+
+    # The switch is now tripped (hard halt) and the resting order was cancelled.
+    assert risk.tripped is True
+    cancelled = router.get("rest-1")
+    assert cancelled is not None
+    assert cancelled.status is OrderStatus.CANCELLED
+
+    # Any further order is now refused as the kill-switch, not the per-order limit.
+    with pytest.raises(RiskLimitBreached) as again:
+        await router.submit(_order("blocked-2"))
+    assert again.value.limit == "kill_switch"

--- a/trading_bot/tests/application/test_service_factory.py
+++ b/trading_bot/tests/application/test_service_factory.py
@@ -29,7 +29,11 @@ from trading_bot.application.service_factory import Engine, build_engine
 from trading_bot.brokers.binance import TESTNET_API_BASE, BinanceBroker
 from trading_bot.brokers.kraken import KrakenBroker
 from trading_bot.brokers.paper import PaperBroker
-from trading_bot.domain.errors import BrokerError, LiveTradingNotEnabled
+from trading_bot.domain.errors import (
+    BrokerError,
+    LiveTradingNotEnabled,
+    RiskLimitBreached,
+)
 from trading_bot.domain.fill import Fill
 from trading_bot.domain.instrument import Instrument, Symbol
 from trading_bot.domain.money import money
@@ -397,3 +401,44 @@ def test_paper_mode_ignores_testnet() -> None:
 def test_brokerconfig_testnet_defaults_false() -> None:
     """``testnet`` defaults to False (a plain broker is mainnet/live)."""
     assert BrokerConfig(name="bn", exchange="binance").testnet is False
+
+
+# --- the daily-loss circuit breaker is wired to live PnL ------------------- #
+
+
+def test_build_engine_wires_daily_loss_provider_to_performance_service() -> None:
+    """``build_engine`` feeds the risk gate the day's realised PnL from ``perf``.
+
+    Verification on real engine state: with ``max_daily_loss`` set, a BUY then a
+    lower SELL are emitted as fills on the engine bus (realising a loss in the
+    shared :class:`PerformanceService`). The risk gate — which previously saw a
+    constant zero and never engaged — now reads that loss through the wired
+    provider and refuses the next order with ``max_daily_loss``.
+    """
+    from trading_bot.application.config import RiskConfig
+
+    config = AppConfig(risk=RiskConfig(max_daily_loss=money("5")))
+    engine = build_engine(config)
+
+    # Before any loss, the gate passes.
+    probe = Order(
+        client_order_id="probe-0",
+        instrument=_BTCUSD,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        type=OrderType.LIMIT,
+        limit_price=money("100"),
+    )
+    engine.risk.check(probe)  # no raise — flat day
+
+    # Realise a loss of 10 (BUY 1 @ 100, SELL 1 @ 90) via fills on the bus, so the
+    # shared performance service reports realised_pnl == -10.
+    engine.bus.emit(_fill_event("F1", OrderSide.BUY, qty="1", price="100", fee="0"))
+    engine.bus.emit(_fill_event("F2", OrderSide.SELL, qty="1", price="90", fee="0"))
+    assert engine.perf.realised_pnl() == money("-10")
+
+    # The gate now reads that loss through the wired provider and halts.
+    with pytest.raises(RiskLimitBreached) as excinfo:
+        engine.risk.check(probe)
+    assert excinfo.value.limit == "max_daily_loss"
+    assert excinfo.value.value == money("10")  # the loss magnitude


### PR DESCRIPTION
## Summary
- `build_engine` now wires `daily_pnl_provider=perf.realised_pnl` into the `RiskManager`, so `max_daily_loss` reads the **live** signed realised PnL instead of a constant zero.
- A `max_daily_loss` breach **escalates to the kill-switch** in the `OrderRouter`: cancel every resting order + trip the halt, then re-raise.

## Why
- A pre-production audit found `max_daily_loss` was **inert**: no provider was wired (the gate always saw zero loss) and `kill()`/`trip()` had no production trigger. The limit is documented as the day's *halt* threshold — reaching it must stop the whole book, not refuse one order.

## Changes
- `application/service_factory.py`: `RiskManager(..., daily_pnl_provider=perf.realised_pnl)`.
- `application/order_router.py`: catch a `max_daily_loss` breach in `_do_submit` and `await risk.kill(router=self)` before re-raising (import `RiskLimitBreached`); docstring.
- `tests/application/test_service_factory.py`: end-to-end — realise a loss via fills on the engine bus, assert the gate then halts (`max_daily_loss`).
- `tests/application/test_order_router.py`: a breach cancels the resting order + trips the switch; a further order is refused as `kill_switch`.
- ADR + CHANGELOG (Fixed).

## Notes / deferred
- "Daily" = the run session (the manager owns no clock). A multi-day reset wires `reset_day`/a perf reset to a scheduler — deferred.

## Test plan
- [x] `pytest` — 704 passed, 9 deselected
- [x] `ruff check trading_bot/` clean
- [x] `mypy trading_bot/` clean
- [ ] CI green