### PR TITLE
perf: O(n) position/PnL drain via incremental Position.with_fill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Position.with_fill(fill)` + `Position.flat(instrument)` — the exact **incremental**
+  fold (`from_fills` is now a fold of `with_fill`). (#82)
+
 ### Changed
+
+- **Tracker & performance drain is now O(n)**, not O(n²). The `PositionTracker` and
+  `PerformanceService` keep a **running** `Position` per instrument advanced one fill at
+  a time (`Position.with_fill`) instead of recomputing `Position.from_fills` over the
+  whole accumulated fill history on every fill (the perf service did it *twice* per
+  fill). Behaviour is identical — `from_fills` is now implemented as the same fold, so
+  one-shot and incremental results agree by construction (existing equivalence tests stay
+  green) — but a long run / replay through the engine is no longer quadratic. (#82)
 
 ### Fixed
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,30 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Linear position drain via an incremental `Position.with_fill` (PR #82)  [accepted]
+
+**Choice.** Add `Position.with_fill(fill) -> Position` (+ `Position.flat`); reimplement
+`from_fills` as a fold of `with_fill` from `flat`; have `PositionTracker` and
+`PerformanceService` keep a **running** per-instrument `Position` advanced one fill at a
+time, dropping the per-instrument fill lists.
+
+**Why.** The audit's O(n²) follow-up: both `apply` paths recomputed `Position.from_fills`
+over the full accumulated fill list on every fill (the performance service did it
+*twice*), so draining N fills was Σk = O(n²) — a multi-year daily run/replay through the
+engine was slow. Incremental folding is O(1) per fill, O(n) overall.
+
+**Why it stays exact.** `from_fills` is now *implemented* as the same `with_fill` fold, so
+the one-shot and incremental results are identical **by construction** — the existing
+per-step equivalence tests (`apply` == `from_fills` at every prefix) remain the guard and
+stay green; the two can't drift.
+
+**Rejected alternatives.** A bespoke incremental updater duplicated in each service
+(re-implements the close/flip/fee logic — invites divergence; instead the single source of
+truth is the pure `Position.with_fill`); prefix-memoised `from_fills` (still O(n) list
+memory, more complex, same result).
+
+---
+
 ### 2026-06-29 Remove the unused `BrokerRegistry` (delete, don't wire) (PR #77)  [accepted]
 
 **Choice.** Delete `brokers/registry.py` (`BrokerRegistry`) rather than wire it into the

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -29,11 +29,6 @@ the gitignored `strategies/`, real dccd-data verified). History in `CHANGELOG.md
   to trigger a reconcile pass on, and live fills are not streamed onto the bus. Wire
   the private fill WS into the engine and trigger `reconcile` on each reconnect (and
   land fill-id dedup — see below — before that stream feeds the tracker).
-- [ ] **PaperBroker/engine drain is superlinear (~O(n²)) over accumulated ticks.** A
-  full multi-year daily run through `run_app` is slow (≈10 ticks 6.5s → 200 ticks 118s);
-  the LS1 real-data tests assert on a single latest-cross-section rebalance instead.
-  Profile the per-fill rebuild (tracker/perf/bus) and make the drain linear before any
-  long backtest/live-replay through the engine.
 - [ ] **dccd API drift breaks two `-m network` data-feed tests.** `dccd.Client().inventory()`
   is now called outside an `async with` in `test_data_feed.py` / `test_data_provider.py`
   (current dccd rejects it). Network-only (not in CI). Realign the dccd client usage.

--- a/trading_bot/application/performance_service.py
+++ b/trading_bot/application/performance_service.py
@@ -136,10 +136,9 @@ class PerformanceService:
         self, *, v0: Money = _ZERO, event_bus: EventBus | None = None
     ) -> None:
         self._v0: Money = v0
-        # Global arrival-order fill list — drives the aggregate equity series.
-        self._fills: list[Fill] = []
-        # Per-instrument arrival-order fill lists — drive position()/realised_pnl.
-        self._by_instrument: dict[Instrument, list[Fill]] = {}
+        # Running net position per instrument, advanced one fill at a time via
+        # Position.with_fill (O(1) per fill — no full-history refold).
+        self._positions: dict[Instrument, Position] = {}
         # Running aggregate realised PnL after each global fill (one entry per
         # fill). Rebuilt incrementally so equity_curve() is O(1) to read.
         self._equity: list[Money] = []
@@ -169,13 +168,13 @@ class PerformanceService:
     def apply(self, fill: Fill) -> None:
         """Fold ``fill`` into the aggregate and per-instrument performance views.
 
-        Appends the fill to the global arrival-order list and to its instrument's
-        list, recomputes that instrument's
-        :class:`~trading_bot.domain.position.Position` via
-        :meth:`~trading_bot.domain.position.Position.from_fills`, and updates the
-        running aggregate realised PnL / fees / equity step by the **delta** the
-        fill introduced to its instrument's realised PnL (so totals stay the sum
-        across instruments, and the equity series gains exactly one point).
+        Advances that instrument's **running**
+        :class:`~trading_bot.domain.position.Position` by exactly this fill via
+        :meth:`~trading_bot.domain.position.Position.with_fill` (O(1) per fill, no
+        full-history refold), and updates the running aggregate realised PnL / fees
+        / equity by the **delta** the fill introduced to its instrument's realised
+        PnL (so totals stay the sum across instruments, and the equity series gains
+        exactly one point).
 
         **Idempotent by ``fill_id``.** A fill whose ``fill_id`` was already folded
         is ignored (no PnL/fee/equity change), so a venue re-emitting the same
@@ -194,23 +193,14 @@ class PerformanceService:
         self._seen_fill_ids.add(fill.fill_id)
 
         instrument = fill.instrument
-        inst_fills = self._by_instrument.setdefault(instrument, [])
+        prev = self._positions.get(instrument) or Position.flat(instrument)
+        now = prev.with_fill(fill)
+        self._positions[instrument] = now
 
-        # Realised PnL / fees the instrument had *before* this fill.
-        prev_realised = _ZERO
-        prev_fees = _ZERO
-        if inst_fills:
-            prev = Position.from_fills(inst_fills)
-            prev_realised = prev.realised_pnl
-            prev_fees = prev.fees_paid
-
-        inst_fills.append(fill)
-        self._fills.append(fill)
-
-        # Realised PnL / fees after the fill; the deltas fold into the aggregate.
-        now = Position.from_fills(inst_fills)
-        self._realised_pnl += now.realised_pnl - prev_realised
-        self._fees_paid += now.fees_paid - prev_fees
+        # The fill's contribution to the aggregate is the delta of its instrument's
+        # realised PnL / fees (one new equity point: v0 + total realised PnL).
+        self._realised_pnl += now.realised_pnl - prev.realised_pnl
+        self._fees_paid += now.fees_paid - prev.fees_paid
 
         # One new equity point: v0 + total realised PnL through this fill.
         self._equity.append(self._v0 + self._realised_pnl)
@@ -249,8 +239,9 @@ class PerformanceService:
     def position(self, instrument: Instrument) -> Position | None:
         """Return the net :class:`Position` for ``instrument``, or ``None``.
 
-        Computed via :meth:`~trading_bot.domain.position.Position.from_fills` over
-        exactly the fills seen for ``instrument``, in arrival order.
+        The running per-instrument position, advanced one fill at a time (it
+        equals :meth:`~trading_bot.domain.position.Position.from_fills` over every
+        fill seen for ``instrument``).
 
         Parameters
         ----------
@@ -264,10 +255,7 @@ class PerformanceService:
             been applied yet.
 
         """
-        fills = self._by_instrument.get(instrument)
-        if not fills:
-            return None
-        return Position.from_fills(fills)
+        return self._positions.get(instrument)
 
     def equity_curve(self) -> tuple[Money, ...]:
         """The account-value path: ``v0`` + cumulative realised PnL per fill.

--- a/trading_bot/application/position_tracker.py
+++ b/trading_bot/application/position_tracker.py
@@ -90,9 +90,8 @@ class PositionTracker:
     """
 
     def __init__(self, event_bus: EventBus | None = None) -> None:
-        # Ordered fills per instrument (arrival order == fold order) and the
-        # cached snapshot recomputed on each new fill.
-        self._fills: dict[Instrument, list[Fill]] = {}
+        # Running net position per instrument, advanced one fill at a time via
+        # Position.with_fill (O(1) per fill — no full-history refold).
         self._positions: dict[Instrument, Position] = {}
         # Fill ids already folded — guards against a venue re-emitting the same
         # execution (e.g. a private-WS snapshot replay after a reconnect), which
@@ -115,10 +114,11 @@ class PositionTracker:
     def apply(self, fill: Fill) -> Position:
         """Fold ``fill`` into its instrument's running net position.
 
-        Appends the fill to that instrument's ordered list and recomputes the
-        instrument's :class:`Position` via
-        :meth:`~trading_bot.domain.position.Position.from_fills` over the full
-        sequence seen so far (arrival order).
+        Advances the instrument's **running** :class:`Position` by exactly this
+        fill via :meth:`~trading_bot.domain.position.Position.with_fill` — O(1) per
+        fill, no full-history refold (the result is identical to
+        :meth:`~trading_bot.domain.position.Position.from_fills` over every fill
+        seen, which is how ``from_fills`` is itself defined).
 
         **Idempotent by ``fill_id``.** A fill whose ``fill_id`` was already folded
         is ignored (the standing position is returned unchanged) — so a venue
@@ -144,9 +144,8 @@ class PositionTracker:
             # seen (this id was folded into it), so its position is cached.
             return self._positions[instrument]
         self._seen_fill_ids.add(fill.fill_id)
-        fills = self._fills.setdefault(instrument, [])
-        fills.append(fill)
-        position = Position.from_fills(fills)
+        current = self._positions.get(instrument) or Position.flat(instrument)
+        position = current.with_fill(fill)
         self._positions[instrument] = position
         return position
 
@@ -175,7 +174,6 @@ class PositionTracker:
             empty, which clears the tracker to flat.
 
         """
-        self._fills = {}
         self._positions = {}
         self._seen_fill_ids = set()
         for fill in fills:

--- a/trading_bot/domain/position.py
+++ b/trading_bot/domain/position.py
@@ -135,13 +135,123 @@ class Position:
         return self.net_qty < 0
 
     @classmethod
+    def flat(cls, instrument: Instrument) -> Position:
+        """A flat (zero-exposure) position for ``instrument`` — the fold identity.
+
+        The starting point of a fold: ``net_qty`` ``0``, no average entry, zero
+        realised PnL/fees. :meth:`from_fills` folds :meth:`with_fill` over the
+        fills starting from this; a live caller (the position tracker /
+        performance service) keeps one of these per instrument and advances it
+        one fill at a time.
+        """
+        return cls(
+            instrument=instrument,
+            net_qty=_ZERO,
+            avg_entry_price=None,
+            realised_pnl=_ZERO,
+            fees_paid=_ZERO,
+        )
+
+    def with_fill(self, fill: Fill) -> Position:
+        """Fold one more ``fill`` into this position, returning the next snapshot.
+
+        The **incremental** counterpart of :meth:`from_fills`: it applies exactly
+        the same per-fill rules — fee accrual, quantity-weighted-average increase,
+        partial/full close (realise PnL on the closed part), and flip (close then
+        re-open at the flipping fill's price) — to *this* position's state and
+        returns the next :class:`Position`. Because :meth:`from_fills` is itself
+        implemented as a fold of ``with_fill`` from :meth:`flat`,
+        ``Position.from_fills(fills)`` **equals** folding ``with_fill`` over those
+        fills — by construction, so the two can never diverge. This lets a caller
+        maintain a running position in **O(1) per fill** (O(n) overall) instead of
+        recomputing the whole fill history on every new fill.
+
+        Parameters
+        ----------
+        fill : Fill
+            The next fill to fold in (execution order). Must name this position's
+            instrument.
+
+        Returns
+        -------
+        Position
+            The net position after folding in ``fill``.
+
+        Raises
+        ------
+        InstrumentMismatch
+            If ``fill`` names a different instrument than this position.
+
+        """
+        if fill.instrument != self.instrument:
+            raise InstrumentMismatch(str(self.instrument), str(fill.instrument))
+
+        net_qty = self.net_qty
+        # Average entry of the open exposure; 0 when flat (the value is irrelevant
+        # while flat — the opening branch overwrites it).
+        avg_entry: Money = (
+            self.avg_entry_price if self.avg_entry_price is not None else _ZERO
+        )
+        # Fees always accrue and always reduce realised PnL.
+        fees_paid = self.fees_paid + fill.fee
+        realised_pnl = self.realised_pnl - fill.fee
+
+        signed = fill.signed_qty  # +qty for BUY, -qty for SELL
+        price = fill.price
+
+        if net_qty == 0:
+            # Opening from flat: the fill becomes the whole exposure.
+            net_qty = signed
+            avg_entry = price
+        elif (net_qty > 0) == (fill.side is OrderSide.BUY):
+            # Increasing exposure: quantity-weighted average of old + added.
+            old_mag = abs(net_qty)
+            add_mag = fill.qty
+            total_mag = old_mag + add_mag
+            avg_entry = (avg_entry * old_mag + price * add_mag) / total_mag
+            net_qty += signed
+        else:
+            # Opposite direction: this fill reduces (and maybe flips) exposure.
+            open_mag = abs(net_qty)
+            closed_mag = min(open_mag, fill.qty)
+            realised_pnl += _close_pnl(
+                was_long=net_qty > 0,
+                entry=avg_entry,
+                exit_price=price,
+                closed_qty=closed_mag,
+            )
+            new_net = net_qty + signed
+            if new_net == 0:
+                # Exact close back to flat.
+                net_qty = _ZERO
+                avg_entry = _ZERO
+            elif (new_net > 0) == (net_qty > 0):
+                # Partial close: same sign, entry unchanged, qty reduced.
+                net_qty = new_net
+            else:
+                # Flip: old side fully closed above; remainder opens at the
+                # flipping fill's price, which becomes the new average entry.
+                net_qty = new_net
+                avg_entry = price
+
+        return Position(
+            instrument=self.instrument,
+            net_qty=net_qty,
+            avg_entry_price=None if net_qty == 0 else avg_entry,
+            realised_pnl=realised_pnl,
+            fees_paid=fees_paid,
+        )
+
+    @classmethod
     def from_fills(cls, fills: Iterable[Fill]) -> Position:
         """Fold an **ordered** sequence of fills into a net :class:`Position`.
 
         Handles increases (quantity-weighted average entry), partial closes and
         full closes (realise PnL on the closed part), flips (close then re-open
         at the flipping fill's price), and fee accrual. See the module docstring
-        for the PnL sign convention and flip handling.
+        for the PnL sign convention and flip handling. Implemented as a fold of
+        :meth:`with_fill` from :meth:`flat`, so a one-shot ``from_fills`` and an
+        incremental per-fill caller compute identical positions.
 
         Parameters
         ----------
@@ -166,76 +276,10 @@ class Position:
         if not ordered:
             raise ValueError("from_fills requires at least one fill")
 
-        instrument: Instrument = ordered[0].instrument
-
-        net_qty: Money = _ZERO
-        # Average entry price of the *currently open* exposure. Only meaningful
-        # while net_qty != 0; kept as a plain Decimal (defaults to zero when
-        # flat) and exposed as None when flat in the final snapshot.
-        avg_entry: Money = _ZERO
-        realised_pnl: Money = _ZERO
-        fees_paid: Money = _ZERO
-
+        position = cls.flat(ordered[0].instrument)
         for fill in ordered:
-            if fill.instrument != instrument:
-                raise InstrumentMismatch(str(instrument), str(fill.instrument))
-
-            # Fees always accrue and always reduce realised PnL.
-            fees_paid += fill.fee
-            realised_pnl -= fill.fee
-
-            signed = fill.signed_qty  # +qty for BUY, -qty for SELL
-            price = fill.price
-
-            if net_qty == 0:
-                # Opening from flat: the fill becomes the whole exposure.
-                net_qty = signed
-                avg_entry = price
-                continue
-
-            same_direction = (net_qty > 0) == (fill.side is OrderSide.BUY)
-
-            if same_direction:
-                # Increasing exposure: quantity-weighted average of old + added.
-                # Work in magnitudes; both legs share the position's sign.
-                old_mag = abs(net_qty)
-                add_mag = fill.qty
-                total_mag = old_mag + add_mag
-                avg_entry = (avg_entry * old_mag + price * add_mag) / total_mag
-                net_qty += signed
-                continue
-
-            # Opposite direction: this fill reduces (and maybe flips) exposure.
-            open_mag = abs(net_qty)
-            closed_mag = min(open_mag, fill.qty)
-            realised_pnl += _close_pnl(
-                was_long=net_qty > 0,
-                entry=avg_entry,
-                exit_price=price,
-                closed_qty=closed_mag,
-            )
-
-            new_net = net_qty + signed
-            if new_net == 0:
-                # Exact close back to flat.
-                net_qty = _ZERO
-                avg_entry = _ZERO
-            elif (new_net > 0) == (net_qty > 0):
-                # Partial close: same sign, entry unchanged, qty reduced.
-                net_qty = new_net
-            else:
-                # Flip: old side fully closed above; remainder opens at the
-                # flipping fill's price, which becomes the new average entry.
-                net_qty = new_net
-                avg_entry = price
-
-        return cls(
-            instrument=instrument,
-            net_qty=net_qty,
-            avg_entry_price=None if net_qty == 0 else avg_entry,
-            realised_pnl=realised_pnl,
-            fees_paid=fees_paid,
-        )
+            position = position.with_fill(fill)
+        return position
 
 
 def _close_pnl(

--- a/trading_bot/tests/domain/test_fill_position.py
+++ b/trading_bot/tests/domain/test_fill_position.py
@@ -307,3 +307,55 @@ class TestRealDataFlipSequence:
         # Exact-Decimal guarantee: no binary float contamination.
         assert isinstance(pos.realised_pnl, Decimal)
         assert pos.realised_pnl == Decimal("13938.4")
+
+
+class TestIncrementalFold:
+    """`Position.flat` + `with_fill` — the O(1)-per-fill incremental fold."""
+
+    def test_flat_is_zero_exposure(self) -> None:
+        """`flat` is a no-exposure position (the fold identity)."""
+        pos = Position.flat(BTCUSD)
+        assert pos.instrument == BTCUSD
+        assert pos.net_qty == money("0")
+        assert pos.avg_entry_price is None
+        assert pos.realised_pnl == money("0")
+        assert pos.fees_paid == money("0")
+        assert pos.is_flat
+
+    def test_with_fill_matches_from_fills_at_every_prefix(self) -> None:
+        """Folding `with_fill` from `flat` == `from_fills` over every prefix.
+
+        Drives a realistic BTC/USD sequence — open, increase (weighted avg),
+        partial close (realise PnL), full close, then a flip — and asserts the
+        running incremental position equals `Position.from_fills` over the same
+        prefix at *every* step. This is the exactness guarantee the tracker and
+        performance service rely on for their O(n) drain.
+        """
+        fills = [
+            make_fill(side=OrderSide.BUY, qty="2", price="30000", fee="1", fill_id="F1"),
+            make_fill(side=OrderSide.BUY, qty="1", price="33000", fee="1", fill_id="F2"),
+            make_fill(side=OrderSide.SELL, qty="1", price="35000", fee="1", fill_id="F3"),
+            make_fill(side=OrderSide.SELL, qty="2", price="31000", fee="1", fill_id="F4"),
+            make_fill(side=OrderSide.SELL, qty="2", price="29000", fee="1", fill_id="F5"),
+        ]
+        running = Position.flat(BTCUSD)
+        for i, fill in enumerate(fills, start=1):
+            running = running.with_fill(fill)
+            expected = Position.from_fills(fills[:i])
+            assert running.net_qty == expected.net_qty
+            assert running.avg_entry_price == expected.avg_entry_price
+            assert running.realised_pnl == expected.realised_pnl
+            assert running.fees_paid == expected.fees_paid
+
+    def test_with_fill_rejects_instrument_mismatch(self) -> None:
+        """`with_fill` of a different instrument raises `InstrumentMismatch`."""
+        pos = Position.from_fills(
+            [make_fill(side=OrderSide.BUY, qty="1", price="30000")]
+        )
+        with pytest.raises(InstrumentMismatch, match="BTC/USD"):
+            pos.with_fill(
+                make_fill(
+                    side=OrderSide.BUY, qty="1", price="2000", instrument=ETHUSD,
+                    fill_id="F2",
+                )
+            )


### PR DESCRIPTION
## Summary
- Add exact incremental `Position.with_fill(fill)` + `Position.flat(instrument)`; `from_fills` is now a fold of `with_fill`.
- `PositionTracker` / `PerformanceService` keep a **running** per-instrument `Position` advanced one fill at a time — no full-history refold.

## Why
- Audit O(n²) follow-up: both `apply` paths recomputed `Position.from_fills` over the whole accumulated list on every fill (perf did it twice) → quadratic drain; a long run/replay was slow.

## Exactness
- `from_fills` is now *implemented* as the same `with_fill` fold, so one-shot and incremental agree **by construction**. The existing per-step equivalence tests (`apply` == `from_fills` at every prefix) stay green; added explicit `with_fill`/`flat` domain tests. domain/position.py 100% cov.

## Test plan
- [x] `pytest` — 721 passed, 9 deselected
- [x] `ruff` + `mypy` clean; domain 100%
- [ ] CI green