### PR TITLE
fix: use async-with dccd.Client in the 2 real-dccd network tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The two `-m network` real-dccd replay tests now use `async with dccd.Client() as c`
+  (current dccd's `Client` is an async context manager — `inventory()`/`read` require it
+  entered); they previously called `inventory()` on a non-entered client. (#83)
+
 ### Deprecated
 
 ### Removed

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -29,9 +29,6 @@ the gitignored `strategies/`, real dccd-data verified). History in `CHANGELOG.md
   to trigger a reconcile pass on, and live fills are not streamed onto the bus. Wire
   the private fill WS into the engine and trigger `reconcile` on each reconnect (and
   land fill-id dedup — see below — before that stream feeds the tracker).
-- [ ] **dccd API drift breaks two `-m network` data-feed tests.** `dccd.Client().inventory()`
-  is now called outside an `async with` in `test_data_feed.py` / `test_data_provider.py`
-  (current dccd rejects it). Network-only (not in CI). Realign the dccd client usage.
 
 ## Open / deferred (maintainer decisions)
 

--- a/trading_bot/tests/application/test_data_feed.py
+++ b/trading_bot/tests/application/test_data_feed.py
@@ -346,39 +346,47 @@ async def test_live_does_not_emit_unclosed_bar_when_none_closed() -> None:
 
 
 @pytest.mark.network
-def test_dccd_real_inventory_causal_replay() -> None:
+async def test_dccd_real_inventory_causal_replay() -> None:
     """Real dccd: replay a stored OHLC dataset and assert no lookahead.
 
     Skips with a clear reason when no OHLC dataset is stored (the injected-client
     tests above cover the logic; this only adds real-data coverage when present).
+    The dccd ``Client`` is an **async context manager** — ``inventory()`` / ``read``
+    require it entered (``async with``), which builds the store.
     """
     dccd = pytest.importorskip("dccd")
-    client = dccd.Client()
-    ohlc = [d for d in client.inventory() if d.get("data_type") == "ohlc" and d.get("rows", 0) > 0]
-    if not ohlc:
-        pytest.skip("no stored dccd OHLC dataset to replay (inventory empty)")
+    async with dccd.Client() as client:
+        ohlc = [
+            d
+            for d in client.inventory()
+            if d.get("data_type") == "ohlc" and d.get("rows", 0) > 0
+        ]
+        if not ohlc:
+            pytest.skip("no stored dccd OHLC dataset to replay (inventory empty)")
 
-    entry = ohlc[0]
-    feed = DccdFeed(
-        client,
-        entry["exchange"],
-        entry["pair"],
-        int(entry["span"]),
-    )
-    full = feed.latest()
-    if full.height == 0:
-        pytest.skip(f"dccd OHLC dataset {entry['exchange']}/{entry['pair']} read empty")
+        entry = ohlc[0]
+        feed = DccdFeed(
+            client,
+            entry["exchange"],
+            entry["pair"],
+            int(entry["span"]),
+        )
+        full = feed.latest()
+        if full.height == 0:
+            pytest.skip(
+                f"dccd OHLC dataset {entry['exchange']}/{entry['pair']} read empty"
+            )
 
-    assert list(full.columns) == list(BARS_SCHEMA)
-    # Monotonic non-decreasing timestamps over the whole frame.
-    times = full["time"].to_list()
-    assert times == sorted(times)
+        assert list(full.columns) == list(BARS_SCHEMA)
+        # Monotonic non-decreasing timestamps over the whole frame.
+        times = full["time"].to_list()
+        assert times == sorted(times)
 
-    # Replay a few causal prefixes and assert each window's last time is its
-    # current bar's — never a later one.
-    for t, window in enumerate(feed):
-        assert window.height == t + 1
-        assert window["time"][-1] == full["time"][t]
-        assert window["time"].max() == full["time"][t]
-        if t >= 4:
-            break
+        # Replay a few causal prefixes and assert each window's last time is its
+        # current bar's — never a later one.
+        for t, window in enumerate(feed):
+            assert window.height == t + 1
+            assert window["time"][-1] == full["time"][t]
+            assert window["time"].max() == full["time"][t]
+            if t >= 4:
+                break

--- a/trading_bot/tests/application/test_data_provider.py
+++ b/trading_bot/tests/application/test_data_provider.py
@@ -283,42 +283,46 @@ def test_feed_for_requires_data_source() -> None:
 
 
 @pytest.mark.network
-def test_feed_for_real_inventory_causal_replay() -> None:
+async def test_feed_for_real_inventory_causal_replay() -> None:
     """Real dccd: feed_for over a stored OHLC dataset replays with no lookahead.
 
     Skips with a clear reason when no OHLC dataset is stored (the injected-client
     tests above cover the logic; this only adds real-data coverage when present).
+    The dccd ``Client`` is an **async context manager** — ``inventory()`` / ``read``
+    require it entered (``async with``), which builds the store.
     """
     dccd = pytest.importorskip("dccd")
-    client = dccd.Client()
-    ohlc = [
-        d
-        for d in client.inventory()
-        if d.get("data_type") == "ohlc" and d.get("rows", 0) > 0
-    ]
-    if not ohlc:
-        pytest.skip("no stored dccd OHLC dataset to replay (inventory empty)")
+    async with dccd.Client() as client:
+        ohlc = [
+            d
+            for d in client.inventory()
+            if d.get("data_type") == "ohlc" and d.get("rows", 0) > 0
+        ]
+        if not ohlc:
+            pytest.skip("no stored dccd OHLC dataset to replay (inventory empty)")
 
-    entry = ohlc[0]
-    cfg = StrategyConfig.model_validate(
-        {
-            "name": "real",
-            "symbol": entry["pair"],
-            "data": {"exchange": entry["exchange"], "span": int(entry["span"])},
-        }
-    )
-    feed = feed_for(cfg, client=client)
-    full = feed.latest()
-    if full.height == 0:
-        pytest.skip(f"dccd OHLC dataset {entry['exchange']}/{entry['pair']} read empty")
+        entry = ohlc[0]
+        cfg = StrategyConfig.model_validate(
+            {
+                "name": "real",
+                "symbol": entry["pair"],
+                "data": {"exchange": entry["exchange"], "span": int(entry["span"])},
+            }
+        )
+        feed = feed_for(cfg, client=client)
+        full = feed.latest()
+        if full.height == 0:
+            pytest.skip(
+                f"dccd OHLC dataset {entry['exchange']}/{entry['pair']} read empty"
+            )
 
-    assert list(full.columns) == list(BARS_SCHEMA)
-    times = full["time"].to_list()
-    assert times == sorted(times)  # monotonic non-decreasing
+        assert list(full.columns) == list(BARS_SCHEMA)
+        times = full["time"].to_list()
+        assert times == sorted(times)  # monotonic non-decreasing
 
-    for t, window in enumerate(feed):
-        assert window.height == t + 1
-        assert window["time"][-1] == full["time"][t]
-        assert window["time"].max() == full["time"][t]
-        if t >= 4:
-            break
+        for t, window in enumerate(feed):
+            assert window.height == t + 1
+            assert window["time"][-1] == full["time"][t]
+            assert window["time"].max() == full["time"][t]
+            if t >= 4:
+                break


### PR DESCRIPTION
## Summary
- The two `@pytest.mark.network` real-dccd replay tests now `async with dccd.Client() as client:` (and are `async def`), matching dccd's current API.

## Why
- Audit follow-up: dccd's `Client` is an **async context manager** — `inventory()`/`read` call `_require_ready()` which needs `__aenter__` to have built the store. The tests called `inventory()` on a freshly-constructed (not entered) client → reject. Network-only (not in CI; `importorskip` skips without dccd installed).

## Test plan
- [x] both tests collect as async and SKIP cleanly under `-m network` (dccd not installed here)
- [x] `pytest` (default) — 721 passed; `ruff` + `mypy` clean
- [ ] CI green