### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [0.4.0] - 2026-06-29
+
+### Added
+
 - `Position.with_fill(fill)` + `Position.flat(instrument)` — the exact **incremental**
   fold (`from_fills` is now a fold of `with_fill`). (#82)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trading_bot"
-version = "0.3.0"
+version = "0.4.0"
 description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v0.4.0

Freezes `[Unreleased]` into `## [0.4.0] - 2026-06-29`, bumps `pyproject.toml` to `0.4.0`.

### Highlights
- **Added**: `Position.with_fill` / `Position.flat` (exact incremental fold).
- **Changed**: the tracker & performance **drain is now O(n)** (was O(n²)) — long runs/replays no longer quadratic; behaviour identical by construction.
- **Fixed**: the two real-dccd network tests use `async with dccd.Client()`.

718→721 tests green; ruff + mypy clean.

### Roadmap after this
Down to the **go-live bundle** (needs a real Kraken key): wire+validate the private fill WS, and real-key live enablement. The project name is finalized (`trading_bot`).