### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [0.5.0] - 2026-06-29
+
+### Added
+
 - **Live monitoring — `trading-bot run --serve`.** Runs the declared system **and**
   serves the read-only dashboard over the **same** engine in one process, so positions
   / orders / PnL update in real time (engine bus + SSE) while the strategies run — not a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trading_bot"
-version = "0.4.0"
+version = "0.5.0"
 description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v0.5.0

Freezes `[Unreleased]` into `## [0.5.0] - 2026-06-29`, bumps `pyproject.toml` to `0.5.0`.

### Highlights — live execution + monitoring
- **Added**: `trading-bot run --serve` (live monitoring dashboard over the running engine); live fill streaming (`LiveFillStreamer` + `KrakenPrivateWS` reconcile-on-reconnect), validated read-only against real Kraken.
- **Fixed**: `GetWebSocketsToken` missing from the Kraken call-counter cost table (the private WS was non-functional) — found by the read-only live validation.

730→732 tests green; ruff + mypy clean.

### Roadmap after this
Engine-side roadmap is clear. The only remaining item is the maintainer's **real-key live enablement** (real order path), which is deliberately deferred — read-only live testing only for now.