### PR TITLE
feat: live monitoring — trading-bot run --serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live monitoring — `trading-bot run --serve`.** Runs the declared system **and**
+  serves the read-only dashboard over the **same** engine in one process, so positions
+  / orders / PnL update in real time (engine bus + SSE) while the strategies run — not a
+  separate, freshly-built engine. uvicorn owns `SIGINT` (Ctrl-C ends serve, then the
+  orchestrator drains); a finite paper run keeps the dashboard up on its final state
+  until Ctrl-C. The dashboard stays **read-only** (never places an order).
+  `application.prepare_system` / `PreparedSystem` factor the build (engine + an
+  orchestrator loaded with runners) shared by `run_app` and the serve path. (#89)
 - **Live fill streaming.** `application.LiveFillStreamer` pumps a venue's private
   fill stream (e.g. `KrakenPrivateWS`) onto the engine bus — each confirmed
   execution becomes a `FillEvent`, so the tracker / performance service / store

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ engine — harmonised with dccd. The full engine is in place and hardened: domai
 transport, **Kraken** + **Binance** brokers behind a multi-exchange port, a
 paper-trading broker, the idempotent order router, single-instrument **and**
 native **multi-asset / portfolio** strategy runners, performance/risk services,
-SQLite persistence, a Typer CLI and a read-only FastAPI/Jinja2 dashboard. One
+SQLite persistence, a Typer CLI and a read-only FastAPI/Jinja2 dashboard (`trading-bot serve`, or
+`trading-bot run --serve` to monitor a live run in real time). One
 `AppConfig` conducts the triptych (dccd data + fynance signals + brokers). The
 money-safety invariants are proven under fault injection (`tests/hardening/`) and
 the safety machinery is wired into the run loop (reconcile-on-startup, the

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,32 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Live monitoring via `run --serve` over the same engine (PR #89)  [accepted]
+
+**Choice.** A `--serve` flag on `trading-bot run` serves the read-only dashboard
+(`create_app(engine)`) under uvicorn **concurrently** with the orchestrator, over the
+**same** `Engine`. The build is factored into `prepare_system(config) -> PreparedSystem`
+(engine + an orchestrator loaded with runners), shared by `run_app` (run + report) and
+the serve path. uvicorn owns `SIGINT`: `await server.serve()` blocks until Ctrl-C, then a
+`finally` stops the orchestrator (set its stop event, then await/cancel). The dashboard
+keeps the existing read-only API + SSE — it never places an order.
+
+**Why.** The dashboard's pre-existing `serve` builds a *fresh* engine and reads the
+persisted store — it cannot show a *running* `run`'s live in-memory state, which is what
+"monitor the strategies in prod" needs. Sharing the one engine (and its bus, so SSE is
+live) is the smallest change that makes the dashboard reflect the running system in real
+time. Factoring `prepare_system` avoids duplicating the restore/reconcile/build sequence.
+
+**Rejected alternatives.** Two processes coordinating via the SQLite store (lossy,
+lagged, no live SSE — only persisted snapshots); a separate long-lived daemon exposing
+the engine over IPC (far heavier than a flag); cloning dccd's full multi-page UI
+(custom fonts/logo/auth) for a single read-only dashboard — disproportionate; the
+existing clean dark dashboard is kept, a visual restyle left as reviewable polish.
+uvicorn-owns-SIGINT over installing the orchestrator's own handlers (avoids two handlers
+racing for Ctrl-C).
+
+---
+
 ### 2026-06-29 Live fill streaming via a `LiveFillStreamer` hosted by the orchestrator (PR #87)  [accepted]
 
 **Choice.** A new `application.LiveFillStreamer` consumes a structural `FillSource`

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -114,8 +114,10 @@ __all__ = [
     "StrategyReport",
     "PortfolioReport",
     "PortfolioCoinReport",
+    "PreparedSystem",
     "build_runners",
     "build_portfolio_runners",
+    "prepare_system",
     "run_app",
 ]
 
@@ -697,6 +699,143 @@ def _portfolio_start_ns(start: str | int | None) -> int | None:
     return _resolve_start_ns(start)
 
 
+@dataclass(frozen=True, slots=True)
+class PreparedSystem:
+    """A built — but **not yet run** — declared system.
+
+    The output of :func:`prepare_system`: the wired
+    :class:`~trading_bot.application.service_factory.Engine`, an
+    :class:`~trading_bot.application.orchestrator.Orchestrator` already loaded with
+    every runner (and, for a live Kraken run, the fill streamer), and the runner
+    lists used to build the final report. :func:`run_app` runs the orchestrator and
+    reports; the ``run --serve`` path instead serves a dashboard over the **same**
+    ``engine`` while the orchestrator runs, so the dashboard observes the live run.
+
+    Attributes
+    ----------
+    engine : Engine
+        The wired engine (broker / router / tracker / perf / risk / bus / store).
+    orchestrator : Orchestrator
+        Loaded with the strategy + portfolio runners (and the live fill streamer).
+    runners : list of StrategyRunner
+        The single-instrument runners, in config order.
+    portfolio_runners : list of PortfolioRunner
+        The portfolio runners, in config order.
+
+    """
+
+    engine: Engine
+    orchestrator: Orchestrator
+    runners: list[StrategyRunner]
+    portfolio_runners: list[PortfolioRunner]
+
+
+async def prepare_system(
+    config: AppConfig,
+    *,
+    dccd_client: DccdClient | None = None,
+    max_steps: int | None = None,
+    reconcile_on_start: bool = True,
+) -> PreparedSystem:
+    """Build the declared system up to (but not running) the orchestrator.
+
+    Assembles the engine, **restores** the router's dedup map from the store (if
+    any), **reconciles** to the broker before the first order, rejects commingled
+    instruments, builds the runners, and loads them — plus the live fill streamer
+    for a real-money live Kraken run — into a fresh
+    :class:`~trading_bot.application.orchestrator.Orchestrator`. Shared by
+    :func:`run_app` (run + report) and the ``run --serve`` path (serve the
+    dashboard over the same engine while the orchestrator runs). See
+    :func:`run_app` for the parameter meanings.
+    """
+    engine = build_engine(config, db_path=config.storage.db_path)
+    # Recover idempotency state across a restart: seed the router's dedup map from
+    # the persisted store (the append-only order history) so a re-submit of any
+    # previously-recorded order id is de-duplicated — closing the crash-restart
+    # double-submit window for ids the in-memory map lost. Done *before* reconcile,
+    # which then converges to the venue's current truth.
+    if engine.store is not None:
+        engine.router.restore(engine.store.orders())
+    # Reconcile, don't assume: converge the fresh engine's empty maps to the
+    # broker's truth (open orders + fills) before the first order is placed.
+    if reconcile_on_start:
+        await reconcile(
+            engine.broker, engine.router, engine.tracker, event_bus=engine.bus
+        )
+    # Reject any instrument claimed by two runners up front — across both the
+    # single-instrument strategies and the portfolios (the shared per-instrument
+    # tracker has no attribution).
+    _reject_commingled(config)
+    runners = build_runners(
+        config, engine, dccd_client=dccd_client, max_steps=max_steps
+    )
+    portfolio_runners = build_portfolio_runners(
+        config, engine, dccd_client=dccd_client, max_steps=max_steps
+    )
+
+    orchestrator = Orchestrator(event_bus=engine.bus)
+    orchestrator.add_all(runners)
+    orchestrator.add_all(portfolio_runners)  # type: ignore[arg-type]
+    # A real-money live Kraken run also streams the venue's confirmed fills onto the
+    # bus (and reconciles on every WS (re)connect); paper/testnet add nothing here.
+    fill_streamer = _maybe_build_fill_streamer(config, engine)
+    if fill_streamer is not None:
+        orchestrator.add(fill_streamer)  # type: ignore[arg-type]
+    return PreparedSystem(
+        engine=engine,
+        orchestrator=orchestrator,
+        runners=runners,
+        portfolio_runners=portfolio_runners,
+    )
+
+
+def _build_report(
+    system: PreparedSystem, results: dict[StrategyRunner, int]
+) -> RunReport:
+    """Build the :class:`RunReport` from a finished system's per-runner counts."""
+    engine = system.engine
+    strategies: list[StrategyReport] = []
+    for runner in system.runners:
+        strat = runner.strategy
+        strategies.append(
+            StrategyReport(
+                name=strat.name,
+                instrument=strat.instrument,
+                orders_submitted=results.get(runner, 0),
+                position=engine.tracker.position(strat.instrument),
+            )
+        )
+
+    # The orchestrator keys its results by the runner objects it ran (both the
+    # StrategyRunners and the PortfolioRunners); its return type is annotated for the
+    # single-instrument runner, so view it as a plain object map for the portfolios.
+    results_by_runner = cast("dict[object, int]", results)
+    portfolios: list[PortfolioReport] = []
+    for prunner in system.portfolio_runners:
+        pstrat = prunner.strategy
+        coins = [
+            PortfolioCoinReport(
+                instrument=Instrument(symbol),
+                position=engine.tracker.position(Instrument(symbol)),
+            )
+            for symbol in pstrat.universe
+        ]
+        portfolios.append(
+            PortfolioReport(
+                name=pstrat.name,
+                orders_submitted=results_by_runner.get(prunner, 0),
+                coins=coins,
+            )
+        )
+
+    return RunReport(
+        strategies=strategies,
+        portfolios=portfolios,
+        realised_pnl=engine.perf.realised_pnl(),
+        fees_paid=engine.perf.fees_paid(),
+    )
+
+
 async def run_app(
     config: AppConfig,
     *,
@@ -741,9 +880,11 @@ async def run_app(
     restart even before reconcile runs — closing the crash-restart double-submit
     window for ids the in-memory map lost.
 
-    Reconciling **after a disconnect** (the WS-reconnect half of the invariant)
-    attaches to the private fill stream, which is not yet wired into this run
-    loop; that lands with live fill streaming (tracked in the roadmap).
+    Reconciling **after a disconnect** is also wired for a real-money live Kraken
+    run: the private fill stream (:class:`~trading_bot.application.live_fills.
+    LiveFillStreamer` over :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS`)
+    re-runs :func:`~trading_bot.application.reconcile.reconcile` on every WS
+    (re)connect and streams the venue's confirmed fills onto the bus.
 
     Parameters
     ----------
@@ -783,83 +924,11 @@ async def run_app(
         refuses — never falling back to paper).
 
     """
-    engine = build_engine(config, db_path=config.storage.db_path)
-    # Recover idempotency state across a restart: seed the router's dedup map from
-    # the persisted store (the append-only order history) so a re-submit of any
-    # previously-recorded order id is de-duplicated — closing the crash-restart
-    # double-submit window for ids the in-memory map lost (the residual gap for a
-    # venue, like Kraken, with no venue-side idempotency token). No events emitted;
-    # done *before* reconcile, which then converges to the venue's current truth.
-    if engine.store is not None:
-        engine.router.restore(engine.store.orders())
-    # Reconcile, don't assume: converge the fresh engine's empty maps to the
-    # broker's truth (open orders + fills) before the first order is placed, so a
-    # restart never re-submits a venue-held order or trades a stale position. A
-    # no-op on a fresh PaperBroker; the safety backstop on a live/testnet venue.
-    if reconcile_on_start:
-        await reconcile(
-            engine.broker, engine.router, engine.tracker, event_bus=engine.bus
-        )
-    # Reject any instrument claimed by two runners up front — across both the
-    # single-instrument strategies and the portfolios (the shared per-instrument
-    # tracker has no attribution). build_runners also calls this for the
-    # strategy-only path; calling it here covers the cross-portfolio overlaps too.
-    _reject_commingled(config)
-    runners = build_runners(
-        config, engine, dccd_client=dccd_client, max_steps=max_steps
+    system = await prepare_system(
+        config,
+        dccd_client=dccd_client,
+        max_steps=max_steps,
+        reconcile_on_start=reconcile_on_start,
     )
-    portfolio_runners = build_portfolio_runners(
-        config, engine, dccd_client=dccd_client, max_steps=max_steps
-    )
-
-    orchestrator = Orchestrator(event_bus=engine.bus)
-    orchestrator.add_all(runners)
-    orchestrator.add_all(portfolio_runners)  # type: ignore[arg-type]
-    # A real-money live Kraken run also streams the venue's confirmed fills onto the
-    # bus (and reconciles on every WS (re)connect); paper/testnet add nothing here.
-    fill_streamer = _maybe_build_fill_streamer(config, engine)
-    if fill_streamer is not None:
-        orchestrator.add(fill_streamer)  # type: ignore[arg-type]
-    results = await orchestrator.run()
-
-    strategies: list[StrategyReport] = []
-    for runner in runners:
-        strat = runner.strategy
-        strategies.append(
-            StrategyReport(
-                name=strat.name,
-                instrument=strat.instrument,
-                orders_submitted=results.get(runner, 0),
-                position=engine.tracker.position(strat.instrument),
-            )
-        )
-
-    # The orchestrator keys its results by the runner objects it ran (both the
-    # StrategyRunners and the PortfolioRunners added via add_all); its return type
-    # is annotated for the single-instrument runner, so view it as a plain object
-    # map to look up the portfolio runners.
-    results_by_runner = cast("dict[object, int]", results)
-    portfolios: list[PortfolioReport] = []
-    for prunner in portfolio_runners:
-        pstrat = prunner.strategy
-        coins = [
-            PortfolioCoinReport(
-                instrument=Instrument(symbol),
-                position=engine.tracker.position(Instrument(symbol)),
-            )
-            for symbol in pstrat.universe
-        ]
-        portfolios.append(
-            PortfolioReport(
-                name=pstrat.name,
-                orders_submitted=results_by_runner.get(prunner, 0),
-                coins=coins,
-            )
-        )
-
-    return RunReport(
-        strategies=strategies,
-        portfolios=portfolios,
-        realised_pnl=engine.perf.realised_pnl(),
-        fees_paid=engine.perf.fees_paid(),
-    )
+    results = await system.orchestrator.run()
+    return _build_report(system, results)

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -45,6 +45,7 @@ out of the box.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import math
 import pathlib
@@ -263,6 +264,19 @@ def run(
         "--yes-i-understand",
         help="Explicit acknowledgement required to go --live.",
     ),
+    serve: bool = typer.Option(
+        False,
+        "--serve",
+        help="Also serve the read-only live dashboard over HTTP while the run "
+        "executes, so you can monitor positions / orders / PnL in real time "
+        "(Ctrl-C stops both). Read-only — the dashboard never places an order.",
+    ),
+    serve_host: str = typer.Option(
+        "127.0.0.1", "--serve-host", help="Dashboard bind interface (loopback)."
+    ),
+    serve_port: int = typer.Option(
+        8000, "--serve-port", help="Dashboard TCP port."
+    ),
 ) -> None:
     """Run the declared system (or a quick demo) and print a short summary.
 
@@ -297,6 +311,12 @@ def run(
 
     mode = _resolve_mode(config, live=live, yes_i_understand=yes_i_understand)
     config = config.model_copy(update={"mode": mode})
+
+    # --serve: run the declared system AND serve the read-only dashboard over the
+    # SAME engine, so the run can be monitored live. Handles 0+ strategies.
+    if serve:
+        _run_and_serve(config, host=serve_host, port=serve_port)
+        return
 
     # A config that declares strategies (with their own data + signal) runs the
     # whole declared system via the triptych entrypoint. A bare config (no
@@ -389,6 +409,55 @@ def _run_declared_system(config: AppConfig) -> None:
         if s.position is not None
     }
     _console.print(_render.positions_table(positions))
+
+
+def _run_and_serve(config: AppConfig, *, host: str, port: int) -> None:
+    """Run the declared system **and** serve the live dashboard over one engine.
+
+    Builds the system once (:func:`~trading_bot.application.run_app.prepare_system`),
+    serves the read-only FastAPI dashboard
+    (:func:`~trading_bot.interfaces.api.create_app`) over the **same** engine under
+    uvicorn, and runs the orchestrator concurrently — so the dashboard reflects the
+    live run in real time (positions / orders / PnL via the engine bus + SSE).
+    uvicorn owns ``SIGINT``: Ctrl-C ends ``serve``, and the ``finally`` then drains
+    the orchestrator. The dashboard is **read-only** — it can never place an order.
+    A finite (paper) run completes while the dashboard keeps serving the final state
+    until Ctrl-C; a live run streams until stopped. Build/config failures surface as
+    a clean non-zero exit with no order placed.
+    """
+    import uvicorn
+
+    from trading_bot.application.run_app import prepare_system
+    from trading_bot.interfaces.api import create_app
+
+    async def _serve() -> None:
+        system = await prepare_system(config)
+        api = create_app(system.engine)
+        server = uvicorn.Server(
+            uvicorn.Config(api, host=host, port=port, log_level="warning")
+        )
+        orch_task = asyncio.create_task(system.orchestrator.run())
+        _console.print(
+            f"[green]live dashboard[/green] (mode={config.mode}) on "
+            f"http://{host}:{port}  —  Ctrl-C to stop"
+        )
+        try:
+            await server.serve()  # blocks until SIGINT (uvicorn owns the signal)
+        finally:
+            system.orchestrator.stop_event.set()
+            if not orch_task.done():
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(orch_task, timeout=5.0)
+            if not orch_task.done():
+                orch_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await orch_task
+
+    try:
+        asyncio.run(_serve())
+    except Exception as exc:  # noqa: BLE001 - surface any build/config failure
+        _console.print(f"[red]refusing to run:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
 
 
 def _resolve_mode(

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -769,3 +769,54 @@ def test_fill_streamer_built_for_live_kraken(monkeypatch: pytest.MonkeyPatch) ->
     engine = build_engine(config)
     streamer = _maybe_build_fill_streamer(config, engine)
     assert isinstance(streamer, LiveFillStreamer)
+
+
+# --- prepare_system + live-dashboard monitoring (run --serve) -------------- #
+
+
+async def test_prepare_system_builds_engine_and_loaded_orchestrator() -> None:
+    """`prepare_system` returns a ready engine + an orchestrator loaded with runners."""
+    from trading_bot.application.run_app import PreparedSystem, prepare_system
+
+    pytest.importorskip("fynance")  # the MA-crossover strategies evaluate fynance
+    config = _two_strategy_config()
+    system = await prepare_system(config, dccd_client=_fake_client_for(config))
+
+    assert isinstance(system, PreparedSystem)
+    assert len(system.runners) == 2
+    assert len(system.orchestrator.runners) == 2  # the two strategy runners
+
+
+def test_dashboard_reflects_a_live_run_engine() -> None:
+    """The read-only dashboard, built on the run's engine, shows its positions.
+
+    This is exactly what ``run --serve`` does: `prepare_system`, run the
+    orchestrator, and serve the dashboard over the **same** engine. After a finite
+    offline run the dashboard's ``/api/positions`` reflects the engine's live
+    tracker — proving the dashboard monitors the running engine, not a fresh one.
+    """
+    import asyncio
+
+    from fastapi.testclient import TestClient
+
+    from trading_bot.application.run_app import prepare_system
+    from trading_bot.interfaces.api import create_app
+
+    pytest.importorskip("fynance")
+    config = _two_strategy_config()
+    client = _fake_client_for(config)
+
+    async def _build_and_run():  # noqa: ANN202
+        system = await prepare_system(config, dccd_client=client)
+        await system.orchestrator.run()
+        return system
+
+    system = asyncio.run(_build_and_run())
+
+    http = TestClient(create_app(system.engine))
+    resp = http.get("/api/positions")
+    assert resp.status_code == 200
+
+    instruments = {p["instrument"] for p in resp.json()}
+    # The run traded both instruments; the dashboard on the SAME engine sees them.
+    assert {"BTC/USD", "ETH/USD"} & instruments


### PR DESCRIPTION
## Summary
- `trading-bot run --serve` runs the declared system **and** serves the read-only dashboard over the **same** engine in one process — positions/orders/PnL update in real time (engine bus + SSE) while strategies run.
- `application.prepare_system` / `PreparedSystem` factor the build (engine + orchestrator loaded with runners), shared by `run_app` and the serve path.

## Why
- The existing `serve` builds a *fresh* engine reading the persisted store — it can't show a *running* `run`'s live in-memory state, which "monitor strategies in prod" needs. Sharing one engine (and its bus, for live SSE) is the smallest change that makes the dashboard reflect the running system.

## Behaviour
- uvicorn owns `SIGINT`: Ctrl-C ends serve, then the `finally` drains the orchestrator. A finite paper run keeps the dashboard up on its final state until Ctrl-C; a live run streams until stopped. Read-only — never places an order.

## UI note
- Kept the existing clean dark dashboard. A deeper dccd-style visual restyle (custom fonts/logo/multi-tab) is left as reviewable polish — best iterated with the live render.

## Test plan
- [x] `pytest` — 732 passed, 9 deselected
- [x] `ruff` + `mypy` clean
- [ ] CI green