### PR TITLE
fix: price limit-at-close via Decimal, not a float round-trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   *reconcile, don't assume* invariant was implemented + hardening-tested but had **no
   production caller**; it is now enforced on every start (a no-op on a fresh
   `PaperBroker`; the safety backstop on a live/testnet venue). (#71)
+- `run_app`'s limit-at-close order factory prices via `money(str(...))` instead of
+  `from_float(float(...))` — exact `Decimal`, never through `float` (matching
+  `PortfolioRunner`; carries full precision if the dccd close column is `Decimal`). (#78)
 
 ### Deprecated
 

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -348,7 +348,9 @@ def _limit_at_close_factory(
     """
 
     def _factory(strategy: Strategy, delta: Money, bars: "pl.DataFrame") -> Order:
-        close = from_float(float(bars[close_col][-1]))
+        # Price exactly via str -> Decimal (never through float), matching
+        # PortfolioRunner._latest_closes; robust if the close column is Decimal.
+        close = money(str(bars[close_col][-1]))
         side = OrderSide.BUY if delta > 0 else OrderSide.SELL
         return Order(
             client_order_id="pending",  # overridden by the runner

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -677,3 +677,36 @@ async def test_dedup_survives_restart_via_store(tmp_path) -> None:
     assert resubmitted is recovered
     assert await engine2.broker.fills() == []  # the broker was never called
     engine2.store.close()
+
+
+# --- the limit-at-close factory prices via Decimal, never through float ---- #
+
+
+def test_limit_at_close_prices_exactly_from_decimal_close_no_float() -> None:
+    """The limit-at-close factory prices via str->Decimal — exact, never via float.
+
+    A close stored as polars ``Decimal`` with more precision than a ``float`` can
+    hold is carried **exactly** into the order's limit price (the previous
+    ``from_float(float(...))`` would have truncated it), matching
+    ``PortfolioRunner``'s ``money(str(...))`` idiom.
+    """
+    from decimal import Decimal
+
+    from trading_bot.application.run_app import _limit_at_close_factory
+    from trading_bot.application.strategy import Strategy
+    from trading_bot.domain.money import from_float
+    from trading_bot.domain.signal import Signal
+
+    exact = Decimal("100.123456789012345678")  # 18 frac digits: a float can't hold it
+    bars = pl.DataFrame({"c": pl.Series("c", [exact], dtype=pl.Decimal(scale=18))})
+    strat = Strategy(
+        name="x",
+        instrument=BTC_USD,
+        signal_fn=lambda _bars: Signal.exposure(BTC_USD, money("0"), ts=0),
+    )
+
+    order = _limit_at_close_factory()(strat, money("1"), bars)
+
+    assert order.limit_price == money("100.123456789012345678")  # exact
+    # And strictly better than the old float round-trip, which loses the tail.
+    assert order.limit_price != from_float(float(exact))


### PR DESCRIPTION
## Summary
- `run_app`'s `_limit_at_close_factory` now prices via `money(str(bars[close_col][-1]))` instead of `from_float(float(...))`.

## Why
- Audit [LOW]: the single-instrument paper path went through `float` on a money value, inconsistent with `PortfolioRunner._latest_closes` (`money(str(...))`). `from_float` already str-round-trips so the common float case is unchanged, but `money(str(...))` is the right idiom and carries full precision if the close column is `Decimal`-typed.

## Changes
- `application/run_app.py`: one-line change in `_limit_at_close_factory`.
- `tests/application/test_run_app.py`: a Decimal-close test proving exact pricing (and that it differs from the old float round-trip).

## Test plan
- [x] `pytest` — 718 passed, 9 deselected
- [x] `ruff` + `mypy` clean
- [ ] CI green