### PR TITLE
fix: read __version__ from installed metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`trading_bot.__version__` now reads from installed metadata** instead of a
+  hand-bumped constant that the release flow never updated — it had been stuck at
+  `"0.2.0"` across 0.3/0.4/0.5, so `trading-bot version` and the dashboard showed a
+  stale version. Now always matches `pyproject.toml` (the single release source). (#92)
+
 ### Deprecated
 
 ### Removed

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -10,6 +10,14 @@ package). See ``doc/dev/07-roadmap.md`` for the rewrite roadmap.
 """
 from __future__ import annotations
 
-__version__ = "0.2.0"
+from importlib import metadata
+
+try:
+    #: The installed package version — read from metadata so it always matches
+    #: ``pyproject.toml`` (the single release source) instead of a hand-bumped
+    #: string that silently goes stale across releases.
+    __version__ = metadata.version("trading_bot")
+except metadata.PackageNotFoundError:  # pragma: no cover - not installed (raw checkout)
+    __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__"]

--- a/trading_bot/tests/test_smoke.py
+++ b/trading_bot/tests/test_smoke.py
@@ -6,9 +6,21 @@ those layers are built (see ``doc/dev/07-roadmap.md``).
 """
 from __future__ import annotations
 
+from importlib import metadata
+
 import trading_bot
 
 
 def test_package_exposes_version() -> None:
     assert isinstance(trading_bot.__version__, str)
     assert trading_bot.__version__
+
+
+def test_version_reads_from_installed_metadata_not_a_stale_constant() -> None:
+    """`__version__` tracks the installed package metadata (i.e. pyproject).
+
+    Regression: it used to be a hand-bumped constant (`"0.2.0"`) that the release
+    flow never updated, so `trading-bot version` / the dashboard went stale across
+    releases. It must now equal the installed metadata version.
+    """
+    assert trading_bot.__version__ == metadata.version("trading_bot")


### PR DESCRIPTION
## Summary
- `trading_bot.__version__` now reads from `importlib.metadata.version("trading_bot")` instead of a hardcoded `"0.2.0"`.

## Why
- The constant was never bumped by the release flow (which bumps `pyproject.toml`), so `trading-bot version` and the dashboard reported `0.2.0` across 0.3/0.4/0.5. Reading from metadata makes it always match pyproject (the single release source) — the dccd pattern.

## Test plan
- [x] `trading-bot version` → `0.5.0`
- [x] `pytest` — 733 passed (+1 regression test); `ruff` + `mypy` clean
- [ ] CI green