### PR TITLE
feat: require explicit risk limits on the real-money live path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`pip install -e ../fynance-research`, like `dccd`) — the source of validated
   portfolio signals (LS1); kept out of the hard deps. (#66)
 
+### Changed
+
+- **Real-money live now requires explicit risk limits.** `build_engine` refuses a
+  `mode: live` + `live_enabled` config (with credentials) whose `RiskConfig` leaves
+  any of `max_order` / `max_position` / `max_daily_loss` unset — a `BrokerError`
+  naming the gaps, checked **after** the credential gate. An all-`None` `RiskConfig`
+  is *unconstrained*; trading real money with no size/exposure/daily-loss cap is
+  refused. Paper and testnet (paper money) are exempt. (#73)
+
 ### Fixed
 
 - **Daily-loss circuit breaker is now wired.** `build_engine` feeds the `RiskManager`

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,28 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Real-money live requires all three risk limits (PR #73)  [accepted]
+
+**Choice.** On the real-money live path (`mode: live` + `live_enabled` + credentials),
+`build_engine` refuses to return the live adapter unless `RiskConfig` sets all of
+`max_order`, `max_position` and `max_daily_loss` (a `BrokerError` naming the gaps).
+The check sits **after** the credential gate, so the existing "no creds → BrokerError"
+ordering is unchanged; paper and testnet return earlier and are exempt.
+
+**Why.** A pre-production audit found `RiskConfig` defaults every limit to `None`
+(unconstrained), so a live config with no `risk:` block would place orders with no
+size, exposure or daily-loss cap. For real money the limits must be deliberate, not
+opt-in-by-omission.
+
+**Rejected alternatives.** A pydantic `model_validator` on `AppConfig` (fires at config
+construction, which would change the error surface of several broker-selection tests
+that build `live_enabled` configs without limits, and would couple config validity to a
+risk policy); requiring limits for testnet too (testnet is paper money — over-strict).
+`ConfigError` vs `BrokerError` — kept `BrokerError` to match the factory's existing
+"refusing to trade live without X" vocabulary.
+
+---
+
 ### 2026-06-29 Daily-loss limit is wired to live PnL and escalates to the kill-switch (PR #72)  [accepted]
 
 **Choice.** `build_engine` passes `daily_pnl_provider=perf.realised_pnl` to the

--- a/doc/dev/09-go-live.md
+++ b/doc/dev/09-go-live.md
@@ -42,7 +42,13 @@ missing any one refuses with a non-zero exit / a raised
 3. **Credentials** — `KRAKEN_API_KEY` / `KRAKEN_API_SECRET` in the environment
    (via a gitignored `.env`, never committed). With `live_enabled: true` but no
    credentials the factory raises `BrokerError`.
-4. **CLI acknowledgement** — `trading-bot run --live` additionally requires
+4. **Risk limits set** — a real-money live engine requires **all three**
+   `RiskConfig` limits (`max_order`, `max_position`, `max_daily_loss`) to be
+   set. `build_engine` raises `BrokerError` (naming the missing ones) if any is
+   left `None` on the live path — an all-`None` config would trade with no
+   size/exposure/daily-loss cap. Checked **after** credentials; paper and testnet
+   (paper money) are exempt.
+5. **CLI acknowledgement** — `trading-bot run --live` additionally requires
    `--yes-i-understand` (or an interactive confirmation) *and* re-checks
    `live_enabled`. Missing either, the command refuses and points here.
 
@@ -90,12 +96,17 @@ Before the first live order, confirm every item:
 
 - [ ] **Risk limits set** in `RiskConfig`: `max_order` (largest single order),
       `max_position` (largest net exposure), `max_daily_loss` (the halt
-      threshold). An unset limit is *unconstrained* — set them deliberately.
+      threshold). All three are **now required on the live path** — `build_engine`
+      refuses (a `BrokerError` naming the gaps) if any is left `None`, since an
+      unset limit is *unconstrained*. The `max_daily_loss` breach is wired to halt
+      the book (refuse new orders + cancel resting orders via the kill-switch).
 - [ ] **Kill-switch tested** — confirm the `RiskManager` kill-switch cancels open
-      orders and halts new ones (covered offline by the hardening suite).
-- [ ] **Reconcile-on-startup** — on start and after any disconnect the engine
-      refetches open orders + balances + fills and reconciles local state;
-      confirm it converges (proven offline).
+      orders and halts new ones (covered offline by the hardening suite). It is
+      now auto-triggered on a `max_daily_loss` breach.
+- [ ] **Reconcile-on-startup** — on start the engine refetches open orders +
+      balances + fills and reconciles local state (now wired into `run_app`,
+      before the first order); confirm it converges (proven offline). Reconcile
+      *after a disconnect* is deferred to live fill streaming (roadmap).
 - [ ] **Strategy paper-validated** — the exact strategy you intend to run has
       been validated in `mode: paper` over representative data and behaves as
       expected.

--- a/trading_bot/application/service_factory.py
+++ b/trading_bot/application/service_factory.py
@@ -292,12 +292,47 @@ def _build_broker(config: AppConfig, bus: EventBus) -> Broker:
                 "set the venue's API key/secret in the environment "
                 "(refusing to trade live without credentials)"
             )
+        # Final live gate: a real-money engine must carry explicit risk limits — an
+        # all-None RiskConfig would trade with no size/exposure/daily-loss cap.
+        _require_live_risk_limits(config)
         return broker
 
     raise BrokerError(
         f"live mode: unknown venue {venue!r}; "
         f"known live venues are {sorted(_LIVE_VENUES)!r}"
     )
+
+
+def _require_live_risk_limits(config: AppConfig) -> None:
+    """Refuse a real-money live engine whose risk limits are not all set.
+
+    A :class:`~trading_bot.application.config.RiskConfig` leaves every limit
+    ``None`` (unconstrained) by default, so a live config with no ``risk:`` block
+    would place orders with **no** size, exposure or daily-loss cap — unacceptable
+    for real money. This gate requires ``max_order``, ``max_position`` **and**
+    ``max_daily_loss`` to be set before the live adapter is returned, naming any
+    that are missing. Reached **only** on the opted-in real-money path (``mode:
+    live`` + ``live_enabled`` + credentials); paper mode and testnet (paper money)
+    never get here, so they are exempt.
+    """
+    risk = config.risk
+    missing = [
+        name
+        for name, value in (
+            ("max_order", risk.max_order),
+            ("max_position", risk.max_position),
+            ("max_daily_loss", risk.max_daily_loss),
+        )
+        if value is None
+    ]
+    if missing:
+        raise BrokerError(
+            "live trading requires explicit risk limits, but "
+            f"{', '.join(missing)} {'is' if len(missing) == 1 else 'are'} unset "
+            "in RiskConfig (each None = unconstrained). Set max_order, "
+            "max_position and max_daily_loss before going live (see "
+            f"{_RUNBOOK}). No order placed."
+        )
 
 
 def _selected_venue(config: AppConfig) -> str:

--- a/trading_bot/tests/application/test_service_factory.py
+++ b/trading_bot/tests/application/test_service_factory.py
@@ -247,12 +247,20 @@ def test_live_enabled_with_credentials_builds_live_broker_no_order(
     is the whole point of the off-by-default opt-in: enabling it constructs the
     adapter without trading.
     """
+    from trading_bot.application.config import RiskConfig
+
     monkeypatch.setenv("KRAKEN_API_KEY", "k")
     monkeypatch.setenv("KRAKEN_API_SECRET", "c2VjcmV0")  # base64("secret")
     cfg = AppConfig(
         mode="live",
         live_enabled=True,
         brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
+        # A real-money live config must carry explicit risk limits (see below).
+        risk=RiskConfig(
+            max_order=money("1"),
+            max_position=money("5"),
+            max_daily_loss=money("1000"),
+        ),
     )
 
     engine = build_engine(cfg)
@@ -260,6 +268,49 @@ def test_live_enabled_with_credentials_builds_live_broker_no_order(
     # so no order / no network call was ever made.
     assert isinstance(engine.broker, KrakenBroker)
     assert engine.broker.has_credentials
+
+
+def test_live_without_risk_limits_refuses(monkeypatch) -> None:
+    """A real-money live config with no risk limits refuses (BrokerError).
+
+    `RiskConfig` defaults every limit to None (unconstrained); going live with an
+    all-None config would trade with no size/exposure/daily-loss cap. With opt-in
+    + credentials present, `build_engine` refuses and names the missing limits —
+    *after* the credential gate (so this is the real-money completeness check).
+    """
+    monkeypatch.setenv("KRAKEN_API_KEY", "k")
+    monkeypatch.setenv("KRAKEN_API_SECRET", "c2VjcmV0")
+    cfg = AppConfig(
+        mode="live",
+        live_enabled=True,
+        brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
+    )  # no risk block → all limits None
+    with pytest.raises(BrokerError, match="risk limits") as exc:
+        build_engine(cfg)
+    msg = str(exc.value)
+    assert "max_order" in msg
+    assert "max_position" in msg
+    assert "max_daily_loss" in msg
+
+
+def test_live_with_partial_risk_limits_refuses_naming_the_gaps(monkeypatch) -> None:
+    """Partial limits still refuse, naming exactly the unset ones."""
+    from trading_bot.application.config import RiskConfig
+
+    monkeypatch.setenv("KRAKEN_API_KEY", "k")
+    monkeypatch.setenv("KRAKEN_API_SECRET", "c2VjcmV0")
+    cfg = AppConfig(
+        mode="live",
+        live_enabled=True,
+        brokers=[BrokerConfig(name="kraken-main", exchange="kraken")],
+        risk=RiskConfig(max_order=money("1")),  # the other two still None
+    )
+    with pytest.raises(BrokerError, match="risk limits") as exc:
+        build_engine(cfg)
+    msg = str(exc.value)
+    assert "max_position" in msg
+    assert "max_daily_loss" in msg
+    assert "max_order" not in msg.split("unset")[0]  # max_order is set, not listed
 
 
 def test_live_mode_unknown_venue_refuses() -> None:

--- a/trading_bot/tests/brokers/test_binance_rest.py
+++ b/trading_bot/tests/brokers/test_binance_rest.py
@@ -23,7 +23,7 @@ from decimal import Decimal
 import httpx
 import pytest
 
-from trading_bot.application.config import AppConfig, BrokerConfig
+from trading_bot.application.config import AppConfig, BrokerConfig, RiskConfig
 from trading_bot.application.service_factory import build_engine
 from trading_bot.brokers import BinanceBroker, BrokerError, Capability
 from trading_bot.brokers.binance import TESTNET_API_BASE, _sign
@@ -734,6 +734,12 @@ def test_factory_live_binance_with_creds_builds_adapter_no_order(
         mode="live",
         live_enabled=True,
         brokers=[BrokerConfig(name="binance-main", exchange="binance")],
+        # A real-money live config must carry explicit risk limits.
+        risk=RiskConfig(
+            max_order=money("1"),
+            max_position=money("5"),
+            max_daily_loss=money("1000"),
+        ),
     )
 
     engine = build_engine(cfg)


### PR DESCRIPTION
## Summary
- `build_engine` now refuses a real-money live config (`mode: live` + `live_enabled` + credentials) whose `RiskConfig` leaves any of `max_order` / `max_position` / `max_daily_loss` unset — a `BrokerError` naming the gaps.
- Checked **after** the credential gate, so broker-selection error ordering is unchanged. Paper and testnet (paper money) are exempt.

## Why
- Audit: `RiskConfig` defaults every limit to `None` (unconstrained). A live config with no `risk:` block would trade with **no** size/exposure/daily-loss cap. For real money the limits must be deliberate.

## Changes
- `application/service_factory.py`: `_require_live_risk_limits(config)` on the `_LIVE_VENUES` branch (after creds).
- `tests/application/test_service_factory.py`: refusal with no limits + with partial limits (naming gaps); the live-build test now carries limits.
- `tests/brokers/test_binance_rest.py`: the live-build test now carries limits.
- `doc/dev/09-go-live.md`: new gate #4 (risk limits) + checklist updates (also notes A1 reconcile-on-startup + A2 daily-loss auto-halt).
- ADR + CHANGELOG (Changed).

## Test plan
- [x] `pytest` — 706 passed, 9 deselected
- [x] `ruff` + `mypy` clean
- [ ] CI green