### PR TITLE
feat: live fill streaming — wire KrakenPrivateWS into the run loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live fill streaming.** `application.LiveFillStreamer` pumps a venue's private
+  fill stream (e.g. `KrakenPrivateWS`) onto the engine bus — each confirmed
+  execution becomes a `FillEvent`, so the tracker / performance service / store
+  update from the venue in real time (fill-id dedup guards the snapshot replayed on
+  resubscribe). `KrakenPrivateWS` gains an `on_connected` hook awaited after each
+  (re)connect's subscribe, and `run_app` wires it: a **real-money live Kraken** run
+  builds the streamer with an `on_connected` that **reconciles on every reconnect**
+  and hosts it in the orchestrator (paper/testnet add nothing). Validated read-only
+  against real Kraken (executions snapshot streamed + parsed; no order sent). (#87)
+
 ### Changed
 
 ### Fixed
+
+- **Kraken `GetWebSocketsToken` was missing from the call-counter cost table**, so
+  `cost_of` raised "Unknown method" and the private executions WebSocket could never
+  fetch a token (it was wholly non-functional). Added (cost 1); the live WS read path
+  now works. Found by the read-only live validation. (#87)
 
 ### Deprecated
 

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,38 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Live fill streaming via a `LiveFillStreamer` hosted by the orchestrator (PR #87)  [accepted]
+
+**Choice.** A new `application.LiveFillStreamer` consumes a structural `FillSource`
+(`fills()` async-iterator + `stop()`; `KrakenPrivateWS` satisfies it) and emits a
+`FillEvent` per fill onto the engine bus. It exposes the runner's
+`run(stop_event=...) -> int` contract, so the `Orchestrator` hosts it as just another
+concurrent task; consumption is raced against the stop event and **cancelled** on stop
+(a quiet stream never delays shutdown). `KrakenPrivateWS` gains an injected
+`on_connected` async hook (awaited after each (re)connect's subscribe); `run_app` builds
+the streamer **only** for a real-money live Kraken broker, with `on_connected` =
+reconcile, so the engine re-syncs to the venue after every reconnect.
+
+**Why.** The audit's "after-disconnect reconcile + live fills not streamed" follow-up.
+The private WS already re-runs `on_connect` on every reconnect, so an injected hook is
+the clean reconcile trigger (the WS layer stays ignorant of reconcile — pure DI). The
+streamer matches the runner contract so the existing orchestrator hosts it with no new
+lifecycle machinery, sharing the one cooperative stop event. Validated **read-only**
+against real Kraken (executions snapshot streamed + parsed; **no order sent**).
+
+**Found + fixed in passing.** The read-only live validation exposed that
+`GetWebSocketsToken` was absent from the Kraken call-counter cost table — `cost_of`
+raised "Unknown method", so the private WS could *never* fetch a token. Added (cost 1).
+
+**Rejected alternatives.** Hooking reconcile inside the transport WS layer (a layering
+violation — the WS would import application reconcile); a bespoke lifecycle for the
+streamer outside the orchestrator (the runner contract already fits); streaming for
+testnet/Binance too (Binance has no private-fill WS adapter; testnet is paper money).
+The live **order** path (AddOrder/cancel against a real venue) stays unvalidated by
+deliberate choice — read-only live testing only, per the go-live runbook.
+
+---
+
 ### 2026-06-29 Project name finalized — keep `trading_bot` (no rename) (PR #84)  [accepted]
 
 **Choice.** The triptych keeps its names: **`trading_bot`** (execution/orchestration),

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -22,13 +22,13 @@ the gitignored `strategies/`, real dccd-data verified). History in `CHANGELOG.md
 
 ## Known issues / follow-ups
 
-- [ ] **Live fill streaming + post-disconnect reconcile.** Reconcile is now wired
-  **on startup** (`run_app` converges the engine to the venue before the first order),
-  but the **after-disconnect** half of *reconcile, don't assume* is not: the private
-  fill WS (`KrakenPrivateWS`) is not wired into the run loop, so there is no reconnect
-  to trigger a reconcile pass on, and live fills are not streamed onto the bus. Wire
-  the private fill WS into the engine and trigger `reconcile` on each reconnect (and
-  land fill-id dedup — see below — before that stream feeds the tracker).
+_None open — the engine-side roadmap is clear. Remaining work is the maintainer's
+real-key go-live step below._
+
+> **Live fill streaming — done.** The private `KrakenPrivateWS` is wired into the run
+> loop via `LiveFillStreamer` (real-money live Kraken only), reconcile fires on every
+> WS (re)connect, and fills are de-duplicated by id. Validated **read-only** against
+> real Kraken (no order sent). See `03-decisions.md`.
 
 ## Open / deferred (maintainer decisions)
 

--- a/doc/dev/09-go-live.md
+++ b/doc/dev/09-go-live.md
@@ -103,10 +103,11 @@ Before the first live order, confirm every item:
 - [ ] **Kill-switch tested** — confirm the `RiskManager` kill-switch cancels open
       orders and halts new ones (covered offline by the hardening suite). It is
       now auto-triggered on a `max_daily_loss` breach.
-- [ ] **Reconcile-on-startup** — on start the engine refetches open orders +
-      balances + fills and reconciles local state (now wired into `run_app`,
-      before the first order); confirm it converges (proven offline). Reconcile
-      *after a disconnect* is deferred to live fill streaming (roadmap).
+- [ ] **Reconcile on startup *and* reconnect** — on start the engine refetches open
+      orders + balances + fills and reconciles before the first order; and on a live
+      Kraken run the private fill WS (`KrakenPrivateWS` → `LiveFillStreamer`) re-runs
+      `reconcile` on **every (re)connect**, so a disconnect re-syncs automatically.
+      Both wired into `run_app`; convergence proven offline.
 - [ ] **Strategy paper-validated** — the exact strategy you intend to run has
       been validated in `mode: paper` over representative data and behaves as
       expected.
@@ -121,7 +122,8 @@ Before the first live order, confirm every item:
 
 | Concern | Proven offline (`tests/hardening/`) | Pending — needs a real-key sandbox |
 |---|---|---|
-| Reconciliation | Reconcile converges local state to broker-reported open orders / balances / fills after a disconnect | Real private-endpoint reads (OpenOrders / balances / fills) against a live key |
+| Reconciliation | Reconcile converges local state to broker-reported open orders / balances / fills after a disconnect | — |
+| **Private reads (read-only live ✓)** | — | **Validated read-only against real Kraken**: `OpenOrders` + `TradesHistory` (`fills`) returned + parsed; the private executions **WS** streamed a real snapshot. `balances` needs the key's *Query Funds* permission. **No order was sent.** |
 | Idempotency | **Engine-side** idempotency: a retried submit with the same client-order-id never double-submits locally | **Venue-level** idempotency token: Kraken honouring the client-order-id so a retry never creates a duplicate *at the venue* |
 | Ambiguous failures | Ambiguous submit failures (timeout / unknown outcome) are surfaced, not silently assumed filled or failed | Real network-edge behaviour against the live API |
 | Kill-switch | Kill-switch cancels open orders + halts new ones | Real cancel against the venue |

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -140,6 +140,7 @@ from trading_bot.application.events import (
     LogEvent,
     OrderEvent,
 )
+from trading_bot.application.live_fills import FillSource, LiveFillStreamer
 from trading_bot.application.orchestrator import Orchestrator, RunnerGroupError
 from trading_bot.application.order_router import OrderRouter
 from trading_bot.application.performance_service import PerformanceService
@@ -196,6 +197,8 @@ __all__ = [
     "PositionTracker",
     "PerformanceService",
     "RiskManager",
+    "LiveFillStreamer",
+    "FillSource",
     "reconcile",
     "ReconResult",
     # data feed

--- a/trading_bot/application/live_fills.py
+++ b/trading_bot/application/live_fills.py
@@ -1,0 +1,127 @@
+"""The :class:`LiveFillStreamer` — pump a venue's live fills onto the engine bus.
+
+During a **live** run a venue's private WebSocket (e.g.
+:class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS`) streams the venue's own
+executions as domain :class:`~trading_bot.domain.fill.Fill`s. This component
+consumes that stream and emits one
+:class:`~trading_bot.application.events.FillEvent` per fill onto the shared
+:class:`~trading_bot.application.events.EventBus`, so the
+:class:`~trading_bot.application.position_tracker.PositionTracker`, the
+:class:`~trading_bot.application.performance_service.PerformanceService` and (when
+present) the store update from the venue's **confirmed** fills in real time —
+rather than only from the simulator. Fill-id dedup in those views guards against a
+re-emitted snapshot after a reconnect, so the snapshot Kraken replays on every
+resubscribe never double-counts.
+
+It exposes the same cooperative ``run(stop_event=...) -> int`` contract as a
+:class:`~trading_bot.application.strategy_runner.StrategyRunner`, so the
+:class:`~trading_bot.application.orchestrator.Orchestrator` hosts it as **just
+another concurrent task** sharing the one stop event. Consumption is raced against
+the stop event and **cancelled promptly** when it fires (a blocked read on a quiet
+stream does not delay shutdown).
+
+This module lives in the application layer: it bridges a transport-level fill
+source to the event bus, holds no money logic, and performs no I/O of its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Protocol
+
+from trading_bot.application.events import EventBus, FillEvent
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from trading_bot.domain.fill import Fill
+
+__all__ = ["FillSource", "LiveFillStreamer"]
+
+logger = logging.getLogger(__name__)
+
+
+class FillSource(Protocol):
+    """A live source of domain :class:`~trading_bot.domain.fill.Fill`s.
+
+    The structural contract :class:`LiveFillStreamer` consumes —
+    :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS` satisfies it (its
+    ``fills()`` async-iterates executed trades, reconnecting internally; ``stop()``
+    is inherited from :class:`~trading_bot.transport.ws.WebSocketBase`). A test
+    injects a fake.
+    """
+
+    def fills(self) -> AsyncIterator[Fill]:
+        """Yield confirmed fills as they arrive (the source reconnects internally)."""
+        ...
+
+    def stop(self) -> None:
+        """Request the underlying stream to end (cooperative shutdown)."""
+        ...
+
+
+class LiveFillStreamer:
+    """Emit a :class:`FillEvent` on the bus for every fill from a live source.
+
+    Parameters
+    ----------
+    source : FillSource
+        The live fill stream (e.g. a
+        :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS`).
+    event_bus : EventBus
+        The shared bus to emit each fill onto (the tracker / performance service /
+        store are subscribed to it).
+
+    """
+
+    def __init__(self, source: FillSource, event_bus: EventBus) -> None:
+        self._source = source
+        self._bus = event_bus
+        self._emitted = 0
+
+    async def run(self, *, stop_event: asyncio.Event | None = None) -> int:
+        """Stream fills onto the bus until the stream ends or ``stop_event`` fires.
+
+        Mirrors the :class:`~trading_bot.application.strategy_runner.StrategyRunner`
+        contract so the :class:`~trading_bot.application.orchestrator.Orchestrator`
+        can host it. Consumption is raced against ``stop_event``; when the event is
+        set the source is stopped and the (possibly blocked) consumption is
+        **cancelled**, so a quiet stream never delays shutdown.
+
+        Parameters
+        ----------
+        stop_event : asyncio.Event, optional
+            The shared cooperative-stop flag. ``None`` runs until the source's
+            stream naturally ends (a finite/test source).
+
+        Returns
+        -------
+        int
+            The number of fills emitted onto the bus.
+
+        """
+        consume = asyncio.create_task(self._consume())
+        if stop_event is None:
+            await consume
+            return self._emitted
+
+        stop_wait = asyncio.create_task(stop_event.wait())
+        await asyncio.wait({consume, stop_wait}, return_when=asyncio.FIRST_COMPLETED)
+
+        if not consume.done():
+            # Stop fired first: end the stream and cancel the (blocked) consumer.
+            self._source.stop()
+            consume.cancel()
+        for task in (consume, stop_wait):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        return self._emitted
+
+    async def _consume(self) -> None:
+        """Emit a :class:`FillEvent` for each fill the source yields."""
+        async for fill in self._source.fills():
+            self._bus.emit(FillEvent(fill))
+            self._emitted += 1

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -74,6 +74,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
 from trading_bot.application.data_provider import feed_for
+from trading_bot.application.live_fills import LiveFillStreamer
 from trading_bot.application.orchestrator import Orchestrator
 from trading_bot.application.portfolio import (
     PortfolioStrategy,
@@ -90,6 +91,8 @@ from trading_bot.application.strategy import (
     ma_crossover_signal,
 )
 from trading_bot.application.strategy_runner import StrategyRunner
+from trading_bot.brokers.kraken import KrakenBroker
+from trading_bot.brokers.kraken_ws import KrakenPrivateWS
 from trading_bot.domain.errors import ConfigError
 from trading_bot.domain.instrument import Instrument, Symbol, parse_kraken_pair
 from trading_bot.domain.money import Money, from_float, money
@@ -652,6 +655,36 @@ def _store_key_renderer(
     return lambda sym: sym.to_venue_symbol(exchange)
 
 
+def _maybe_build_fill_streamer(
+    config: AppConfig, engine: Engine
+) -> LiveFillStreamer | None:
+    """Build a live private-fill streamer for a **real-money live Kraken** broker.
+
+    Only an opted-in live :class:`~trading_bot.brokers.kraken.KrakenBroker` has a
+    private ``executions`` WebSocket; paper, testnet (``live_enabled`` is False
+    there) and Binance have none — this returns ``None`` for them, so a paper /
+    testnet run is unchanged. When it applies, a
+    :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS` is built from the
+    broker (token from its signed REST) with an ``on_connected`` hook that
+    **reconciles** the engine to the venue after every (re)connect, and wrapped in
+    a :class:`~trading_bot.application.live_fills.LiveFillStreamer` so the venue's
+    confirmed fills fan out onto the engine bus in real time (fill-id dedup guards
+    the snapshot Kraken replays on resubscribe). Construction performs **no I/O**
+    (no token fetch, no connection); the stream opens only when the streamer runs.
+    """
+    if config.mode != "live" or not config.live_enabled:
+        return None
+    broker = engine.broker
+    if not isinstance(broker, KrakenBroker):
+        return None
+
+    async def _reconcile_on_reconnect() -> None:
+        await reconcile(broker, engine.router, engine.tracker, event_bus=engine.bus)
+
+    ws = KrakenPrivateWS.from_broker(broker, on_connected=_reconcile_on_reconnect)
+    return LiveFillStreamer(ws, engine.bus)
+
+
 def _portfolio_start_ns(start: str | int | None) -> int | None:
     """Map a portfolio data source ``start`` to an epoch-ns bound.
 
@@ -782,6 +815,11 @@ async def run_app(
     orchestrator = Orchestrator(event_bus=engine.bus)
     orchestrator.add_all(runners)
     orchestrator.add_all(portfolio_runners)  # type: ignore[arg-type]
+    # A real-money live Kraken run also streams the venue's confirmed fills onto the
+    # bus (and reconciles on every WS (re)connect); paper/testnet add nothing here.
+    fill_streamer = _maybe_build_fill_streamer(config, engine)
+    if fill_streamer is not None:
+        orchestrator.add(fill_streamer)  # type: ignore[arg-type]
     results = await orchestrator.run()
 
     strategies: list[StrategyReport] = []

--- a/trading_bot/brokers/kraken_ws.py
+++ b/trading_bot/brokers/kraken_ws.py
@@ -224,6 +224,7 @@ class KrakenPrivateWS(WebSocketBase):
         *,
         snap_trades: bool = True,
         snap_orders: bool = True,
+        on_connected: Callable[[], Awaitable[None]] | None = None,
         url: str = _WS_AUTH_URL,
         **ws_kwargs: Any,
     ) -> None:
@@ -231,6 +232,7 @@ class KrakenPrivateWS(WebSocketBase):
         self._token_provider = token_provider
         self._snap_trades = snap_trades
         self._snap_orders = snap_orders
+        self._on_connected = on_connected
 
     @classmethod
     def from_broker(
@@ -239,6 +241,7 @@ class KrakenPrivateWS(WebSocketBase):
         *,
         snap_trades: bool = True,
         snap_orders: bool = True,
+        on_connected: Callable[[], Awaitable[None]] | None = None,
         url: str = _WS_AUTH_URL,
         **ws_kwargs: Any,
     ) -> KrakenPrivateWS:
@@ -247,12 +250,14 @@ class KrakenPrivateWS(WebSocketBase):
         Wires the default :data:`TokenProvider` to ``broker``'s signed private
         REST (``GetWebSocketsToken``). Requires the broker to carry credentials;
         the token fetch raises :class:`~trading_bot.domain.errors.BrokerError`
-        without them, before any I/O.
+        without them, before any I/O. ``on_connected`` (if given) is awaited after
+        each (re)connect's subscribe — the seam a live caller uses to reconcile.
         """
         return cls(
             _broker_token_provider(broker),
             snap_trades=snap_trades,
             snap_orders=snap_orders,
+            on_connected=on_connected,
             url=url,
             **ws_kwargs,
         )
@@ -263,7 +268,10 @@ class KrakenPrivateWS(WebSocketBase):
         Obtains a fresh token via the injected ``token_provider`` and sends the
         v2 ``subscribe`` for the ``executions`` channel with the token in
         ``params``. Because the base re-runs this on every reconnect, the token
-        is refreshed and the subscription re-established automatically.
+        is refreshed and the subscription re-established automatically — and, if an
+        ``on_connected`` hook was supplied, it is awaited afterwards (the seam a
+        live caller uses to **reconcile** the engine to the venue after every
+        reconnect; a failure there is logged, never breaking the stream).
         """
         token = await self._token_provider()
         sub: dict[str, Any] = {
@@ -276,6 +284,11 @@ class KrakenPrivateWS(WebSocketBase):
             },
         }
         await ws.send(json.dumps(sub))
+        if self._on_connected is not None:
+            try:
+                await self._on_connected()
+            except Exception:
+                logger.exception("on_connected hook failed after WS (re)connect")
 
     async def events(self) -> AsyncIterator[Fill | OrderUpdate]:
         """Yield domain :class:`Fill`s and :class:`OrderUpdate`s from the feed.

--- a/trading_bot/tests/application/test_live_fills.py
+++ b/trading_bot/tests/application/test_live_fills.py
@@ -1,0 +1,114 @@
+"""Tests for :class:`LiveFillStreamer` — pumping a live fill source onto the bus.
+
+Drives the streamer with a **fake** fill source (no WebSocket, no network): it
+yields a canned sequence of domain fills and can block afterwards to model a quiet
+live stream. The streamer must emit one ``FillEvent`` per fill onto the bus, and a
+set ``stop_event`` must end even a *blocked* stream promptly (cooperative stop via
+cancellation). Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+from trading_bot.application import EventBus, FillEvent
+from trading_bot.application.live_fills import LiveFillStreamer
+from trading_bot.domain import Fill, Instrument, OrderSide, Symbol, money
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+def _fill(fill_id: str) -> Fill:
+    return Fill(
+        fill_id=fill_id,
+        client_order_id="cid",
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        price=money("30000"),
+        fee=money("1"),
+        ts=1,
+    )
+
+
+class _FakeSource:
+    """A fake fill source: yields ``fills`` then optionally blocks until stopped."""
+
+    def __init__(self, fills: list[Fill], *, block_after: bool = False) -> None:
+        self._fills = fills
+        self._block_after = block_after
+        self._stopped = asyncio.Event()
+
+    async def fills(self) -> AsyncIterator[Fill]:
+        for fill in self._fills:
+            yield fill
+        if self._block_after:
+            await self._stopped.wait()  # model a quiet live stream
+
+    def stop(self) -> None:
+        self._stopped.set()
+
+
+def _fill_events(seen: list[object]) -> list[FillEvent]:
+    return [e for e in seen if isinstance(e, FillEvent)]
+
+
+async def test_emits_one_fillevent_per_fill() -> None:
+    """A finite source: every fill becomes a ``FillEvent`` on the bus, in order."""
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe(seen.append)
+
+    streamer = LiveFillStreamer(
+        _FakeSource([_fill("F1"), _fill("F2"), _fill("F3")]), bus
+    )
+    emitted = await streamer.run()
+
+    assert emitted == 3
+    assert [e.fill.fill_id for e in _fill_events(seen)] == ["F1", "F2", "F3"]
+
+
+async def test_stop_event_ends_a_blocked_stream_promptly() -> None:
+    """A set ``stop_event`` ends even a *blocked* (quiet) stream — no hang.
+
+    The source yields two fills then blocks forever; the streamer must have emitted
+    both, and setting the stop event must let ``run`` return promptly (the blocked
+    consumer is cancelled).
+    """
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe(seen.append)
+    stop = asyncio.Event()
+
+    streamer = LiveFillStreamer(
+        _FakeSource([_fill("F1"), _fill("F2")], block_after=True), bus
+    )
+    task = asyncio.create_task(streamer.run(stop_event=stop))
+
+    # Let it emit both fills and then block on the quiet stream.
+    for _ in range(200):
+        if len(_fill_events(seen)) >= 2:
+            break
+        await asyncio.sleep(0)
+
+    stop.set()
+    emitted = await asyncio.wait_for(task, timeout=2.0)
+
+    assert emitted == 2
+    assert [e.fill.fill_id for e in _fill_events(seen)] == ["F1", "F2"]
+
+
+async def test_subscribed_tracker_updates_from_streamed_fills() -> None:
+    """End to end: streamed fills fan out to a subscribed tracker (live read-back)."""
+    from trading_bot.application import PositionTracker
+
+    bus = EventBus()
+    tracker = PositionTracker(event_bus=bus)
+    streamer = LiveFillStreamer(_FakeSource([_fill("F1"), _fill("F2")]), bus)
+
+    await streamer.run()
+
+    pos = tracker.position(BTC_USD)
+    assert pos is not None
+    assert pos.net_qty == money("2")  # two BUY 1 @ 30000 folded from the stream

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -710,3 +710,62 @@ def test_limit_at_close_prices_exactly_from_decimal_close_no_float() -> None:
     assert order.limit_price == money("100.123456789012345678")  # exact
     # And strictly better than the old float round-trip, which loses the tail.
     assert order.limit_price != from_float(float(exact))
+
+
+# --- live private-fill streamer wiring (real-money live Kraken only) -------- #
+
+
+def test_no_fill_streamer_for_paper() -> None:
+    """Paper runs add no private-fill streamer (nothing to stream)."""
+    from trading_bot.application.run_app import _maybe_build_fill_streamer
+    from trading_bot.application.service_factory import build_engine
+
+    config = AppConfig()  # paper
+    engine = build_engine(config)
+    assert _maybe_build_fill_streamer(config, engine) is None
+
+
+def test_no_fill_streamer_for_testnet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Testnet (``live_enabled`` False, paper money) adds no streamer."""
+    from trading_bot.application.config import BrokerConfig
+    from trading_bot.application.run_app import _maybe_build_fill_streamer
+    from trading_bot.application.service_factory import build_engine
+
+    monkeypatch.setenv("BINANCE_API_KEY", "k")
+    monkeypatch.setenv("BINANCE_API_SECRET", "s")
+    monkeypatch.delenv("BINANCE_API_BASE", raising=False)
+    config = AppConfig(
+        mode="live",
+        live_enabled=False,
+        brokers=[BrokerConfig(name="bn", exchange="binance", testnet=True)],
+    )
+    engine = build_engine(config)
+    assert _maybe_build_fill_streamer(config, engine) is None
+
+
+def test_fill_streamer_built_for_live_kraken(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real-money live Kraken run builds a `LiveFillStreamer` (construction only).
+
+    No network: `build_engine` + `KrakenPrivateWS.from_broker` perform no I/O (no
+    token fetch, no WS connect) — only the wiring is asserted.
+    """
+    from trading_bot.application.config import BrokerConfig, RiskConfig
+    from trading_bot.application.live_fills import LiveFillStreamer
+    from trading_bot.application.run_app import _maybe_build_fill_streamer
+    from trading_bot.application.service_factory import build_engine
+
+    monkeypatch.setenv("KRAKEN_API_KEY", "k")
+    monkeypatch.setenv("KRAKEN_API_SECRET", "c2VjcmV0")  # base64("secret")
+    config = AppConfig(
+        mode="live",
+        live_enabled=True,
+        brokers=[BrokerConfig(name="kraken", exchange="kraken")],
+        risk=RiskConfig(
+            max_order=money("1"),
+            max_position=money("5"),
+            max_daily_loss=money("1000"),
+        ),
+    )
+    engine = build_engine(config)
+    streamer = _maybe_build_fill_streamer(config, engine)
+    assert isinstance(streamer, LiveFillStreamer)

--- a/trading_bot/tests/brokers/test_kraken_ws.py
+++ b/trading_bot/tests/brokers/test_kraken_ws.py
@@ -443,3 +443,49 @@ async def test_from_broker_builds_token_provider_from_signed_rest() -> None:
 
     assert calls == ["GetWebSocketsToken"]
     assert json.loads(ws.sent[0])["params"]["token"] == "from-rest-token"
+
+
+# --- on_connected reconcile hook ------------------------------------------- #
+
+
+async def test_on_connected_hook_fires_after_subscribe_on_each_connect() -> None:
+    """The ``on_connected`` hook is awaited on connect AND on every reconnect.
+
+    The first socket yields one trade then ends (forcing a reconnect); the second
+    yields another. The hook (a live caller's reconcile trigger) must fire once per
+    (re)connect — twice here.
+    """
+    calls: list[int] = []
+
+    async def hook() -> None:
+        calls.append(1)
+
+    private = KrakenPrivateWS(
+        FakeTokenProvider(),
+        connect=FakeConnector([FakeWS([_TRADE_UPDATE_FRAME]), FakeWS([_TRADE_UPDATE_FRAME])]),
+        sleep=RecordingSleep(),
+        on_connected=hook,
+    )
+
+    events = await _drain(private, limit=2)
+
+    assert len(events) == 2  # one trade per connect
+    assert len(calls) == 2  # hook fired on connect AND reconnect
+
+
+async def test_on_connected_failure_does_not_break_the_stream() -> None:
+    """A raising ``on_connected`` hook is logged, not propagated — the stream lives."""
+
+    async def bad_hook() -> None:
+        raise RuntimeError("reconcile boom")
+
+    private = KrakenPrivateWS(
+        FakeTokenProvider(),
+        connect=FakeConnector([FakeWS([_TRADE_UPDATE_FRAME])]),
+        sleep=RecordingSleep(),
+        on_connected=bad_hook,
+    )
+
+    events = await _drain(private, limit=1)
+
+    assert len(events) == 1  # the trade still streamed despite the hook raising

--- a/trading_bot/tests/transport/test_ratelimit.py
+++ b/trading_bot/tests/transport/test_ratelimit.py
@@ -189,6 +189,26 @@ def test_costs_match_legacy_table() -> None:
         KrakenCallCounter.cost_of("NotAMethod")
 
 
+def test_every_private_method_the_broker_calls_has_a_cost() -> None:
+    """Each private endpoint `KrakenBroker` / the private WS posts must be costed.
+
+    Regression for the live-validation finding: `GetWebSocketsToken` was missing
+    from the cost table, so `cost_of` raised "Unknown method" and the private
+    executions WebSocket could never fetch a token (it was wholly non-functional).
+    Every signed endpoint the engine actually calls must be in `COSTS`.
+    """
+    for method in (
+        "AddOrder",
+        "CancelOrder",
+        "Balance",
+        "OpenOrders",
+        "TradesHistory",
+        "GetWebSocketsToken",  # the WS token endpoint — was missing
+    ):
+        KrakenCallCounter.cost_of(method)  # must not raise
+    assert KrakenCallCounter.cost_of("GetWebSocketsToken") == 1
+
+
 def test_tiers_match_legacy_constants() -> None:
     # Legacy KrakenCallCounter.__init__: starter (3, 15), intermediate (2, 20),
     # pro (1, 20).

--- a/trading_bot/transport/ratelimit.py
+++ b/trading_bot/transport/ratelimit.py
@@ -265,6 +265,7 @@ class KrakenCallCounter:
         "QueryTrades": 1,
         "OpenPositions": 1,
         "TradeVolume": 1,
+        "GetWebSocketsToken": 1,
         "AddExport": 1,
         "ExportStatus": 1,
         "RetrieveExport": 1,


### PR DESCRIPTION
## Summary
- `application.LiveFillStreamer` pumps a venue's private fill stream onto the engine bus (each execution → `FillEvent`; fill-id dedup guards the resubscribe snapshot). It matches the runner `run(stop_event=...)` contract, so the `Orchestrator` hosts it as another concurrent task (consumption raced against stop, cancelled promptly).
- `KrakenPrivateWS` gains an `on_connected` async hook (awaited after each (re)connect's subscribe).
- `run_app` builds the streamer **only** for a real-money live Kraken broker, with `on_connected` = `reconcile`, so the engine re-syncs to the venue on **every reconnect**. Paper/testnet add nothing.

## Bug found + fixed by the read-only live validation
- **`GetWebSocketsToken` was missing from the Kraken call-counter cost table** → `cost_of` raised "Unknown method", so the private WS could **never** fetch a token (wholly non-functional). Added (cost 1).

## Live validation (read-only, NO orders)
- Against **real Kraken** with the `.env` key: `OpenOrders` ✓, `TradesHistory`/`fills` ✓ (50 real fills parsed), and the private **executions WS** streamed a real snapshot (25 fills parsed). `balances` needs the key's *Query Funds* permission. **No order was placed or cancelled.**

## Changes
- `application/live_fills.py` (new) + export; `brokers/kraken_ws.py` (`on_connected`); `application/run_app.py` (`_maybe_build_fill_streamer` + orchestrator wiring); `transport/ratelimit.py` (cost fix).
- Tests: `test_live_fills.py` (new), `test_kraken_ws.py` (hook on connect+reconnect; failing hook doesn't break the stream), `test_run_app.py` (streamer built for live Kraken only), `test_ratelimit.py` (every called private method is costed).
- ADR + CHANGELOG + roadmap (item closed) + go-live runbook (private reads now read-only-proven; reconcile-on-reconnect).

## Test plan
- [x] `pytest` — 730 passed, 9 deselected
- [x] `ruff` + `mypy` clean
- [x] read-only live validation against real Kraken (no order)
- [ ] CI green