### PR TITLE
feat: runner step-over-latest (daemon foundation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `StrategyRunner.step_latest()` / `PortfolioRunner.rebalance_latest()` — a single,
+  idempotent re-evaluation over the feed's **latest** data (vs `run`, which drains the
+  feed once). The primitive a scheduler-driven daemon calls each tick: a tick over
+  unchanged data trades nothing (already on target). Foundation for the control-plane
+  daemon. (#93)
+
 ### Changed
 
 ### Fixed

--- a/trading_bot/application/portfolio_runner.py
+++ b/trading_bot/application/portfolio_runner.py
@@ -430,6 +430,32 @@ class PortfolioRunner:
 
         return RebalanceResult(submitted=submitted, failures=failures)
 
+    async def rebalance_latest(self) -> RebalanceResult | None:
+        """Rebalance the book over the feed's **latest** cross-section — for a daemon.
+
+        Reads the feed's most recent causal cross-section (the last one a fresh
+        iteration yields — a live :class:`~trading_bot.application.portfolio_feed
+        .PortfolioFeed` re-reads the dccd store each iteration) and runs **one**
+        :meth:`rebalance` over it. Where :meth:`run` *drains* the feed once
+        (replay/backtest), this is the single, on-demand rebalance a
+        **scheduler-driven daemon** calls each tick: per-coin deltas are computed
+        against the live tracker, so a tick over unchanged weights/data submits
+        nothing and only changed targets trade. Idempotent under repetition.
+
+        Returns
+        -------
+        RebalanceResult or None
+            The tick's result, or ``None`` if the feed currently yields no closed
+            cross-section (e.g. the universe has no common closed bar yet).
+
+        """
+        latest: Mapping[Symbol, pl.DataFrame] | None = None
+        for frames in self._feed:  # type: ignore[attr-defined]
+            latest = frames
+        if latest is None:
+            return None
+        return await self.rebalance(latest)
+
     def _build_order(
         self,
         symbol: Symbol,

--- a/trading_bot/application/strategy_runner.py
+++ b/trading_bot/application/strategy_runner.py
@@ -319,6 +319,28 @@ class StrategyRunner:
             )
         return submitted
 
+    async def step_latest(self) -> Order | None:
+        """Process **one** step over the feed's **latest** window — for a daemon.
+
+        Reads the feed's full known frame (:meth:`~trading_bot.application.data_feed
+        .DataFeed.latest`, which re-reads the dccd store for a live feed) and runs
+        one :meth:`step` over it. Where :meth:`run` *drains* the feed once
+        (replay/backtest), this is the single, on-demand re-evaluation a
+        **scheduler-driven daemon** calls each tick: the delta is computed against
+        the live tracker position, so a tick over unchanged data submits nothing
+        (already on target) and only a changed target trades. Idempotent under
+        repetition. The step index still advances (so a tick that *does* trade
+        carries a fresh, unique ``client_order_id``).
+
+        Returns
+        -------
+        Order or None
+            The submitted order, or ``None`` if the latest re-evaluation was on
+            target (``delta == 0``) or in warmup.
+
+        """
+        return await self.step(self._feed.latest())
+
     def _build_order(self, delta: Money, bars: pl.DataFrame, step: int) -> Order:
         """Build the step's order, stamping the deterministic per-step id.
 

--- a/trading_bot/tests/application/test_portfolio_runner.py
+++ b/trading_bot/tests/application/test_portfolio_runner.py
@@ -471,3 +471,38 @@ async def test_money_read_off_frame_is_exact_decimal() -> None:
     assert btc_leg.limit_price == Decimal("50000.5")
     expected = money(str(money("0.5") * CAPITAL / money("50000.5")))
     assert btc_leg.qty == abs(expected)
+
+
+# --- rebalance_latest: single rebalance over the latest cross-section ------- #
+
+
+async def test_rebalance_latest_rebalances_over_the_feeds_latest_cross_section() -> None:
+    """`rebalance_latest` takes the feed's latest cross-section and rebalances once."""
+    weights = {BTC: money("0.5"), ETH: money("-0.25")}
+    router, tracker, bus, _broker = _engine()
+    runner = PortfolioRunner(
+        _strategy(_weights_signal(weights)),
+        _ListFeed([_frames()], asof=1_700),
+        router,
+        tracker,
+        event_bus=bus,
+    )
+
+    result = await runner.rebalance_latest()
+
+    assert result is not None
+    assert result.submitted == 2  # one leg per coin, from flat
+
+
+async def test_rebalance_latest_returns_none_on_empty_feed() -> None:
+    """`rebalance_latest` returns None when the feed yields no cross-section yet."""
+    router, tracker, bus, _broker = _engine()
+    runner = PortfolioRunner(
+        _strategy(_weights_signal({BTC: money("0.5")})),
+        _ListFeed([], asof=1_700),
+        router,
+        tracker,
+        event_bus=bus,
+    )
+
+    assert await runner.rebalance_latest() is None

--- a/trading_bot/tests/application/test_strategy_runner.py
+++ b/trading_bot/tests/application/test_strategy_runner.py
@@ -583,3 +583,39 @@ async def test_order_factory_and_log_events() -> None:
     # The orders were LIMITs (from the factory), filled at the close.
     fills = await broker.fills()
     assert fills
+
+
+# --- step_latest: single re-evaluation over the latest data (daemon hook) --- #
+
+
+async def test_step_latest_evaluates_latest_window_and_is_idempotent() -> None:
+    """`step_latest` steps over `feed.latest()`; a repeat on unchanged data no-ops.
+
+    The scheduler-driven daemon hook: one re-evaluation over the freshest data
+    trades to the latest target, and calling it again over the same data submits
+    nothing (already on target) — idempotent under repetition.
+    """
+    pytest.importorskip("fynance")  # ma_crossover_signal evaluates fynance.sma
+    up = [float(100 + i) for i in range(20)]
+    down = [float(120 - i) for i in range(1, 21)]
+    frame = _bars(up + down)
+    strat = Strategy(
+        name="ma",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+    runner, _broker, tracker, _bus = _wire(strat, frame, mark="100")
+
+    first = await runner.step_latest()  # from flat → trades to the latest target
+    assert first is not None
+    pos = tracker.position(BTC_USD)
+    assert pos is not None
+    assert pos.net_qty == Decimal("-2")  # latest signal is short on the down tail
+
+    second = await runner.step_latest()  # already on target → no order
+    assert second is None
+    again = tracker.position(BTC_USD)
+    assert again is not None
+    assert again.net_qty == Decimal("-2")  # unchanged


### PR DESCRIPTION
## Summary
- `StrategyRunner.step_latest()` + `PortfolioRunner.rebalance_latest()` — one **idempotent** re-evaluation over the feed's **latest** data (vs `run`, which drains the feed once).

## Why
- The control-plane daemon (next) needs a scheduler primitive: each tick, re-evaluate over the freshest data and trade only the delta. A tick over unchanged data submits nothing (already on target).

## Changes
- `application/strategy_runner.py`: `step_latest()` (steps over `feed.latest()`).
- `application/portfolio_runner.py`: `rebalance_latest()` (rebalances over the feed's latest cross-section; `None` if no closed cross-section yet).
- Tests: idempotent re-evaluation (2nd tick on-target = no order); empty-feed → None.

## Test plan
- [x] `pytest` — 736 passed; `ruff` + `mypy` clean
- [ ] CI green