### PR TITLE
fix: restore order dedup state from the store across a restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Order idempotency now survives a restart.** `OrderRouter.restore(orders)` seeds the
+  dedup map from persisted orders (no events emitted), and `run_app` calls it on startup
+  from the configured store — so a re-submit of any previously-recorded `client_order_id`
+  is de-duplicated even after the in-memory map is lost, closing the crash-restart
+  double-submit window for a venue (like Kraken) that issues no venue-side idempotency
+  token. Runs before the startup reconcile. (#75)
 - **Fills are now de-duplicated by `fill_id`** in both the `PositionTracker` and the
   `PerformanceService`: a re-applied execution (e.g. a private-WS snapshot replay after
   a reconnect) is ignored instead of silently double-counting the position / corrupting

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,30 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Order dedup state is restored from the store on startup (PR #75)  [accepted]
+
+**Choice.** `OrderRouter.restore(orders)` seeds the in-memory dedup map (`_orders`)
+from the append-only `SqliteStore` on startup — emitting **no** events and never
+clobbering an id the router already tracks — and `run_app` calls it (when a store is
+configured) **before** the startup reconcile. A re-submit of any persisted
+`client_order_id` then dedups in `submit` (returns the recorded order, no broker call).
+
+**Why.** The audit's most dangerous interaction: Kraken issues no venue-side idempotency
+token, so dedup rests entirely on the in-memory map. A crash between `AddOrder` success
+and recording it loses that map; on restart a deterministic id (`{name}-{step}`) would
+re-submit and **duplicate the order at the venue**. Reconcile-on-startup (PR #71) only
+recovers orders the venue still reports **open**; the store recovers *every* recorded id
+(including filled/rejected) — together they close the common crash-restart window.
+
+**Rejected alternatives.** Reusing `ingest` to seed (it emits an `OrderEvent`, so a
+dashboard/store would see historical orders as fresh activity — `restore` is silent);
+deduping by object identity (a re-submit is a new `Order` with the same id). **Residual
+gap (unclosed):** an order that *filled during the crash gap, before any persist* leaves
+no local record and reconcile sees no open order — only a venue-side dedup token closes
+that, which Kraken lacks (the documented real-key-sandbox prerequisite).
+
+---
+
 ### 2026-06-29 Fills are de-duplicated by `fill_id` in the read-side views (PR #74)  [accepted]
 
 **Choice.** `PositionTracker.apply` and `PerformanceService.apply` each keep a

--- a/trading_bot/application/order_router.py
+++ b/trading_bot/application/order_router.py
@@ -72,6 +72,8 @@ from trading_bot.domain.errors import (
 from trading_bot.domain.order import Order, OrderStatus
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from trading_bot.application.risk import RiskManager
 
 __all__ = ["OrderRouter"]
@@ -425,3 +427,41 @@ class OrderRouter:
         if the id was not tracked (a no-op, so a second reconcile is clean).
         """
         return self._orders.pop(client_order_id, None)
+
+    def restore(self, orders: Iterable[Order]) -> int:
+        """Seed the dedup map from persisted orders after a restart — **no events**.
+
+        Recovers the router's idempotency state from the append-only store
+        (:meth:`~trading_bot.storage.sqlite_store.SqliteStore.orders`) on startup:
+        every persisted order's ``client_order_id`` is re-registered so a
+        re-submit of that id is de-duplicated (:meth:`submit` returns the recorded
+        order and never re-calls the broker). This closes the **crash-restart
+        double-submit window** for ids the in-memory map lost — the residual gap
+        for a venue like Kraken that issues no venue-side idempotency token.
+
+        Unlike :meth:`ingest`, this emits **no** :class:`~trading_bot.application.
+        events.OrderEvent` (these are *historical* records, not fresh order
+        activity, so a dashboard/store must not see them as new) and never
+        clobbers an id the router already tracks (the live object wins). Call it
+        **before** the startup reconcile, which then converges the recovered map
+        to the venue's *current* truth (ingest still-open orders, rebuild
+        positions from confirmed fills).
+
+        Parameters
+        ----------
+        orders : Iterable[Order]
+            The persisted orders to recover (their ``client_order_id`` is the
+            dedup key; their last-known status/venue id is carried as-is).
+
+        Returns
+        -------
+        int
+            How many ids were newly registered (already-tracked ids are skipped).
+
+        """
+        restored = 0
+        for order in orders:
+            if order.client_order_id not in self._orders:
+                self._orders[order.client_order_id] = order
+                restored += 1
+        return restored

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -672,6 +672,12 @@ async def run_app(
     recovers state after a restart. The pass emits one
     :class:`~trading_bot.application.events.LogEvent` on the engine bus.
 
+    When a store is configured, the router's dedup map is first **restored** from
+    the persisted order history (``engine.router.restore(engine.store.orders())``),
+    so a re-submit of any previously-recorded order id is de-duplicated after a
+    restart even before reconcile runs — closing the crash-restart double-submit
+    window for ids the in-memory map lost.
+
     Reconciling **after a disconnect** (the WS-reconnect half of the invariant)
     attaches to the private fill stream, which is not yet wired into this run
     loop; that lands with live fill streaming (tracked in the roadmap).
@@ -715,6 +721,14 @@ async def run_app(
 
     """
     engine = build_engine(config, db_path=config.storage.db_path)
+    # Recover idempotency state across a restart: seed the router's dedup map from
+    # the persisted store (the append-only order history) so a re-submit of any
+    # previously-recorded order id is de-duplicated — closing the crash-restart
+    # double-submit window for ids the in-memory map lost (the residual gap for a
+    # venue, like Kraken, with no venue-side idempotency token). No events emitted;
+    # done *before* reconcile, which then converges to the venue's current truth.
+    if engine.store is not None:
+        engine.router.restore(engine.store.orders())
     # Reconcile, don't assume: converge the fresh engine's empty maps to the
     # broker's truth (open orders + fills) before the first order is placed, so a
     # restart never re-submits a venue-held order or trades a stale position. A

--- a/trading_bot/tests/application/test_order_router.py
+++ b/trading_bot/tests/application/test_order_router.py
@@ -376,3 +376,44 @@ async def test_daily_loss_breach_escalates_to_kill_switch_and_cancels_resting() 
     with pytest.raises(RiskLimitBreached) as again:
         await router.submit(_order("blocked-2"))
     assert again.value.limit == "kill_switch"
+
+
+# --- restore: recover dedup state across a restart ------------------------- #
+
+
+async def test_restore_seeds_dedup_so_resubmit_skips_broker() -> None:
+    """`restore` recovers ids from persistence: a re-submit dedups, no broker call."""
+    broker = _SpyBroker()
+    router = OrderRouter(broker, EventBus())
+
+    # An order the engine submitted before a crash (reconstructed from the store).
+    prior = _order("prior-1")
+    prior.submit()
+    prior.open("SPY-OLD")  # its last-known live venue state
+
+    assert router.restore([prior]) == 1
+    assert router.get("prior-1") is prior
+
+    # A re-submit of the same id returns the restored order; the broker is untouched
+    # — the crash-restart double-submit window is closed.
+    returned = await router.submit(_order("prior-1"))
+    assert returned is prior
+    assert broker.place_calls == 0
+
+
+def test_restore_emits_no_events_and_never_clobbers_a_tracked_id() -> None:
+    """`restore` is silent (historical, not fresh) and keeps a tracked id intact."""
+    broker = _SpyBroker()
+    bus = EventBus()
+    seen = _capture(bus)
+    router = OrderRouter(broker, bus)
+
+    a = _order("a")
+    a.submit()
+    a.open("V1")
+    assert router.restore([a]) == 1
+    assert seen == []  # no OrderEvent emitted for a restored historical order
+
+    # Re-restoring the same id is a no-op (count 0) and does not replace the object.
+    assert router.restore([_order("a")]) == 0
+    assert router.get("a") is a  # original kept, not clobbered

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -590,3 +590,90 @@ async def test_run_app_startup_reconcile_converges_to_venue(
     # rebuilt from the venue's confirmed fill — the engine converged to the venue.
     assert router.get("pre-existing") is not None
     assert BTC_USD in tracker.all_positions()
+
+
+# --- restore dedup state from the store across a restart ------------------- #
+
+
+async def test_run_app_restores_dedup_when_store_present(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """`run_app` seeds the router's dedup map from the store when one is configured."""
+    from trading_bot.application.order_router import OrderRouter
+
+    calls: list[int] = []
+
+    def _spy(self: OrderRouter, orders: object) -> int:
+        calls.append(1)
+        return 0
+
+    monkeypatch.setattr(OrderRouter, "restore", _spy)
+
+    db = str(tmp_path / "engine.db")
+    cfg = AppConfig.model_validate({"mode": "paper", "storage": {"db_path": db}})
+    await run_app(cfg)
+
+    assert calls == [1]  # restore called exactly once (a store was configured)
+
+
+async def test_run_app_skips_restore_without_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With no store (no db_path) there is nothing to restore from — restore unused."""
+    from trading_bot.application.order_router import OrderRouter
+
+    calls: list[int] = []
+    monkeypatch.setattr(
+        OrderRouter, "restore", lambda self, orders: calls.append(1) or 0
+    )
+
+    await run_app(AppConfig())  # no storage.db_path → engine.store is None
+    assert calls == []
+
+
+async def test_dedup_survives_restart_via_store(tmp_path) -> None:
+    """Real restart: an order persisted to SQLite is recovered into a fresh engine.
+
+    Verification on real persisted state: submit an order through engine #1 (its
+    attached SQLite store records it), then build engine #2 on the SAME db_path
+    (the restart — its router map is empty) and restore from the store. A re-submit
+    of the same id on engine #2 dedups against the recovered record — the (fresh)
+    broker is never asked again — closing the crash-restart double-submit window.
+    """
+    from trading_bot.application.service_factory import build_engine
+    from trading_bot.domain.order import Order, OrderSide, OrderType
+
+    db = str(tmp_path / "engine.db")
+    config = AppConfig.model_validate({"mode": "paper", "storage": {"db_path": db}})
+
+    def _order(cid: str) -> Order:
+        return Order(
+            client_order_id=cid,
+            instrument=BTC_USD,
+            side=OrderSide.BUY,
+            qty=money("1"),
+            type=OrderType.LIMIT,
+            limit_price=money("30000"),
+        )
+
+    # Engine #1: submit an order; the attached store persists it.
+    engine1 = build_engine(config, db_path=db)
+    await engine1.router.submit(_order("restart-1"))
+    assert engine1.store is not None
+    assert engine1.store.get_order("restart-1") is not None  # persisted
+    engine1.store.close()
+
+    # Engine #2 on the SAME db (a restart): the router map starts empty.
+    engine2 = build_engine(config, db_path=db)
+    assert engine2.store is not None
+    assert engine2.router.get("restart-1") is None
+    assert engine2.router.restore(engine2.store.orders()) >= 1
+    recovered = engine2.router.get("restart-1")
+    assert recovered is not None
+
+    # A re-submit of the same id dedups against the recovered record: it returns the
+    # restored order and the (fresh) broker is never asked → no fill created.
+    resubmitted = await engine2.router.submit(_order("restart-1"))
+    assert resubmitted is recovered
+    assert await engine2.broker.fills() == []  # the broker was never called
+    engine2.store.close()


### PR DESCRIPTION
## Summary
- `OrderRouter.restore(orders)` seeds the dedup map from persisted orders (no events emitted, never clobbers a tracked id).
- `run_app` calls it on startup from the configured store, **before** reconcile — so a re-submit of any previously-recorded `client_order_id` is de-duplicated even after the in-memory map is lost.

## Why
- Audit's most dangerous interaction: Kraken issues no venue-side idempotency token, so dedup rests entirely on the in-memory map. A crash between `AddOrder` success and recording it loses that map; on restart a deterministic id would **duplicate the order at the venue**. Reconcile-on-startup (#71) only recovers still-open orders; the store recovers *every* recorded id.

## Changes
- `application/order_router.py`: `restore(orders) -> int` (silent seed); `Iterable` import.
- `application/run_app.py`: `engine.router.restore(engine.store.orders())` before reconcile (when a store is configured); docstring.
- `tests/application/test_order_router.py`: restore seeds dedup (re-submit skips broker); restore is silent + never clobbers.
- `tests/application/test_run_app.py`: run_app wires restore iff a store is present; **real two-engine SQLite restart** — dedup survives across a fresh engine on the same db.
- ADR + CHANGELOG (Fixed).

## Residual (documented)
- An order that *filled during the crash gap before any persist* leaves no local record and reconcile sees no open order — only a venue-side dedup token closes that (Kraken lacks one; the real-key-sandbox prerequisite).

## Test plan
- [x] `pytest` — 716 passed, 9 deselected
- [x] `ruff` + `mypy` clean
- [ ] CI green