### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [0.3.0] - 2026-06-29
+
+### Added
+
 - `PortfolioStrategyConfig.store_key_format` (`"venue"` \| `"hyphen"` \| `"slash"`,
   default `"venue"`) — pins how each universe pair is rendered to the **dccd store
   key** its bars are read under, threaded through `build_portfolio_runners` into the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trading_bot"
-version = "0.2.0"
+version = "0.3.0"
 description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v0.3.0

Freezes `[Unreleased]` into `## [0.3.0] - 2026-06-29` and bumps `pyproject.toml` to `0.3.0`.

### Highlights — pre-production hardening + the multi-asset unit

**Added**
- Native multi-asset / portfolio-strategy unit (`PortfolioStrategy`/`PortfolioRunner`/`PortfolioFeed`, `AppConfig.portfolios`, `ResamplingDccdClient`, the generic `as_portfolio_signal` adapter) — concrete strategies stay local-only.
- `BrokerConfig.testnet` (safe engine-path testnet, mainnet-incapable).
- `PortfolioStrategyConfig.store_key_format` — pin the dccd store-key convention.

**Changed**
- Real-money live now **requires** explicit risk limits (`max_order`/`max_position`/`max_daily_loss`).

**Fixed (the audit safety wiring)**
- Reconcile-on-startup wired into the run loop (#71).
- Daily-loss circuit breaker fed live PnL + escalates to the kill-switch (#72).
- Fills de-duplicated by `fill_id` (#74).
- Order dedup survives a restart (router restored from the store) (#75).
- Limit-at-close priced via exact `Decimal`, no float (#78).

**Removed**
- Dead `BrokerRegistry` (#77).

### Test plan
- [x] `pytest` — 718 passed, 9 deselected
- [x] `ruff` + `mypy` clean
- [ ] CI green