### PR TITLE
fix: de-duplicate fills by fill_id (tracker + performance service)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,21 +54,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `[triptych]` extra documents `fynance-research` as an editable sibling install
-  (`pip install -e ../fynance-research`, like `dccd`) — the source of validated
-  portfolio signals (LS1); kept out of the hard deps. (#66)
-
-### Changed
-
 - **Real-money live now requires explicit risk limits.** `build_engine` refuses a
   `mode: live` + `live_enabled` config (with credentials) whose `RiskConfig` leaves
   any of `max_order` / `max_position` / `max_daily_loss` unset — a `BrokerError`
   naming the gaps, checked **after** the credential gate. An all-`None` `RiskConfig`
   is *unconstrained*; trading real money with no size/exposure/daily-loss cap is
   refused. Paper and testnet (paper money) are exempt. (#73)
+- `[triptych]` extra documents `fynance-research` as an editable sibling install
+  (`pip install -e ../fynance-research`, like `dccd`) — the source of validated
+  portfolio signals (LS1); kept out of the hard deps. (#66)
 
 ### Fixed
 
+- **Fills are now de-duplicated by `fill_id`** in both the `PositionTracker` and the
+  `PerformanceService`: a re-applied execution (e.g. a private-WS snapshot replay after
+  a reconnect) is ignored instead of silently double-counting the position / corrupting
+  the running realised PnL. `PositionTracker.reset` clears the seen-id set so a reconcile
+  rebuild from the broker's fills still folds them. (#74)
 - **Daily-loss circuit breaker is now wired.** `build_engine` feeds the `RiskManager`
   the live signed realised PnL (`daily_pnl_provider=perf.realised_pnl`) — previously it
   saw a constant zero, so `max_daily_loss` never engaged. Reaching the limit now refuses

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,30 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Fills are de-duplicated by `fill_id` in the read-side views (PR #74)  [accepted]
+
+**Choice.** `PositionTracker.apply` and `PerformanceService.apply` each keep a
+`set[str]` of folded `fill_id`s and ignore a fill whose id was already seen (the
+tracker returns the standing position; the service makes no PnL/fee/equity change).
+`PositionTracker.reset` clears the set so a reconcile rebuild from the broker's fills
+re-folds them.
+
+**Why.** The audit found both `apply` paths explicitly skipped dedup, trusting "the
+broker's fill stream is the de-duplicated source." That holds for the PaperBroker today,
+but a live **private fill WS** can re-emit an execution (Kraken v2 resends a snapshot on
+resubscribe after a reconnect). With no dedup, the tracker would double the position and
+the service's *incremental* running realised PnL would be silently corrupted with no
+detectable error. Dedup-by-id makes both views safe to feed from a live stream.
+
+**Rejected alternatives.** Relying on the upstream stream to never duplicate (fragile —
+exactly the reconnect case we must survive); deduping by object identity (a re-emit is a
+*new* `Fill` object with the same id); keying the set by `(instrument, fill_id)` (venue
+trade ids are unique per venue — a flat id set is enough and simpler). Not adding a perf
+`reset` (the service accumulates over the run session; the id set growing is bounded by
+fills seen and is fine).
+
+---
+
 ### 2026-06-29 Real-money live requires all three risk limits (PR #73)  [accepted]
 
 **Choice.** On the real-money live path (`mode: live` + `live_enabled` + credentials),

--- a/trading_bot/application/performance_service.py
+++ b/trading_bot/application/performance_service.py
@@ -147,6 +147,11 @@ class PerformanceService:
         # realised PnL is the delta of its instrument's position realised PnL).
         self._realised_pnl: Money = _ZERO
         self._fees_paid: Money = _ZERO
+        # Fill ids already folded — guards against a venue re-emitting the same
+        # execution (e.g. a private-WS snapshot replay after a reconnect), which
+        # would otherwise silently corrupt the running realised PnL. See
+        # :meth:`apply`.
+        self._seen_fill_ids: set[str] = set()
         self._bus = event_bus
         if event_bus is not None:
             event_bus.subscribe(self._on_event)
@@ -172,8 +177,10 @@ class PerformanceService:
         fill introduced to its instrument's realised PnL (so totals stay the sum
         across instruments, and the equity series gains exactly one point).
 
-        The service does **not** dedup by ``fill_id`` — the broker's fill stream
-        is the de-duplicated source, mirroring the
+        **Idempotent by ``fill_id``.** A fill whose ``fill_id`` was already folded
+        is ignored (no PnL/fee/equity change), so a venue re-emitting the same
+        execution (e.g. a private-WS snapshot replay after a reconnect) never
+        corrupts the running realised PnL. Mirrors the
         :class:`~trading_bot.application.position_tracker.PositionTracker`.
 
         Parameters
@@ -182,6 +189,10 @@ class PerformanceService:
             A broker-confirmed execution (the PnL source of truth).
 
         """
+        if fill.fill_id in self._seen_fill_ids:
+            return  # duplicate execution — never double-count.
+        self._seen_fill_ids.add(fill.fill_id)
+
         instrument = fill.instrument
         inst_fills = self._by_instrument.setdefault(instrument, [])
 

--- a/trading_bot/application/position_tracker.py
+++ b/trading_bot/application/position_tracker.py
@@ -94,6 +94,10 @@ class PositionTracker:
         # cached snapshot recomputed on each new fill.
         self._fills: dict[Instrument, list[Fill]] = {}
         self._positions: dict[Instrument, Position] = {}
+        # Fill ids already folded — guards against a venue re-emitting the same
+        # execution (e.g. a private-WS snapshot replay after a reconnect), which
+        # would otherwise double-count the position. See :meth:`apply`.
+        self._seen_fill_ids: set[str] = set()
         self._bus = event_bus
         if event_bus is not None:
             event_bus.subscribe(self._on_event)
@@ -114,10 +118,13 @@ class PositionTracker:
         Appends the fill to that instrument's ordered list and recomputes the
         instrument's :class:`Position` via
         :meth:`~trading_bot.domain.position.Position.from_fills` over the full
-        sequence seen so far (arrival order). Idempotent only in the trivial
-        sense that re-applying a *new* ``Fill`` object always reflects it — the
-        tracker does **not** dedup by ``fill_id``; the broker's fill stream is the
-        de-duplicated source.
+        sequence seen so far (arrival order).
+
+        **Idempotent by ``fill_id``.** A fill whose ``fill_id`` was already folded
+        is ignored (the standing position is returned unchanged) — so a venue
+        re-emitting the same execution (e.g. a private-WS snapshot replay after a
+        reconnect) never double-counts. A genuinely new execution must carry a new
+        ``fill_id``.
 
         Parameters
         ----------
@@ -127,10 +134,16 @@ class PositionTracker:
         Returns
         -------
         Position
-            The instrument's net position after folding in ``fill``.
+            The instrument's net position after folding in ``fill`` (or unchanged
+            if ``fill`` was a duplicate).
 
         """
         instrument = fill.instrument
+        if fill.fill_id in self._seen_fill_ids:
+            # Duplicate execution — never double-count. The instrument was already
+            # seen (this id was folded into it), so its position is cached.
+            return self._positions[instrument]
+        self._seen_fill_ids.add(fill.fill_id)
         fills = self._fills.setdefault(instrument, [])
         fills.append(fill)
         position = Position.from_fills(fills)
@@ -164,6 +177,7 @@ class PositionTracker:
         """
         self._fills = {}
         self._positions = {}
+        self._seen_fill_ids = set()
         for fill in fills:
             self.apply(fill)
 

--- a/trading_bot/tests/application/test_performance_service.py
+++ b/trading_bot/tests/application/test_performance_service.py
@@ -359,3 +359,37 @@ async def test_end_to_end_router_paperbroker_drives_performance() -> None:
     assert svc.max_drawdown() == perf.max_drawdown(curve)
     # max drawdown is a finite fraction in [0, 1].
     assert 0.0 <= svc.max_drawdown() <= 1.0
+
+
+# --- fill-id dedup (a re-emitted execution never corrupts realised PnL) ----- #
+
+
+def test_apply_dedups_by_fill_id() -> None:
+    """A re-applied fill (seen ``fill_id``) leaves PnL/fees/equity unchanged."""
+    svc = PerformanceService(v0=money("1000"))
+    svc.apply(_fill(fill_id="F1", side=OrderSide.BUY, qty="1", price="100", fee="1"))
+    svc.apply(_fill(fill_id="F2", side=OrderSide.SELL, qty="1", price="110", fee="1"))
+    realised = svc.realised_pnl()
+    fees = svc.fees_paid()
+    points = len(svc.equity_curve())
+
+    # The SELL execution is re-emitted (same fill_id) — must be ignored.
+    svc.apply(_fill(fill_id="F2", side=OrderSide.SELL, qty="1", price="110", fee="1"))
+    assert svc.realised_pnl() == realised  # not double-counted
+    assert svc.fees_paid() == fees
+    assert len(svc.equity_curve()) == points  # no spurious equity point
+
+
+def test_subscribed_service_dedups_reemitted_fill_event() -> None:
+    """A re-emitted ``FillEvent`` (same ``fill_id``) does not corrupt realised PnL."""
+    bus = EventBus()
+    svc = PerformanceService(v0=money("1000"), event_bus=bus)
+    bus.emit(FillEvent(_fill(fill_id="F1", side=OrderSide.BUY, qty="1", price="100",
+                             fee="1")))
+    sell = FillEvent(_fill(fill_id="F2", side=OrderSide.SELL, qty="1", price="110",
+                           fee="1"))
+    bus.emit(sell)
+    bus.emit(sell)  # the venue re-emits the same execution after a reconnect
+    # Realised PnL == one BUY 1@100 (fee 1) then one SELL 1@110 (fee 1): +10 - 2 = 8.
+    assert svc.realised_pnl() == Decimal("8")
+    assert svc.fees_paid() == Decimal("2")

--- a/trading_bot/tests/application/test_position_tracker.py
+++ b/trading_bot/tests/application/test_position_tracker.py
@@ -229,3 +229,49 @@ async def test_end_to_end_router_paperbroker_fills_drive_tracker() -> None:
     assert pos is not None
     assert pos.net_qty == Decimal("2")
     assert pos.avg_entry_price == Decimal("30500")
+
+
+# --- fill-id dedup (a re-emitted execution never double-counts) ------------ #
+
+
+def test_apply_dedups_by_fill_id() -> None:
+    """Re-applying a fill with a seen ``fill_id`` is ignored (no double-count)."""
+    tracker = PositionTracker()
+    tracker.apply(_fill(fill_id="T1", side=OrderSide.BUY, qty="2", price="30000"))
+    first = tracker.position(BTC_USD)
+    assert first is not None and first.net_qty == Decimal("2")
+
+    # The very same execution arrives again (e.g. a private-WS snapshot replay).
+    returned = tracker.apply(
+        _fill(fill_id="T1", side=OrderSide.BUY, qty="2", price="30000")
+    )
+    again = tracker.position(BTC_USD)
+    assert again is not None and again.net_qty == Decimal("2")  # unchanged, not 4
+    assert returned is again  # the standing position is returned for a duplicate
+
+
+def test_subscribed_tracker_dedups_reemitted_fill_event() -> None:
+    """A re-emitted ``FillEvent`` (same ``fill_id``) does not double the position."""
+    bus = EventBus()
+    tracker = PositionTracker(event_bus=bus)
+    event = FillEvent(_fill(fill_id="T1", side=OrderSide.BUY, qty="2", price="30000"))
+    bus.emit(event)
+    bus.emit(event)  # the venue re-emits the same execution after a reconnect
+    pos = tracker.position(BTC_USD)
+    assert pos is not None and pos.net_qty == Decimal("2")  # counted exactly once
+
+
+def test_reset_clears_seen_fill_ids_so_rebuild_folds_them() -> None:
+    """``reset`` clears the dedup set: a previously-seen id folds again (fresh truth).
+
+    Reconciliation rebuilds the tracker from the broker's confirmed fills via
+    :meth:`reset`. Those fills carry the same ``fill_id``\\ s the live stream
+    already showed, so the dedup set must be cleared on reset — otherwise the
+    rebuild would skip every fill and reconcile to flat.
+    """
+    tracker = PositionTracker()
+    f = _fill(fill_id="T1", side=OrderSide.BUY, qty="2", price="30000")
+    tracker.apply(f)
+    tracker.reset([f])  # same id, fresh rebuild from the broker's truth
+    pos = tracker.position(BTC_USD)
+    assert pos is not None and pos.net_qty == Decimal("2")  # folded, not skipped


### PR DESCRIPTION
## Summary
- `PositionTracker.apply` and `PerformanceService.apply` now ignore a fill whose `fill_id` was already folded — no double-counting of position / realised PnL.
- `PositionTracker.reset` clears the seen-id set so a reconcile rebuild from the broker's fills still folds them.

## Why
- Audit: both paths skipped dedup, trusting "the broker's stream is de-duplicated." That breaks once a live **private fill WS** re-emits an execution (e.g. Kraken v2 resends a snapshot on resubscribe after a reconnect) — the tracker would double the position and the service's *incremental* running realised PnL would be silently corrupted. Dedup-by-id makes both views safe to feed from a live stream.

## Changes
- `application/position_tracker.py`, `application/performance_service.py`: `set[str]` of folded `fill_id`s + guard in `apply`; tracker `reset` clears it; docstrings.
- `tests/application/test_position_tracker.py`, `test_performance_service.py`: duplicate `apply` is a no-op; re-emitted `FillEvent` counted once; `reset` re-folds a previously-seen id.
- Consolidated a duplicate `[Unreleased]` `### Changed` heading in the CHANGELOG.
- ADR + CHANGELOG (Fixed).

## Test plan
- [x] `pytest` — 711 passed, 9 deselected
- [x] `ruff` + `mypy` clean
- [ ] CI green