### PR TITLE
feat: pin portfolio dccd store-key convention via config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `PortfolioStrategyConfig.store_key_format` (`"venue"` \| `"hyphen"` \| `"slash"`,
+  default `"venue"`) — pins how each universe pair is rendered to the **dccd store
+  key** its bars are read under, threaded through `build_portfolio_runners` into the
+  `PortfolioFeed`'s `symbol_for`. A real `trading-bot run <portfolio>.yaml` against a
+  hyphen-keyed (`BTC-USDT`) or slash-keyed store is no longer locked to the venue's
+  native `BTCUSDT`/`XBTUSD` convention. (#76)
+
 - `BrokerConfig.testnet` — a per-venue **testnet** flag: `mode: live` + `testnet: true`
   (Binance only — Kraken has no public spot testnet) builds an adapter **hard-pinned**
   to the venue's sandbox URL (`testnet.binance.vision`), so it **cannot reach mainnet**

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,29 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Portfolio store-key convention is pinned by config, not guessed (PR #76)  [accepted]
+
+**Choice.** `PortfolioStrategyConfig` gains `store_key_format`
+(`"venue"` | `"hyphen"` | `"slash"`, default `"venue"`); `build_portfolio_runners`
+maps it to a `Symbol -> str` renderer and threads it into the `PortfolioFeed`'s existing
+`symbol_for` hook. The universe stays written in canonical `BASE/QUOTE`; the field pins
+how those pairs render to the dccd store keys (`BTCUSDT` / `BTC-USDT` / `BTC/USDT`).
+
+**Why.** The audit's open follow-up: `PortfolioFeed` had a `symbol_for` hook but the
+config/`run_app` path never exposed it, so a real `trading-bot run <portfolio>.yaml` was
+locked to `to_venue_symbol` (`BTCUSDT`/`XBTUSD`) — which doesn't match a hyphen-keyed
+dccd store and is ambiguous to invert. LS1 runs were therefore only verified via the test
+harness, not raw `run_app`. A declared format removes the guess.
+
+**Rejected alternatives.** Auto-detecting the store key by existence-checking the dccd
+store (what a strategy's local test client does — convenient but implicit and untestable
+in the engine); putting the field on `DataSourceConfig` (single-instrument strategies
+read under the exact `symbol` string given, so they have no re-render ambiguity — the
+field is portfolio-specific); a free-form format string (a `Literal` catches typos at
+config time).
+
+---
+
 ### 2026-06-29 Order dedup state is restored from the store on startup (PR #75)  [accepted]
 
 **Choice.** `OrderRouter.restore(orders)` seeds the in-memory dedup map (`_orders`)

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -29,14 +29,6 @@ the gitignored `strategies/`, real dccd-data verified). History in `CHANGELOG.md
   to trigger a reconcile pass on, and live fills are not streamed onto the bus. Wire
   the private fill WS into the engine and trigger `reconcile` on each reconnect (and
   land fill-id dedup — see below — before that stream feeds the tracker).
-- [ ] **Portfolio config → real-dccd store-key convention unpinned.** The default
-  `PortfolioFeed` renders pairs via `to_venue_symbol(exchange)` (`BTCUSDT`; Kraken
-  `XBTUSD`/`TRXUSD`), which (a) doesn't match a hyphen-keyed `BASE-QUOTE` dccd store and
-  (b) is ambiguous to invert (`XBTUSD`→`XB/TUSD`, `TRXUSD`→`TR/USD` under the parsers).
-  A strategy's local test client normalises by existence-checking the store; a real
-  `trading-bot run strategies/<name>/*.yaml` against a live `dccd.Client` needs the convention
-  pinned (a `symbol_for`/store-key field on `PortfolioStrategyConfig`, or a canonical
-  render). Until then LS1 runs are verified via the test harness, not raw `run_app`.
 - [ ] **PaperBroker/engine drain is superlinear (~O(n²)) over accumulated ticks.** A
   full multi-year daily run through `run_app` is slow (≈10 ticks 6.5s → 200 ticks 118s);
   the LS1 real-data tests assert on a single latest-cross-section rebalance instead.

--- a/trading_bot/application/config.py
+++ b/trading_bot/application/config.py
@@ -288,6 +288,23 @@ class PortfolioStrategyConfig(BaseModel):
     venue : str, optional
         The venue key the universe's bars are stored under / rendered for (e.g.
         ``"binance"``). Defaults to ``"binance"``. Must be non-empty.
+    store_key_format : {"venue", "hyphen", "slash"}, optional
+        How each universe pair (a canonical
+        :class:`~trading_bot.domain.instrument.Symbol`) is rendered to the **dccd
+        store key** the bars are read under. The universe is written in canonical
+        ``BASE/QUOTE`` form, but a real dccd store may key its pairs differently;
+        this pins the convention rather than guessing:
+
+        * ``"venue"`` (default) — the venue's native code via
+          :meth:`~trading_bot.domain.instrument.Symbol.to_venue_symbol`
+          (Binance ``BTCUSDT``; Kraken ``XBTUSD``). Backward-compatible.
+        * ``"hyphen"`` — ``BASE-QUOTE`` (e.g. ``BTC-USDT``), the common
+          hyphen-keyed dccd layout.
+        * ``"slash"`` — ``BASE/QUOTE`` (e.g. ``BTC/USDT``), the canonical form
+          verbatim.
+
+        Single-instrument strategies need no equivalent: they read under the exact
+        ``symbol`` string the config gives, so there is nothing to re-render.
 
     """
 
@@ -298,6 +315,7 @@ class PortfolioStrategyConfig(BaseModel):
     data: DataSourceConfig
     gross_cap: Decimal | None = None
     venue: str = "binance"
+    store_key_format: Literal["venue", "hyphen", "slash"] = "venue"
 
     @field_validator("name", "venue")
     @classmethod

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -606,6 +606,9 @@ def build_portfolio_runners(
             start_ns=_portfolio_start_ns(data.start),
             data_type=data.data_type,
             data_path=config.storage.data_path,
+            symbol_for=_store_key_renderer(
+                portfolio_cfg.store_key_format, data.exchange
+            ),
         )
         capped: object = (
             feed if max_steps is None else _CappedPortfolioFeed(feed, max_steps)
@@ -620,6 +623,31 @@ def build_portfolio_runners(
         )
         runners.append(runner)
     return runners
+
+
+def _store_key_renderer(
+    store_key_format: str, exchange: str
+) -> Callable[[Symbol], str]:
+    """Build the ``Symbol -> dccd store key`` renderer for a portfolio feed.
+
+    Maps the config's ``store_key_format`` (see
+    :class:`~trading_bot.application.config.PortfolioStrategyConfig`) to the
+    callable a :class:`~trading_bot.application.portfolio_feed.PortfolioFeed` uses
+    to render each canonical pair to the key its bars are stored under, so a real
+    ``trading-bot run`` against a live dccd store is no longer locked to one
+    guessed convention:
+
+    * ``"venue"`` (default) — the venue's native code
+      (``Symbol.to_venue_symbol(exchange)``), matching the feed's own default;
+    * ``"hyphen"`` — ``BASE-QUOTE`` (e.g. ``BTC-USDT``);
+    * ``"slash"`` — ``BASE/QUOTE`` (e.g. ``BTC/USDT``).
+    """
+    if store_key_format == "hyphen":
+        return lambda sym: f"{sym.base}-{sym.quote}"
+    if store_key_format == "slash":
+        return lambda sym: f"{sym.base}/{sym.quote}"
+    # "venue" (default): the venue's native code, matching the feed's own default.
+    return lambda sym: sym.to_venue_symbol(exchange)
 
 
 def _portfolio_start_ns(start: str | int | None) -> int | None:

--- a/trading_bot/tests/application/test_portfolio_config.py
+++ b/trading_bot/tests/application/test_portfolio_config.py
@@ -141,6 +141,7 @@ def _one_portfolio_config(
     *,
     universe: list[str] | None = None,
     capital: str = "100000",
+    store_key_format: str | None = None,
     extra_strategies: list[dict] | None = None,
     extra_portfolios: list[dict] | None = None,
 ) -> AppConfig:
@@ -152,6 +153,8 @@ def _one_portfolio_config(
         "capital": capital,
         "data": {"exchange": "binance", "span": 86400},
     }
+    if store_key_format is not None:
+        portfolio["store_key_format"] = store_key_format
     return AppConfig.model_validate(
         {
             "mode": "paper",
@@ -258,6 +261,62 @@ def test_gross_cap_carried_onto_strategy() -> None:
     client = _daily_client({"BTCUSDT": [50000.0], "ETHUSDT": [2500.0]})
     runners = build_portfolio_runners(cfg, engine, dccd_client=client)
     assert runners[0].strategy.gross_cap == money("1.5")
+
+
+# --- store-key format (dccd store-key convention) -------------------------- #
+
+
+def test_store_key_format_defaults_to_venue() -> None:
+    """``store_key_format`` defaults to ``"venue"`` (backward-compatible)."""
+    cfg = _one_portfolio_config()
+    assert cfg.portfolios[0].store_key_format == "venue"
+
+
+def test_store_key_format_accepts_known_values() -> None:
+    """``venue`` / ``hyphen`` / ``slash`` all validate."""
+    for fmt in ("venue", "hyphen", "slash"):
+        cfg = _one_portfolio_config(store_key_format=fmt)
+        assert cfg.portfolios[0].store_key_format == fmt
+
+
+def test_store_key_format_rejects_unknown_value() -> None:
+    """An unknown format is a config validation error (the Literal guards it)."""
+    with pytest.raises(ValidationError):
+        _one_portfolio_config(store_key_format="concat")
+
+
+async def test_portfolio_reads_hyphen_keyed_store_when_configured() -> None:
+    """``store_key_format='hyphen'`` reads a hyphen-keyed dccd store (``BTC-USDT``).
+
+    Verification on real data (offline): the dccd store is keyed ``BASE-QUOTE``
+    (not the venue's ``BTCUSDT``). With ``store_key_format: hyphen`` the portfolio
+    feed renders each pair to that convention, reads the right series, and the run
+    reaches the intended per-coin targets — proving the config field is threaded
+    through ``build_portfolio_runners`` into the feed's ``symbol_for``.
+    """
+    from trading_bot.application.orchestrator import Orchestrator
+
+    btc_price, eth_price = 50000.0, 2500.0
+    cfg = _one_portfolio_config(capital="100000", store_key_format="hyphen")
+    client = _daily_client(
+        {"BTC-USDT": [btc_price] * 4, "ETH-USDT": [eth_price] * 4}
+    )
+
+    engine = build_engine(cfg, db_path=None)
+    runners = build_portfolio_runners(cfg, engine, dccd_client=client)
+
+    orch = Orchestrator(event_bus=engine.bus)
+    orch.add_all(runners)  # type: ignore[arg-type]
+    await orch.run()
+
+    # The feed read the HYPHEN store keys — not the venue-native "BTCUSDT".
+    read_symbols = {sym for _exch, sym, _span in client.reads}
+    assert read_symbols == {"BTC-USDT", "ETH-USDT"}
+
+    # And the read actually fed sizing: BTC target = +0.5 * 100000 / 50000 = +1.
+    btc_pos = engine.tracker.position(BTC_USDT)
+    assert btc_pos is not None
+    assert btc_pos.net_qty == money("1")
 
 
 # --- backward compat ------------------------------------------------------- #


### PR DESCRIPTION
## Summary
- `PortfolioStrategyConfig.store_key_format` (`venue` | `hyphen` | `slash`, default `venue`) pins how each universe pair renders to the dccd store key, threaded into the `PortfolioFeed`'s existing `symbol_for` hook by `build_portfolio_runners`.

## Why
- Audit follow-up: the feed had a `symbol_for` hook but the config/`run_app` path never exposed it, so a real `trading-bot run <portfolio>.yaml` was locked to `to_venue_symbol` (`BTCUSDT`/`XBTUSD`) — which doesn't match a hyphen-keyed dccd store and is ambiguous to invert. LS1 runs were only verified via the test harness, not raw `run_app`.

## Changes
- `application/config.py`: `store_key_format: Literal["venue","hyphen","slash"] = "venue"` + docstring.
- `application/run_app.py`: `_store_key_renderer(fmt, exchange)` threaded into `PortfolioFeed(symbol_for=...)`.
- `tests/application/test_portfolio_config.py`: defaults/accepts/rejects + a **real offline read** of a hyphen-keyed store (`BTC-USDT`) reaching the intended targets.
- ADR + CHANGELOG (Added); removed the resolved roadmap follow-up.

## Test plan
- [x] `pytest` — 720 passed, 9 deselected
- [x] `ruff` + `mypy` clean
- [ ] CI green