### PR TITLE
docs: finalize project name — keep trading_bot (no rename)

### DIFF
--- a/doc/dev/01-overview.md
+++ b/doc/dev/01-overview.md
@@ -40,7 +40,7 @@ deepens it epic by epic.
   [`07-roadmap.md`](07-roadmap.md) for what comes next.
 - **Decided direction:** full rewrite (not incremental); execution **and**
   orchestration; multi-exchange-ready with **Kraken first**; **paper-first**;
-  name kept as `trading_bot` for now (final name deferred). See
+  name **decided** — kept as `trading_bot` (with `dccd` / `fynance`); no rename. See
   [`03-decisions.md`](03-decisions.md).
 
 ## Repo map

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,23 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Project name finalized — keep `trading_bot` (no rename) (PR #84)  [accepted]
+
+**Choice.** The triptych keeps its names: **`trading_bot`** (execution/orchestration),
+**`dccd`** (data), **`fynance`** (research). The long-deferred "final project name"
+decision is **closed** — there is no rename of the package / repo / docs.
+
+**Why.** The maintainer reviewed naming and chose to keep the existing names. The names
+are clear, already established across the three repos and their tooling, and a rename
+would churn the package import path, the repo, CI, and every cross-repo reference for no
+functional gain. Closing the decision removes a standing "deferred" item that was
+otherwise blocking the roadmap from reaching zero open work before go-live.
+
+**Rejected alternatives.** A themed rename of the project/package (considered earlier in
+the session, then dropped — "on garde ces noms là"): pure churn, no benefit.
+
+---
+
 ### 2026-06-29 Linear position drain via an incremental `Position.with_fill` (PR #82)  [accepted]
 
 **Choice.** Add `Position.with_fill(fill) -> Position` (+ `Position.flat`); reimplement

--- a/doc/dev/06-status.md
+++ b/doc/dev/06-status.md
@@ -55,10 +55,11 @@ store-key convention is pinned** by config (`store_key_format`). Hygiene in the 
 removed the dead `BrokerRegistry`, and the limit-at-close price is exact `Decimal` (no
 float). Remaining venue-side idempotency token is the real-key-sandbox prerequisite.
 
-**Remaining (maintainer decisions, see `07-roadmap.md`):** the **final project name**
-(kept `trading_bot`), and **real-key live enablement** (validate Kraken private
-endpoints + venue-level idempotency against a real-key sandbox, then flip
-`live_enabled`). Engine layers, the triptych wiring (one `AppConfig` →
+**Remaining:** **real-key live enablement** (validate Kraken private endpoints +
+venue-level idempotency against a real-key sandbox, then flip `live_enabled`) — the one
+maintainer step left, see `07-roadmap.md`. The **project name is decided** (kept
+`trading_bot`, with `dccd` / `fynance`; no rename). Engine layers, the triptych wiring
+(one `AppConfig` →
 `run_app` → one engine → runners via the `Orchestrator`; `trading-bot serve` for the
 read-only dashboard), and the Phase-0 dev standard (packaging, CI 3.11–3.13, Git Flow,
 `.claude/` workflow, this `doc/dev/` pack) are all in place — see the paragraphs above
@@ -78,12 +79,13 @@ and `CHANGELOG.md` for what shipped.
 
 The engine is feature-complete and the safety machinery is wired. What remains is **not**
 engine code: **real-key live enablement** (validate Kraken private endpoints +
-venue-level idempotency against a real-key sandbox, then flip `live_enabled`) and the
-**final project name** — both maintainer decisions in [`07-roadmap.md`](07-roadmap.md).
+venue-level idempotency against a real-key sandbox, then flip `live_enabled`) — the one
+maintainer step in [`07-roadmap.md`](07-roadmap.md).
 
 ## Known gaps / deferred
 
-- **Final project name** — kept as `trading_bot` for now (deferred decision).
+- ~~**Final project name**~~ — **decided**: kept as `trading_bot` (with `dccd` /
+  `fynance`); no rename.
 - ~~**KPI ratios need a positive starting capital**~~ — **resolved (E10)**:
   `AppConfig.starting_capital` (default 100000) is wired into `PerformanceService(v0=)`.
 - ~~**Same-instrument strategies commingle in `run_app`**~~ — **resolved (E10)**:

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -32,8 +32,9 @@ the gitignored `strategies/`, real dccd-data verified). History in `CHANGELOG.md
 
 ## Open / deferred (maintainer decisions)
 
-- [ ] **Final project name.** Kept `trading_bot` for now — choose and apply a final
-  name when ready (touches the package/repo/docs).
 - [ ] **Real-key live enablement.** Validate Kraken private endpoints + venue-level
   order idempotency against a **real-key sandbox**, then flip `live_enabled` — the one
   remaining prerequisite before real-money trading. See `doc/dev/09-go-live.md`.
+
+> **Project name — decided:** kept as `trading_bot` (with `dccd` / `fynance`). The
+> deferred "final name" decision is **closed**; no rename. See `03-decisions.md`.


### PR DESCRIPTION
## Summary
- Close the deferred **final project name** decision: keep `trading_bot` (with `dccd` / `fynance`), no rename.
- Record the ADR; remove the open deferral lines from `07-roadmap.md`, `06-status.md`, `01-overview.md`.

## Why
- The maintainer chose to keep the existing names ("on garde ces noms là"). Closing this removes the last non-go-live open item so the roadmap reaches zero open engineering work.

## Test plan
- [x] docs-only; `ruff` clean
- [ ] CI green