### PR TITLE
Release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live fill streaming.** `application.LiveFillStreamer` pumps a venue's private
+  fill stream (e.g. `KrakenPrivateWS`) onto the engine bus — each confirmed
+  execution becomes a `FillEvent`, so the tracker / performance service / store
+  update from the venue in real time (fill-id dedup guards the snapshot replayed on
+  resubscribe). `KrakenPrivateWS` gains an `on_connected` hook awaited after each
+  (re)connect's subscribe, and `run_app` wires it: a **real-money live Kraken** run
+  builds the streamer with an `on_connected` that **reconciles on every reconnect**
+  and hosts it in the orchestrator (paper/testnet add nothing). Validated read-only
+  against real Kraken (executions snapshot streamed + parsed; no order sent). (#87)
+
 ### Changed
 
 ### Fixed
+
+- **Kraken `GetWebSocketsToken` was missing from the call-counter cost table**, so
+  `cost_of` raised "Unknown method" and the private executions WebSocket could never
+  fetch a token (it was wholly non-functional). Added (cost 1); the live WS read path
+  now works. Found by the read-only live validation. (#87)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [0.5.0] - 2026-06-29
+
+### Added
+
 - **Live monitoring — `trading-bot run --serve`.** Runs the declared system **and**
   serves the read-only dashboard over the **same** engine in one process, so positions
   / orders / PnL update in real time (engine bus + SSE) while the strategies run — not a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Live monitoring — `trading-bot run --serve`.** Runs the declared system **and**
+  serves the read-only dashboard over the **same** engine in one process, so positions
+  / orders / PnL update in real time (engine bus + SSE) while the strategies run — not a
+  separate, freshly-built engine. uvicorn owns `SIGINT` (Ctrl-C ends serve, then the
+  orchestrator drains); a finite paper run keeps the dashboard up on its final state
+  until Ctrl-C. The dashboard stays **read-only** (never places an order).
+  `application.prepare_system` / `PreparedSystem` factor the build (engine + an
+  orchestrator loaded with runners) shared by `run_app` and the serve path. (#89)
 - **Live fill streaming.** `application.LiveFillStreamer` pumps a venue's private
   fill stream (e.g. `KrakenPrivateWS`) onto the engine bus — each confirmed
   execution becomes a `FillEvent`, so the tracker / performance service / store

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ engine — harmonised with dccd. The full engine is in place and hardened: domai
 transport, **Kraken** + **Binance** brokers behind a multi-exchange port, a
 paper-trading broker, the idempotent order router, single-instrument **and**
 native **multi-asset / portfolio** strategy runners, performance/risk services,
-SQLite persistence, a Typer CLI and a read-only FastAPI/Jinja2 dashboard. One
+SQLite persistence, a Typer CLI and a read-only FastAPI/Jinja2 dashboard (`trading-bot serve`, or
+`trading-bot run --serve` to monitor a live run in real time). One
 `AppConfig` conducts the triptych (dccd data + fynance signals + brokers). The
 money-safety invariants are proven under fault injection (`tests/hardening/`) and
 the safety machinery is wired into the run loop (reconcile-on-startup, the

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,32 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Live monitoring via `run --serve` over the same engine (PR #89)  [accepted]
+
+**Choice.** A `--serve` flag on `trading-bot run` serves the read-only dashboard
+(`create_app(engine)`) under uvicorn **concurrently** with the orchestrator, over the
+**same** `Engine`. The build is factored into `prepare_system(config) -> PreparedSystem`
+(engine + an orchestrator loaded with runners), shared by `run_app` (run + report) and
+the serve path. uvicorn owns `SIGINT`: `await server.serve()` blocks until Ctrl-C, then a
+`finally` stops the orchestrator (set its stop event, then await/cancel). The dashboard
+keeps the existing read-only API + SSE — it never places an order.
+
+**Why.** The dashboard's pre-existing `serve` builds a *fresh* engine and reads the
+persisted store — it cannot show a *running* `run`'s live in-memory state, which is what
+"monitor the strategies in prod" needs. Sharing the one engine (and its bus, so SSE is
+live) is the smallest change that makes the dashboard reflect the running system in real
+time. Factoring `prepare_system` avoids duplicating the restore/reconcile/build sequence.
+
+**Rejected alternatives.** Two processes coordinating via the SQLite store (lossy,
+lagged, no live SSE — only persisted snapshots); a separate long-lived daemon exposing
+the engine over IPC (far heavier than a flag); cloning dccd's full multi-page UI
+(custom fonts/logo/auth) for a single read-only dashboard — disproportionate; the
+existing clean dark dashboard is kept, a visual restyle left as reviewable polish.
+uvicorn-owns-SIGINT over installing the orchestrator's own handlers (avoids two handlers
+racing for Ctrl-C).
+
+---
+
 ### 2026-06-29 Live fill streaming via a `LiveFillStreamer` hosted by the orchestrator (PR #87)  [accepted]
 
 **Choice.** A new `application.LiveFillStreamer` consumes a structural `FillSource`

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,38 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-29 Live fill streaming via a `LiveFillStreamer` hosted by the orchestrator (PR #87)  [accepted]
+
+**Choice.** A new `application.LiveFillStreamer` consumes a structural `FillSource`
+(`fills()` async-iterator + `stop()`; `KrakenPrivateWS` satisfies it) and emits a
+`FillEvent` per fill onto the engine bus. It exposes the runner's
+`run(stop_event=...) -> int` contract, so the `Orchestrator` hosts it as just another
+concurrent task; consumption is raced against the stop event and **cancelled** on stop
+(a quiet stream never delays shutdown). `KrakenPrivateWS` gains an injected
+`on_connected` async hook (awaited after each (re)connect's subscribe); `run_app` builds
+the streamer **only** for a real-money live Kraken broker, with `on_connected` =
+reconcile, so the engine re-syncs to the venue after every reconnect.
+
+**Why.** The audit's "after-disconnect reconcile + live fills not streamed" follow-up.
+The private WS already re-runs `on_connect` on every reconnect, so an injected hook is
+the clean reconcile trigger (the WS layer stays ignorant of reconcile — pure DI). The
+streamer matches the runner contract so the existing orchestrator hosts it with no new
+lifecycle machinery, sharing the one cooperative stop event. Validated **read-only**
+against real Kraken (executions snapshot streamed + parsed; **no order sent**).
+
+**Found + fixed in passing.** The read-only live validation exposed that
+`GetWebSocketsToken` was absent from the Kraken call-counter cost table — `cost_of`
+raised "Unknown method", so the private WS could *never* fetch a token. Added (cost 1).
+
+**Rejected alternatives.** Hooking reconcile inside the transport WS layer (a layering
+violation — the WS would import application reconcile); a bespoke lifecycle for the
+streamer outside the orchestrator (the runner contract already fits); streaming for
+testnet/Binance too (Binance has no private-fill WS adapter; testnet is paper money).
+The live **order** path (AddOrder/cancel against a real venue) stays unvalidated by
+deliberate choice — read-only live testing only, per the go-live runbook.
+
+---
+
 ### 2026-06-29 Project name finalized — keep `trading_bot` (no rename) (PR #84)  [accepted]
 
 **Choice.** The triptych keeps its names: **`trading_bot`** (execution/orchestration),

--- a/doc/dev/07-roadmap.md
+++ b/doc/dev/07-roadmap.md
@@ -22,13 +22,13 @@ the gitignored `strategies/`, real dccd-data verified). History in `CHANGELOG.md
 
 ## Known issues / follow-ups
 
-- [ ] **Live fill streaming + post-disconnect reconcile.** Reconcile is now wired
-  **on startup** (`run_app` converges the engine to the venue before the first order),
-  but the **after-disconnect** half of *reconcile, don't assume* is not: the private
-  fill WS (`KrakenPrivateWS`) is not wired into the run loop, so there is no reconnect
-  to trigger a reconcile pass on, and live fills are not streamed onto the bus. Wire
-  the private fill WS into the engine and trigger `reconcile` on each reconnect (and
-  land fill-id dedup — see below — before that stream feeds the tracker).
+_None open — the engine-side roadmap is clear. Remaining work is the maintainer's
+real-key go-live step below._
+
+> **Live fill streaming — done.** The private `KrakenPrivateWS` is wired into the run
+> loop via `LiveFillStreamer` (real-money live Kraken only), reconcile fires on every
+> WS (re)connect, and fills are de-duplicated by id. Validated **read-only** against
+> real Kraken (no order sent). See `03-decisions.md`.
 
 ## Open / deferred (maintainer decisions)
 

--- a/doc/dev/09-go-live.md
+++ b/doc/dev/09-go-live.md
@@ -103,10 +103,11 @@ Before the first live order, confirm every item:
 - [ ] **Kill-switch tested** — confirm the `RiskManager` kill-switch cancels open
       orders and halts new ones (covered offline by the hardening suite). It is
       now auto-triggered on a `max_daily_loss` breach.
-- [ ] **Reconcile-on-startup** — on start the engine refetches open orders +
-      balances + fills and reconciles local state (now wired into `run_app`,
-      before the first order); confirm it converges (proven offline). Reconcile
-      *after a disconnect* is deferred to live fill streaming (roadmap).
+- [ ] **Reconcile on startup *and* reconnect** — on start the engine refetches open
+      orders + balances + fills and reconciles before the first order; and on a live
+      Kraken run the private fill WS (`KrakenPrivateWS` → `LiveFillStreamer`) re-runs
+      `reconcile` on **every (re)connect**, so a disconnect re-syncs automatically.
+      Both wired into `run_app`; convergence proven offline.
 - [ ] **Strategy paper-validated** — the exact strategy you intend to run has
       been validated in `mode: paper` over representative data and behaves as
       expected.
@@ -121,7 +122,8 @@ Before the first live order, confirm every item:
 
 | Concern | Proven offline (`tests/hardening/`) | Pending — needs a real-key sandbox |
 |---|---|---|
-| Reconciliation | Reconcile converges local state to broker-reported open orders / balances / fills after a disconnect | Real private-endpoint reads (OpenOrders / balances / fills) against a live key |
+| Reconciliation | Reconcile converges local state to broker-reported open orders / balances / fills after a disconnect | — |
+| **Private reads (read-only live ✓)** | — | **Validated read-only against real Kraken**: `OpenOrders` + `TradesHistory` (`fills`) returned + parsed; the private executions **WS** streamed a real snapshot. `balances` needs the key's *Query Funds* permission. **No order was sent.** |
 | Idempotency | **Engine-side** idempotency: a retried submit with the same client-order-id never double-submits locally | **Venue-level** idempotency token: Kraken honouring the client-order-id so a retry never creates a duplicate *at the venue* |
 | Ambiguous failures | Ambiguous submit failures (timeout / unknown outcome) are surfaced, not silently assumed filled or failed | Real network-edge behaviour against the live API |
 | Kill-switch | Kill-switch cancels open orders + halts new ones | Real cancel against the venue |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trading_bot"
-version = "0.4.0"
+version = "0.5.0"
 description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first."
 readme = "README.md"
 license = { text = "MIT" }

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -140,6 +140,7 @@ from trading_bot.application.events import (
     LogEvent,
     OrderEvent,
 )
+from trading_bot.application.live_fills import FillSource, LiveFillStreamer
 from trading_bot.application.orchestrator import Orchestrator, RunnerGroupError
 from trading_bot.application.order_router import OrderRouter
 from trading_bot.application.performance_service import PerformanceService
@@ -196,6 +197,8 @@ __all__ = [
     "PositionTracker",
     "PerformanceService",
     "RiskManager",
+    "LiveFillStreamer",
+    "FillSource",
     "reconcile",
     "ReconResult",
     # data feed

--- a/trading_bot/application/live_fills.py
+++ b/trading_bot/application/live_fills.py
@@ -1,0 +1,127 @@
+"""The :class:`LiveFillStreamer` — pump a venue's live fills onto the engine bus.
+
+During a **live** run a venue's private WebSocket (e.g.
+:class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS`) streams the venue's own
+executions as domain :class:`~trading_bot.domain.fill.Fill`s. This component
+consumes that stream and emits one
+:class:`~trading_bot.application.events.FillEvent` per fill onto the shared
+:class:`~trading_bot.application.events.EventBus`, so the
+:class:`~trading_bot.application.position_tracker.PositionTracker`, the
+:class:`~trading_bot.application.performance_service.PerformanceService` and (when
+present) the store update from the venue's **confirmed** fills in real time —
+rather than only from the simulator. Fill-id dedup in those views guards against a
+re-emitted snapshot after a reconnect, so the snapshot Kraken replays on every
+resubscribe never double-counts.
+
+It exposes the same cooperative ``run(stop_event=...) -> int`` contract as a
+:class:`~trading_bot.application.strategy_runner.StrategyRunner`, so the
+:class:`~trading_bot.application.orchestrator.Orchestrator` hosts it as **just
+another concurrent task** sharing the one stop event. Consumption is raced against
+the stop event and **cancelled promptly** when it fires (a blocked read on a quiet
+stream does not delay shutdown).
+
+This module lives in the application layer: it bridges a transport-level fill
+source to the event bus, holds no money logic, and performs no I/O of its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from typing import TYPE_CHECKING, Protocol
+
+from trading_bot.application.events import EventBus, FillEvent
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from trading_bot.domain.fill import Fill
+
+__all__ = ["FillSource", "LiveFillStreamer"]
+
+logger = logging.getLogger(__name__)
+
+
+class FillSource(Protocol):
+    """A live source of domain :class:`~trading_bot.domain.fill.Fill`s.
+
+    The structural contract :class:`LiveFillStreamer` consumes —
+    :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS` satisfies it (its
+    ``fills()`` async-iterates executed trades, reconnecting internally; ``stop()``
+    is inherited from :class:`~trading_bot.transport.ws.WebSocketBase`). A test
+    injects a fake.
+    """
+
+    def fills(self) -> AsyncIterator[Fill]:
+        """Yield confirmed fills as they arrive (the source reconnects internally)."""
+        ...
+
+    def stop(self) -> None:
+        """Request the underlying stream to end (cooperative shutdown)."""
+        ...
+
+
+class LiveFillStreamer:
+    """Emit a :class:`FillEvent` on the bus for every fill from a live source.
+
+    Parameters
+    ----------
+    source : FillSource
+        The live fill stream (e.g. a
+        :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS`).
+    event_bus : EventBus
+        The shared bus to emit each fill onto (the tracker / performance service /
+        store are subscribed to it).
+
+    """
+
+    def __init__(self, source: FillSource, event_bus: EventBus) -> None:
+        self._source = source
+        self._bus = event_bus
+        self._emitted = 0
+
+    async def run(self, *, stop_event: asyncio.Event | None = None) -> int:
+        """Stream fills onto the bus until the stream ends or ``stop_event`` fires.
+
+        Mirrors the :class:`~trading_bot.application.strategy_runner.StrategyRunner`
+        contract so the :class:`~trading_bot.application.orchestrator.Orchestrator`
+        can host it. Consumption is raced against ``stop_event``; when the event is
+        set the source is stopped and the (possibly blocked) consumption is
+        **cancelled**, so a quiet stream never delays shutdown.
+
+        Parameters
+        ----------
+        stop_event : asyncio.Event, optional
+            The shared cooperative-stop flag. ``None`` runs until the source's
+            stream naturally ends (a finite/test source).
+
+        Returns
+        -------
+        int
+            The number of fills emitted onto the bus.
+
+        """
+        consume = asyncio.create_task(self._consume())
+        if stop_event is None:
+            await consume
+            return self._emitted
+
+        stop_wait = asyncio.create_task(stop_event.wait())
+        await asyncio.wait({consume, stop_wait}, return_when=asyncio.FIRST_COMPLETED)
+
+        if not consume.done():
+            # Stop fired first: end the stream and cancel the (blocked) consumer.
+            self._source.stop()
+            consume.cancel()
+        for task in (consume, stop_wait):
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+        return self._emitted
+
+    async def _consume(self) -> None:
+        """Emit a :class:`FillEvent` for each fill the source yields."""
+        async for fill in self._source.fills():
+            self._bus.emit(FillEvent(fill))
+            self._emitted += 1

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -114,8 +114,10 @@ __all__ = [
     "StrategyReport",
     "PortfolioReport",
     "PortfolioCoinReport",
+    "PreparedSystem",
     "build_runners",
     "build_portfolio_runners",
+    "prepare_system",
     "run_app",
 ]
 
@@ -697,6 +699,143 @@ def _portfolio_start_ns(start: str | int | None) -> int | None:
     return _resolve_start_ns(start)
 
 
+@dataclass(frozen=True, slots=True)
+class PreparedSystem:
+    """A built — but **not yet run** — declared system.
+
+    The output of :func:`prepare_system`: the wired
+    :class:`~trading_bot.application.service_factory.Engine`, an
+    :class:`~trading_bot.application.orchestrator.Orchestrator` already loaded with
+    every runner (and, for a live Kraken run, the fill streamer), and the runner
+    lists used to build the final report. :func:`run_app` runs the orchestrator and
+    reports; the ``run --serve`` path instead serves a dashboard over the **same**
+    ``engine`` while the orchestrator runs, so the dashboard observes the live run.
+
+    Attributes
+    ----------
+    engine : Engine
+        The wired engine (broker / router / tracker / perf / risk / bus / store).
+    orchestrator : Orchestrator
+        Loaded with the strategy + portfolio runners (and the live fill streamer).
+    runners : list of StrategyRunner
+        The single-instrument runners, in config order.
+    portfolio_runners : list of PortfolioRunner
+        The portfolio runners, in config order.
+
+    """
+
+    engine: Engine
+    orchestrator: Orchestrator
+    runners: list[StrategyRunner]
+    portfolio_runners: list[PortfolioRunner]
+
+
+async def prepare_system(
+    config: AppConfig,
+    *,
+    dccd_client: DccdClient | None = None,
+    max_steps: int | None = None,
+    reconcile_on_start: bool = True,
+) -> PreparedSystem:
+    """Build the declared system up to (but not running) the orchestrator.
+
+    Assembles the engine, **restores** the router's dedup map from the store (if
+    any), **reconciles** to the broker before the first order, rejects commingled
+    instruments, builds the runners, and loads them — plus the live fill streamer
+    for a real-money live Kraken run — into a fresh
+    :class:`~trading_bot.application.orchestrator.Orchestrator`. Shared by
+    :func:`run_app` (run + report) and the ``run --serve`` path (serve the
+    dashboard over the same engine while the orchestrator runs). See
+    :func:`run_app` for the parameter meanings.
+    """
+    engine = build_engine(config, db_path=config.storage.db_path)
+    # Recover idempotency state across a restart: seed the router's dedup map from
+    # the persisted store (the append-only order history) so a re-submit of any
+    # previously-recorded order id is de-duplicated — closing the crash-restart
+    # double-submit window for ids the in-memory map lost. Done *before* reconcile,
+    # which then converges to the venue's current truth.
+    if engine.store is not None:
+        engine.router.restore(engine.store.orders())
+    # Reconcile, don't assume: converge the fresh engine's empty maps to the
+    # broker's truth (open orders + fills) before the first order is placed.
+    if reconcile_on_start:
+        await reconcile(
+            engine.broker, engine.router, engine.tracker, event_bus=engine.bus
+        )
+    # Reject any instrument claimed by two runners up front — across both the
+    # single-instrument strategies and the portfolios (the shared per-instrument
+    # tracker has no attribution).
+    _reject_commingled(config)
+    runners = build_runners(
+        config, engine, dccd_client=dccd_client, max_steps=max_steps
+    )
+    portfolio_runners = build_portfolio_runners(
+        config, engine, dccd_client=dccd_client, max_steps=max_steps
+    )
+
+    orchestrator = Orchestrator(event_bus=engine.bus)
+    orchestrator.add_all(runners)
+    orchestrator.add_all(portfolio_runners)  # type: ignore[arg-type]
+    # A real-money live Kraken run also streams the venue's confirmed fills onto the
+    # bus (and reconciles on every WS (re)connect); paper/testnet add nothing here.
+    fill_streamer = _maybe_build_fill_streamer(config, engine)
+    if fill_streamer is not None:
+        orchestrator.add(fill_streamer)  # type: ignore[arg-type]
+    return PreparedSystem(
+        engine=engine,
+        orchestrator=orchestrator,
+        runners=runners,
+        portfolio_runners=portfolio_runners,
+    )
+
+
+def _build_report(
+    system: PreparedSystem, results: dict[StrategyRunner, int]
+) -> RunReport:
+    """Build the :class:`RunReport` from a finished system's per-runner counts."""
+    engine = system.engine
+    strategies: list[StrategyReport] = []
+    for runner in system.runners:
+        strat = runner.strategy
+        strategies.append(
+            StrategyReport(
+                name=strat.name,
+                instrument=strat.instrument,
+                orders_submitted=results.get(runner, 0),
+                position=engine.tracker.position(strat.instrument),
+            )
+        )
+
+    # The orchestrator keys its results by the runner objects it ran (both the
+    # StrategyRunners and the PortfolioRunners); its return type is annotated for the
+    # single-instrument runner, so view it as a plain object map for the portfolios.
+    results_by_runner = cast("dict[object, int]", results)
+    portfolios: list[PortfolioReport] = []
+    for prunner in system.portfolio_runners:
+        pstrat = prunner.strategy
+        coins = [
+            PortfolioCoinReport(
+                instrument=Instrument(symbol),
+                position=engine.tracker.position(Instrument(symbol)),
+            )
+            for symbol in pstrat.universe
+        ]
+        portfolios.append(
+            PortfolioReport(
+                name=pstrat.name,
+                orders_submitted=results_by_runner.get(prunner, 0),
+                coins=coins,
+            )
+        )
+
+    return RunReport(
+        strategies=strategies,
+        portfolios=portfolios,
+        realised_pnl=engine.perf.realised_pnl(),
+        fees_paid=engine.perf.fees_paid(),
+    )
+
+
 async def run_app(
     config: AppConfig,
     *,
@@ -741,9 +880,11 @@ async def run_app(
     restart even before reconcile runs — closing the crash-restart double-submit
     window for ids the in-memory map lost.
 
-    Reconciling **after a disconnect** (the WS-reconnect half of the invariant)
-    attaches to the private fill stream, which is not yet wired into this run
-    loop; that lands with live fill streaming (tracked in the roadmap).
+    Reconciling **after a disconnect** is also wired for a real-money live Kraken
+    run: the private fill stream (:class:`~trading_bot.application.live_fills.
+    LiveFillStreamer` over :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS`)
+    re-runs :func:`~trading_bot.application.reconcile.reconcile` on every WS
+    (re)connect and streams the venue's confirmed fills onto the bus.
 
     Parameters
     ----------
@@ -783,83 +924,11 @@ async def run_app(
         refuses — never falling back to paper).
 
     """
-    engine = build_engine(config, db_path=config.storage.db_path)
-    # Recover idempotency state across a restart: seed the router's dedup map from
-    # the persisted store (the append-only order history) so a re-submit of any
-    # previously-recorded order id is de-duplicated — closing the crash-restart
-    # double-submit window for ids the in-memory map lost (the residual gap for a
-    # venue, like Kraken, with no venue-side idempotency token). No events emitted;
-    # done *before* reconcile, which then converges to the venue's current truth.
-    if engine.store is not None:
-        engine.router.restore(engine.store.orders())
-    # Reconcile, don't assume: converge the fresh engine's empty maps to the
-    # broker's truth (open orders + fills) before the first order is placed, so a
-    # restart never re-submits a venue-held order or trades a stale position. A
-    # no-op on a fresh PaperBroker; the safety backstop on a live/testnet venue.
-    if reconcile_on_start:
-        await reconcile(
-            engine.broker, engine.router, engine.tracker, event_bus=engine.bus
-        )
-    # Reject any instrument claimed by two runners up front — across both the
-    # single-instrument strategies and the portfolios (the shared per-instrument
-    # tracker has no attribution). build_runners also calls this for the
-    # strategy-only path; calling it here covers the cross-portfolio overlaps too.
-    _reject_commingled(config)
-    runners = build_runners(
-        config, engine, dccd_client=dccd_client, max_steps=max_steps
+    system = await prepare_system(
+        config,
+        dccd_client=dccd_client,
+        max_steps=max_steps,
+        reconcile_on_start=reconcile_on_start,
     )
-    portfolio_runners = build_portfolio_runners(
-        config, engine, dccd_client=dccd_client, max_steps=max_steps
-    )
-
-    orchestrator = Orchestrator(event_bus=engine.bus)
-    orchestrator.add_all(runners)
-    orchestrator.add_all(portfolio_runners)  # type: ignore[arg-type]
-    # A real-money live Kraken run also streams the venue's confirmed fills onto the
-    # bus (and reconciles on every WS (re)connect); paper/testnet add nothing here.
-    fill_streamer = _maybe_build_fill_streamer(config, engine)
-    if fill_streamer is not None:
-        orchestrator.add(fill_streamer)  # type: ignore[arg-type]
-    results = await orchestrator.run()
-
-    strategies: list[StrategyReport] = []
-    for runner in runners:
-        strat = runner.strategy
-        strategies.append(
-            StrategyReport(
-                name=strat.name,
-                instrument=strat.instrument,
-                orders_submitted=results.get(runner, 0),
-                position=engine.tracker.position(strat.instrument),
-            )
-        )
-
-    # The orchestrator keys its results by the runner objects it ran (both the
-    # StrategyRunners and the PortfolioRunners added via add_all); its return type
-    # is annotated for the single-instrument runner, so view it as a plain object
-    # map to look up the portfolio runners.
-    results_by_runner = cast("dict[object, int]", results)
-    portfolios: list[PortfolioReport] = []
-    for prunner in portfolio_runners:
-        pstrat = prunner.strategy
-        coins = [
-            PortfolioCoinReport(
-                instrument=Instrument(symbol),
-                position=engine.tracker.position(Instrument(symbol)),
-            )
-            for symbol in pstrat.universe
-        ]
-        portfolios.append(
-            PortfolioReport(
-                name=pstrat.name,
-                orders_submitted=results_by_runner.get(prunner, 0),
-                coins=coins,
-            )
-        )
-
-    return RunReport(
-        strategies=strategies,
-        portfolios=portfolios,
-        realised_pnl=engine.perf.realised_pnl(),
-        fees_paid=engine.perf.fees_paid(),
-    )
+    results = await system.orchestrator.run()
+    return _build_report(system, results)

--- a/trading_bot/application/run_app.py
+++ b/trading_bot/application/run_app.py
@@ -74,6 +74,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
 from trading_bot.application.data_provider import feed_for
+from trading_bot.application.live_fills import LiveFillStreamer
 from trading_bot.application.orchestrator import Orchestrator
 from trading_bot.application.portfolio import (
     PortfolioStrategy,
@@ -90,6 +91,8 @@ from trading_bot.application.strategy import (
     ma_crossover_signal,
 )
 from trading_bot.application.strategy_runner import StrategyRunner
+from trading_bot.brokers.kraken import KrakenBroker
+from trading_bot.brokers.kraken_ws import KrakenPrivateWS
 from trading_bot.domain.errors import ConfigError
 from trading_bot.domain.instrument import Instrument, Symbol, parse_kraken_pair
 from trading_bot.domain.money import Money, from_float, money
@@ -652,6 +655,36 @@ def _store_key_renderer(
     return lambda sym: sym.to_venue_symbol(exchange)
 
 
+def _maybe_build_fill_streamer(
+    config: AppConfig, engine: Engine
+) -> LiveFillStreamer | None:
+    """Build a live private-fill streamer for a **real-money live Kraken** broker.
+
+    Only an opted-in live :class:`~trading_bot.brokers.kraken.KrakenBroker` has a
+    private ``executions`` WebSocket; paper, testnet (``live_enabled`` is False
+    there) and Binance have none — this returns ``None`` for them, so a paper /
+    testnet run is unchanged. When it applies, a
+    :class:`~trading_bot.brokers.kraken_ws.KrakenPrivateWS` is built from the
+    broker (token from its signed REST) with an ``on_connected`` hook that
+    **reconciles** the engine to the venue after every (re)connect, and wrapped in
+    a :class:`~trading_bot.application.live_fills.LiveFillStreamer` so the venue's
+    confirmed fills fan out onto the engine bus in real time (fill-id dedup guards
+    the snapshot Kraken replays on resubscribe). Construction performs **no I/O**
+    (no token fetch, no connection); the stream opens only when the streamer runs.
+    """
+    if config.mode != "live" or not config.live_enabled:
+        return None
+    broker = engine.broker
+    if not isinstance(broker, KrakenBroker):
+        return None
+
+    async def _reconcile_on_reconnect() -> None:
+        await reconcile(broker, engine.router, engine.tracker, event_bus=engine.bus)
+
+    ws = KrakenPrivateWS.from_broker(broker, on_connected=_reconcile_on_reconnect)
+    return LiveFillStreamer(ws, engine.bus)
+
+
 def _portfolio_start_ns(start: str | int | None) -> int | None:
     """Map a portfolio data source ``start`` to an epoch-ns bound.
 
@@ -782,6 +815,11 @@ async def run_app(
     orchestrator = Orchestrator(event_bus=engine.bus)
     orchestrator.add_all(runners)
     orchestrator.add_all(portfolio_runners)  # type: ignore[arg-type]
+    # A real-money live Kraken run also streams the venue's confirmed fills onto the
+    # bus (and reconciles on every WS (re)connect); paper/testnet add nothing here.
+    fill_streamer = _maybe_build_fill_streamer(config, engine)
+    if fill_streamer is not None:
+        orchestrator.add(fill_streamer)  # type: ignore[arg-type]
     results = await orchestrator.run()
 
     strategies: list[StrategyReport] = []

--- a/trading_bot/brokers/kraken_ws.py
+++ b/trading_bot/brokers/kraken_ws.py
@@ -224,6 +224,7 @@ class KrakenPrivateWS(WebSocketBase):
         *,
         snap_trades: bool = True,
         snap_orders: bool = True,
+        on_connected: Callable[[], Awaitable[None]] | None = None,
         url: str = _WS_AUTH_URL,
         **ws_kwargs: Any,
     ) -> None:
@@ -231,6 +232,7 @@ class KrakenPrivateWS(WebSocketBase):
         self._token_provider = token_provider
         self._snap_trades = snap_trades
         self._snap_orders = snap_orders
+        self._on_connected = on_connected
 
     @classmethod
     def from_broker(
@@ -239,6 +241,7 @@ class KrakenPrivateWS(WebSocketBase):
         *,
         snap_trades: bool = True,
         snap_orders: bool = True,
+        on_connected: Callable[[], Awaitable[None]] | None = None,
         url: str = _WS_AUTH_URL,
         **ws_kwargs: Any,
     ) -> KrakenPrivateWS:
@@ -247,12 +250,14 @@ class KrakenPrivateWS(WebSocketBase):
         Wires the default :data:`TokenProvider` to ``broker``'s signed private
         REST (``GetWebSocketsToken``). Requires the broker to carry credentials;
         the token fetch raises :class:`~trading_bot.domain.errors.BrokerError`
-        without them, before any I/O.
+        without them, before any I/O. ``on_connected`` (if given) is awaited after
+        each (re)connect's subscribe — the seam a live caller uses to reconcile.
         """
         return cls(
             _broker_token_provider(broker),
             snap_trades=snap_trades,
             snap_orders=snap_orders,
+            on_connected=on_connected,
             url=url,
             **ws_kwargs,
         )
@@ -263,7 +268,10 @@ class KrakenPrivateWS(WebSocketBase):
         Obtains a fresh token via the injected ``token_provider`` and sends the
         v2 ``subscribe`` for the ``executions`` channel with the token in
         ``params``. Because the base re-runs this on every reconnect, the token
-        is refreshed and the subscription re-established automatically.
+        is refreshed and the subscription re-established automatically — and, if an
+        ``on_connected`` hook was supplied, it is awaited afterwards (the seam a
+        live caller uses to **reconcile** the engine to the venue after every
+        reconnect; a failure there is logged, never breaking the stream).
         """
         token = await self._token_provider()
         sub: dict[str, Any] = {
@@ -276,6 +284,11 @@ class KrakenPrivateWS(WebSocketBase):
             },
         }
         await ws.send(json.dumps(sub))
+        if self._on_connected is not None:
+            try:
+                await self._on_connected()
+            except Exception:
+                logger.exception("on_connected hook failed after WS (re)connect")
 
     async def events(self) -> AsyncIterator[Fill | OrderUpdate]:
         """Yield domain :class:`Fill`s and :class:`OrderUpdate`s from the feed.

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -45,6 +45,7 @@ out of the box.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import math
 import pathlib
@@ -263,6 +264,19 @@ def run(
         "--yes-i-understand",
         help="Explicit acknowledgement required to go --live.",
     ),
+    serve: bool = typer.Option(
+        False,
+        "--serve",
+        help="Also serve the read-only live dashboard over HTTP while the run "
+        "executes, so you can monitor positions / orders / PnL in real time "
+        "(Ctrl-C stops both). Read-only — the dashboard never places an order.",
+    ),
+    serve_host: str = typer.Option(
+        "127.0.0.1", "--serve-host", help="Dashboard bind interface (loopback)."
+    ),
+    serve_port: int = typer.Option(
+        8000, "--serve-port", help="Dashboard TCP port."
+    ),
 ) -> None:
     """Run the declared system (or a quick demo) and print a short summary.
 
@@ -297,6 +311,12 @@ def run(
 
     mode = _resolve_mode(config, live=live, yes_i_understand=yes_i_understand)
     config = config.model_copy(update={"mode": mode})
+
+    # --serve: run the declared system AND serve the read-only dashboard over the
+    # SAME engine, so the run can be monitored live. Handles 0+ strategies.
+    if serve:
+        _run_and_serve(config, host=serve_host, port=serve_port)
+        return
 
     # A config that declares strategies (with their own data + signal) runs the
     # whole declared system via the triptych entrypoint. A bare config (no
@@ -389,6 +409,55 @@ def _run_declared_system(config: AppConfig) -> None:
         if s.position is not None
     }
     _console.print(_render.positions_table(positions))
+
+
+def _run_and_serve(config: AppConfig, *, host: str, port: int) -> None:
+    """Run the declared system **and** serve the live dashboard over one engine.
+
+    Builds the system once (:func:`~trading_bot.application.run_app.prepare_system`),
+    serves the read-only FastAPI dashboard
+    (:func:`~trading_bot.interfaces.api.create_app`) over the **same** engine under
+    uvicorn, and runs the orchestrator concurrently — so the dashboard reflects the
+    live run in real time (positions / orders / PnL via the engine bus + SSE).
+    uvicorn owns ``SIGINT``: Ctrl-C ends ``serve``, and the ``finally`` then drains
+    the orchestrator. The dashboard is **read-only** — it can never place an order.
+    A finite (paper) run completes while the dashboard keeps serving the final state
+    until Ctrl-C; a live run streams until stopped. Build/config failures surface as
+    a clean non-zero exit with no order placed.
+    """
+    import uvicorn
+
+    from trading_bot.application.run_app import prepare_system
+    from trading_bot.interfaces.api import create_app
+
+    async def _serve() -> None:
+        system = await prepare_system(config)
+        api = create_app(system.engine)
+        server = uvicorn.Server(
+            uvicorn.Config(api, host=host, port=port, log_level="warning")
+        )
+        orch_task = asyncio.create_task(system.orchestrator.run())
+        _console.print(
+            f"[green]live dashboard[/green] (mode={config.mode}) on "
+            f"http://{host}:{port}  —  Ctrl-C to stop"
+        )
+        try:
+            await server.serve()  # blocks until SIGINT (uvicorn owns the signal)
+        finally:
+            system.orchestrator.stop_event.set()
+            if not orch_task.done():
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(orch_task, timeout=5.0)
+            if not orch_task.done():
+                orch_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await orch_task
+
+    try:
+        asyncio.run(_serve())
+    except Exception as exc:  # noqa: BLE001 - surface any build/config failure
+        _console.print(f"[red]refusing to run:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
 
 
 def _resolve_mode(

--- a/trading_bot/tests/application/test_live_fills.py
+++ b/trading_bot/tests/application/test_live_fills.py
@@ -1,0 +1,114 @@
+"""Tests for :class:`LiveFillStreamer` — pumping a live fill source onto the bus.
+
+Drives the streamer with a **fake** fill source (no WebSocket, no network): it
+yields a canned sequence of domain fills and can block afterwards to model a quiet
+live stream. The streamer must emit one ``FillEvent`` per fill onto the bus, and a
+set ``stop_event`` must end even a *blocked* stream promptly (cooperative stop via
+cancellation). Async tests run un-decorated (``asyncio_mode = "auto"``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+from trading_bot.application import EventBus, FillEvent
+from trading_bot.application.live_fills import LiveFillStreamer
+from trading_bot.domain import Fill, Instrument, OrderSide, Symbol, money
+
+BTC_USD = Instrument(Symbol("BTC", "USD"))
+
+
+def _fill(fill_id: str) -> Fill:
+    return Fill(
+        fill_id=fill_id,
+        client_order_id="cid",
+        instrument=BTC_USD,
+        side=OrderSide.BUY,
+        qty=money("1"),
+        price=money("30000"),
+        fee=money("1"),
+        ts=1,
+    )
+
+
+class _FakeSource:
+    """A fake fill source: yields ``fills`` then optionally blocks until stopped."""
+
+    def __init__(self, fills: list[Fill], *, block_after: bool = False) -> None:
+        self._fills = fills
+        self._block_after = block_after
+        self._stopped = asyncio.Event()
+
+    async def fills(self) -> AsyncIterator[Fill]:
+        for fill in self._fills:
+            yield fill
+        if self._block_after:
+            await self._stopped.wait()  # model a quiet live stream
+
+    def stop(self) -> None:
+        self._stopped.set()
+
+
+def _fill_events(seen: list[object]) -> list[FillEvent]:
+    return [e for e in seen if isinstance(e, FillEvent)]
+
+
+async def test_emits_one_fillevent_per_fill() -> None:
+    """A finite source: every fill becomes a ``FillEvent`` on the bus, in order."""
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe(seen.append)
+
+    streamer = LiveFillStreamer(
+        _FakeSource([_fill("F1"), _fill("F2"), _fill("F3")]), bus
+    )
+    emitted = await streamer.run()
+
+    assert emitted == 3
+    assert [e.fill.fill_id for e in _fill_events(seen)] == ["F1", "F2", "F3"]
+
+
+async def test_stop_event_ends_a_blocked_stream_promptly() -> None:
+    """A set ``stop_event`` ends even a *blocked* (quiet) stream — no hang.
+
+    The source yields two fills then blocks forever; the streamer must have emitted
+    both, and setting the stop event must let ``run`` return promptly (the blocked
+    consumer is cancelled).
+    """
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe(seen.append)
+    stop = asyncio.Event()
+
+    streamer = LiveFillStreamer(
+        _FakeSource([_fill("F1"), _fill("F2")], block_after=True), bus
+    )
+    task = asyncio.create_task(streamer.run(stop_event=stop))
+
+    # Let it emit both fills and then block on the quiet stream.
+    for _ in range(200):
+        if len(_fill_events(seen)) >= 2:
+            break
+        await asyncio.sleep(0)
+
+    stop.set()
+    emitted = await asyncio.wait_for(task, timeout=2.0)
+
+    assert emitted == 2
+    assert [e.fill.fill_id for e in _fill_events(seen)] == ["F1", "F2"]
+
+
+async def test_subscribed_tracker_updates_from_streamed_fills() -> None:
+    """End to end: streamed fills fan out to a subscribed tracker (live read-back)."""
+    from trading_bot.application import PositionTracker
+
+    bus = EventBus()
+    tracker = PositionTracker(event_bus=bus)
+    streamer = LiveFillStreamer(_FakeSource([_fill("F1"), _fill("F2")]), bus)
+
+    await streamer.run()
+
+    pos = tracker.position(BTC_USD)
+    assert pos is not None
+    assert pos.net_qty == money("2")  # two BUY 1 @ 30000 folded from the stream

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -710,3 +710,62 @@ def test_limit_at_close_prices_exactly_from_decimal_close_no_float() -> None:
     assert order.limit_price == money("100.123456789012345678")  # exact
     # And strictly better than the old float round-trip, which loses the tail.
     assert order.limit_price != from_float(float(exact))
+
+
+# --- live private-fill streamer wiring (real-money live Kraken only) -------- #
+
+
+def test_no_fill_streamer_for_paper() -> None:
+    """Paper runs add no private-fill streamer (nothing to stream)."""
+    from trading_bot.application.run_app import _maybe_build_fill_streamer
+    from trading_bot.application.service_factory import build_engine
+
+    config = AppConfig()  # paper
+    engine = build_engine(config)
+    assert _maybe_build_fill_streamer(config, engine) is None
+
+
+def test_no_fill_streamer_for_testnet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Testnet (``live_enabled`` False, paper money) adds no streamer."""
+    from trading_bot.application.config import BrokerConfig
+    from trading_bot.application.run_app import _maybe_build_fill_streamer
+    from trading_bot.application.service_factory import build_engine
+
+    monkeypatch.setenv("BINANCE_API_KEY", "k")
+    monkeypatch.setenv("BINANCE_API_SECRET", "s")
+    monkeypatch.delenv("BINANCE_API_BASE", raising=False)
+    config = AppConfig(
+        mode="live",
+        live_enabled=False,
+        brokers=[BrokerConfig(name="bn", exchange="binance", testnet=True)],
+    )
+    engine = build_engine(config)
+    assert _maybe_build_fill_streamer(config, engine) is None
+
+
+def test_fill_streamer_built_for_live_kraken(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A real-money live Kraken run builds a `LiveFillStreamer` (construction only).
+
+    No network: `build_engine` + `KrakenPrivateWS.from_broker` perform no I/O (no
+    token fetch, no WS connect) — only the wiring is asserted.
+    """
+    from trading_bot.application.config import BrokerConfig, RiskConfig
+    from trading_bot.application.live_fills import LiveFillStreamer
+    from trading_bot.application.run_app import _maybe_build_fill_streamer
+    from trading_bot.application.service_factory import build_engine
+
+    monkeypatch.setenv("KRAKEN_API_KEY", "k")
+    monkeypatch.setenv("KRAKEN_API_SECRET", "c2VjcmV0")  # base64("secret")
+    config = AppConfig(
+        mode="live",
+        live_enabled=True,
+        brokers=[BrokerConfig(name="kraken", exchange="kraken")],
+        risk=RiskConfig(
+            max_order=money("1"),
+            max_position=money("5"),
+            max_daily_loss=money("1000"),
+        ),
+    )
+    engine = build_engine(config)
+    streamer = _maybe_build_fill_streamer(config, engine)
+    assert isinstance(streamer, LiveFillStreamer)

--- a/trading_bot/tests/application/test_run_app.py
+++ b/trading_bot/tests/application/test_run_app.py
@@ -769,3 +769,54 @@ def test_fill_streamer_built_for_live_kraken(monkeypatch: pytest.MonkeyPatch) ->
     engine = build_engine(config)
     streamer = _maybe_build_fill_streamer(config, engine)
     assert isinstance(streamer, LiveFillStreamer)
+
+
+# --- prepare_system + live-dashboard monitoring (run --serve) -------------- #
+
+
+async def test_prepare_system_builds_engine_and_loaded_orchestrator() -> None:
+    """`prepare_system` returns a ready engine + an orchestrator loaded with runners."""
+    from trading_bot.application.run_app import PreparedSystem, prepare_system
+
+    pytest.importorskip("fynance")  # the MA-crossover strategies evaluate fynance
+    config = _two_strategy_config()
+    system = await prepare_system(config, dccd_client=_fake_client_for(config))
+
+    assert isinstance(system, PreparedSystem)
+    assert len(system.runners) == 2
+    assert len(system.orchestrator.runners) == 2  # the two strategy runners
+
+
+def test_dashboard_reflects_a_live_run_engine() -> None:
+    """The read-only dashboard, built on the run's engine, shows its positions.
+
+    This is exactly what ``run --serve`` does: `prepare_system`, run the
+    orchestrator, and serve the dashboard over the **same** engine. After a finite
+    offline run the dashboard's ``/api/positions`` reflects the engine's live
+    tracker — proving the dashboard monitors the running engine, not a fresh one.
+    """
+    import asyncio
+
+    from fastapi.testclient import TestClient
+
+    from trading_bot.application.run_app import prepare_system
+    from trading_bot.interfaces.api import create_app
+
+    pytest.importorskip("fynance")
+    config = _two_strategy_config()
+    client = _fake_client_for(config)
+
+    async def _build_and_run():  # noqa: ANN202
+        system = await prepare_system(config, dccd_client=client)
+        await system.orchestrator.run()
+        return system
+
+    system = asyncio.run(_build_and_run())
+
+    http = TestClient(create_app(system.engine))
+    resp = http.get("/api/positions")
+    assert resp.status_code == 200
+
+    instruments = {p["instrument"] for p in resp.json()}
+    # The run traded both instruments; the dashboard on the SAME engine sees them.
+    assert {"BTC/USD", "ETH/USD"} & instruments

--- a/trading_bot/tests/brokers/test_kraken_ws.py
+++ b/trading_bot/tests/brokers/test_kraken_ws.py
@@ -443,3 +443,49 @@ async def test_from_broker_builds_token_provider_from_signed_rest() -> None:
 
     assert calls == ["GetWebSocketsToken"]
     assert json.loads(ws.sent[0])["params"]["token"] == "from-rest-token"
+
+
+# --- on_connected reconcile hook ------------------------------------------- #
+
+
+async def test_on_connected_hook_fires_after_subscribe_on_each_connect() -> None:
+    """The ``on_connected`` hook is awaited on connect AND on every reconnect.
+
+    The first socket yields one trade then ends (forcing a reconnect); the second
+    yields another. The hook (a live caller's reconcile trigger) must fire once per
+    (re)connect — twice here.
+    """
+    calls: list[int] = []
+
+    async def hook() -> None:
+        calls.append(1)
+
+    private = KrakenPrivateWS(
+        FakeTokenProvider(),
+        connect=FakeConnector([FakeWS([_TRADE_UPDATE_FRAME]), FakeWS([_TRADE_UPDATE_FRAME])]),
+        sleep=RecordingSleep(),
+        on_connected=hook,
+    )
+
+    events = await _drain(private, limit=2)
+
+    assert len(events) == 2  # one trade per connect
+    assert len(calls) == 2  # hook fired on connect AND reconnect
+
+
+async def test_on_connected_failure_does_not_break_the_stream() -> None:
+    """A raising ``on_connected`` hook is logged, not propagated — the stream lives."""
+
+    async def bad_hook() -> None:
+        raise RuntimeError("reconcile boom")
+
+    private = KrakenPrivateWS(
+        FakeTokenProvider(),
+        connect=FakeConnector([FakeWS([_TRADE_UPDATE_FRAME])]),
+        sleep=RecordingSleep(),
+        on_connected=bad_hook,
+    )
+
+    events = await _drain(private, limit=1)
+
+    assert len(events) == 1  # the trade still streamed despite the hook raising

--- a/trading_bot/tests/transport/test_ratelimit.py
+++ b/trading_bot/tests/transport/test_ratelimit.py
@@ -189,6 +189,26 @@ def test_costs_match_legacy_table() -> None:
         KrakenCallCounter.cost_of("NotAMethod")
 
 
+def test_every_private_method_the_broker_calls_has_a_cost() -> None:
+    """Each private endpoint `KrakenBroker` / the private WS posts must be costed.
+
+    Regression for the live-validation finding: `GetWebSocketsToken` was missing
+    from the cost table, so `cost_of` raised "Unknown method" and the private
+    executions WebSocket could never fetch a token (it was wholly non-functional).
+    Every signed endpoint the engine actually calls must be in `COSTS`.
+    """
+    for method in (
+        "AddOrder",
+        "CancelOrder",
+        "Balance",
+        "OpenOrders",
+        "TradesHistory",
+        "GetWebSocketsToken",  # the WS token endpoint — was missing
+    ):
+        KrakenCallCounter.cost_of(method)  # must not raise
+    assert KrakenCallCounter.cost_of("GetWebSocketsToken") == 1
+
+
 def test_tiers_match_legacy_constants() -> None:
     # Legacy KrakenCallCounter.__init__: starter (3, 15), intermediate (2, 20),
     # pro (1, 20).

--- a/trading_bot/transport/ratelimit.py
+++ b/trading_bot/transport/ratelimit.py
@@ -265,6 +265,7 @@ class KrakenCallCounter:
         "QueryTrades": 1,
         "OpenPositions": 1,
         "TradeVolume": 1,
+        "GetWebSocketsToken": 1,
         "AddExport": 1,
         "ExportStatus": 1,
         "RetrieveExport": 1,


### PR DESCRIPTION
Release **v0.5.0** — live monitoring (`run --serve`) + live fill streaming (validated read-only vs real Kraken) + the GetWebSocketsToken cost-table fix. After merge: `git fetch origin && git tag v0.5.0 origin/master && git push origin v0.5.0`. See CHANGELOG `[0.5.0]`.