### PR TITLE
feat: StrategySupervisor — per-strategy engines, gated mode control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `application.StrategySupervisor` — manages each declared strategy/portfolio as an
+  **independent unit** in its **own** engine (own broker/mode), so a strategy can be
+  started/stopped and switched between **paper / testnet / live independently**
+  (`start` / `stop` / `set_mode` / `step` / `status`). Restart-safe (restore + reconcile
+  per engine on start). **Real money is gated**: `set_mode(..., "live")` raises unless an
+  explicit `confirm_live=True` is passed (the control plane's deliberate acknowledgement);
+  paper ↔ testnet need none. The control-plane core behind the daemon + dashboard. (#94)
 - `StrategyRunner.step_latest()` / `PortfolioRunner.rebalance_latest()` — a single,
   idempotent re-evaluation over the feed's **latest** data (vs `run`, which drains the
   feed once). The primitive a scheduler-driven daemon calls each tick: a tick over

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,35 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-30 Control plane: per-strategy engines + a gated `StrategySupervisor` (PR #94)  [accepted]
+
+**Choice.** The control plane (start/stop a strategy, switch its mode from the UI) is
+built on a `StrategySupervisor` that splits the config into one **unit per strategy/
+portfolio**, each running in its **own** `build_engine` (own broker / mode / tracker /
+PnL). `start` / `stop` / `set_mode` / `step` / `status` per unit; `step` calls
+`step_latest` / `rebalance_latest`. Real money is gated: `set_mode(..., "live")` raises
+`LiveTradingNotEnabled` unless `confirm_live=True` (the UI's typed acknowledgement);
+paper ↔ testnet are free. The factory's existing gates (credentials, mandatory risk
+limits) still fire when the live engine is actually built on `start`.
+
+**Why.** Per-strategy **mode** (one strategy in testnet, another in live) is impossible
+under the single shared engine (`run_app`), which has one broker for the whole system.
+A per-strategy engine is just `build_engine` over a one-strategy config slice — the
+factory already does the wiring — so the supervisor is a thin manager over N engines.
+Per-strategy engines also dissolve the commingling problem (each unit has its own
+tracker), so the single-engine `_reject_commingled` concern doesn't arise. Gating live
+at `set_mode` preserves the "no real order by accident" invariant now that a UI can flip
+modes — matching the chosen posture (paper/testnet free, prod a deliberate confirmation).
+
+**Rejected alternatives.** One engine with multiple brokers and per-strategy routing
+(the `OrderRouter` binds to one broker; per-strategy routing is effectively per-strategy
+engines anyway, with more coupling); letting the UI flip to real money with no
+confirmation (rejected by the maintainer — keep prod deliberate); a heavyweight
+process-per-strategy supervisor (in-process units are lighter and share the daemon's
+loop/scheduler — wired next).
+
+---
+
 ### 2026-06-29 Live monitoring via `run --serve` over the same engine (PR #89)  [accepted]
 
 **Choice.** A `--serve` flag on `trading-bot run` serves the read-only dashboard

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -176,6 +176,10 @@ from trading_bot.application.strategy import (
     ma_crossover_signal,
 )
 from trading_bot.application.strategy_runner import OrderFactory, StrategyRunner
+from trading_bot.application.supervisor import (
+    StrategyStatus,
+    StrategySupervisor,
+)
 
 __all__ = [
     # config
@@ -199,6 +203,8 @@ __all__ = [
     "RiskManager",
     "LiveFillStreamer",
     "FillSource",
+    "StrategySupervisor",
+    "StrategyStatus",
     "reconcile",
     "ReconResult",
     # data feed

--- a/trading_bot/application/supervisor.py
+++ b/trading_bot/application/supervisor.py
@@ -1,0 +1,339 @@
+"""The :class:`StrategySupervisor` — each declared strategy as an independent unit.
+
+Where :func:`~trading_bot.application.run_app.run_app` builds **one** shared engine
+for the whole config, the supervisor splits the config into per-strategy /
+per-portfolio **units**, each running in its **own**
+:func:`~trading_bot.application.service_factory.build_engine` (its own broker,
+mode, tracker, PnL). That is what lets a strategy be **started, stopped and
+switched between paper / testnet / live independently** — the control plane behind
+the daemon and the dashboard. Because each unit owns its engine, there is no
+cross-unit commingling (the single-engine path's
+:func:`~trading_bot.application.run_app._reject_commingled` concern does not arise
+here).
+
+Modes (carried into the ADR)
+----------------------------
+A unit's :data:`StrategyMode` maps to an :class:`~trading_bot.application.config.
+AppConfig` slice:
+
+* ``"paper"`` — ``mode: paper`` (the simulator; no venue, no key).
+* ``"testnet"`` — ``mode: live`` + every broker ``testnet: true`` (paper money on
+  the real sandbox; mainnet-incapable, so no ``live_enabled`` needed).
+* ``"live"`` — ``mode: live`` + ``live_enabled: true`` + brokers ``testnet: false``
+  (**real money**).
+
+**Real money is gated.** :meth:`set_mode` to ``"live"`` raises unless an explicit
+``confirm_live=True`` is passed — the deliberate acknowledgement the control API /
+UI obtains (a typed confirmation), never a casual flip. Paper ↔ testnet need no
+confirmation. The usual factory gates (credentials, the risk-limit requirement)
+still apply when the live engine is actually built on :meth:`start`.
+
+This module is part of the application layer: it composes the factory and the
+runners, holds money as :class:`~decimal.Decimal`, and performs venue I/O only
+through the engines it builds (reconcile on start; the runners' router/broker).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from trading_bot.application.reconcile import reconcile
+from trading_bot.application.run_app import build_portfolio_runners, build_runners
+from trading_bot.application.service_factory import Engine, build_engine
+from trading_bot.domain.errors import ConfigError, LiveTradingNotEnabled
+
+if TYPE_CHECKING:
+    from trading_bot.application.config import AppConfig
+    from trading_bot.application.data_provider import DccdClient
+    from trading_bot.application.portfolio_runner import PortfolioRunner
+    from trading_bot.application.strategy_runner import StrategyRunner
+    from trading_bot.domain.money import Money
+    from trading_bot.domain.order import Order
+
+__all__ = ["StrategyMode", "StrategyStatus", "StrategySupervisor"]
+
+#: The deployment mode of a managed strategy.
+StrategyMode = Literal["paper", "testnet", "live"]
+
+_KIND = Literal["strategy", "portfolio"]
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyStatus:
+    """A read-only snapshot of one managed strategy's state (for the API / UI).
+
+    Attributes
+    ----------
+    name : str
+        The strategy/portfolio's logical id.
+    kind : {"strategy", "portfolio"}
+        Whether it is a single-instrument strategy or a multi-asset portfolio.
+    mode : StrategyMode
+        Its current deployment mode (``paper`` / ``testnet`` / ``live``).
+    running : bool
+        Whether it is started (its engine is built and steppable).
+    realised_pnl : Money or None
+        The unit engine's realised PnL when running, else ``None``.
+    open_orders : int
+        The number of orders the unit's router currently tracks as non-terminal
+        (``0`` when stopped).
+
+    """
+
+    name: str
+    kind: _KIND
+    mode: StrategyMode
+    running: bool
+    realised_pnl: Money | None
+    open_orders: int
+
+
+@dataclass
+class _Unit:
+    """One managed strategy: its config slice, mode, and (when running) engine."""
+
+    name: str
+    kind: _KIND
+    mode: StrategyMode
+    config: AppConfig
+    engine: Engine | None = None
+    runner: StrategyRunner | PortfolioRunner | None = None
+    running: bool = False
+
+
+class StrategySupervisor:
+    """Manage each declared strategy as an independently-deployable unit.
+
+    Splits ``base_config`` into one unit per declared strategy and portfolio, each
+    with its own engine and mode. Drive them with :meth:`start` / :meth:`stop` /
+    :meth:`set_mode` / :meth:`step`, and read state with :meth:`status`.
+
+    Parameters
+    ----------
+    base_config : AppConfig
+        The declared system. Its mode seeds every unit's initial mode; each unit
+        can then be switched independently.
+    dccd_client : DccdClient or None, optional
+        The dccd client every unit's feed reads through (injected for an offline
+        run/test). ``None`` lets each feed construct a real client.
+
+    """
+
+    def __init__(
+        self, base_config: AppConfig, *, dccd_client: DccdClient | None = None
+    ) -> None:
+        self._base = base_config
+        self._dccd_client = dccd_client
+        self._units: dict[str, _Unit] = {}
+        seed = _mode_of(base_config)
+        for strategy in base_config.strategies:
+            self._add_unit(strategy.name, "strategy", seed)
+        for portfolio in base_config.portfolios:
+            self._add_unit(portfolio.name, "portfolio", seed)
+
+    # --- registry ---------------------------------------------------------- #
+
+    def _add_unit(self, name: str, kind: _KIND, mode: StrategyMode) -> None:
+        if name in self._units:
+            raise ConfigError(
+                f"duplicate strategy name {name!r}: each managed unit needs a "
+                "unique name across strategies and portfolios"
+            )
+        config = self._slice_for(name, kind, mode)
+        self._units[name] = _Unit(name=name, kind=kind, mode=mode, config=config)
+
+    def names(self) -> list[str]:
+        """The managed strategy names, in registration order."""
+        return list(self._units)
+
+    def _unit(self, name: str) -> _Unit:
+        try:
+            return self._units[name]
+        except KeyError:
+            raise ConfigError(f"unknown strategy {name!r}") from None
+
+    # --- config slicing + mode mapping ------------------------------------- #
+
+    def _slice_for(self, name: str, kind: _KIND, mode: StrategyMode) -> AppConfig:
+        """The single-unit ``AppConfig`` for ``name`` in ``mode``."""
+        if kind == "strategy":
+            only = [s for s in self._base.strategies if s.name == name]
+            base_slice = self._base.model_copy(
+                update={"strategies": only, "portfolios": []}
+            )
+        else:
+            only_p = [p for p in self._base.portfolios if p.name == name]
+            base_slice = self._base.model_copy(
+                update={"strategies": [], "portfolios": only_p}
+            )
+        return _config_for_mode(base_slice, mode)
+
+    # --- lifecycle --------------------------------------------------------- #
+
+    async def start(self, name: str) -> None:
+        """Build the unit's engine (in its mode) and make it steppable.
+
+        Builds a fresh :class:`~trading_bot.application.service_factory.Engine` from
+        the unit's config, **restores** the router's dedup map from the store (if
+        any) and **reconciles** to the broker (a no-op on paper; the safety
+        backstop on a live/testnet venue), then builds the unit's runner. Idempotent
+        — starting an already-running unit is a no-op.
+
+        Raises
+        ------
+        LiveTradingNotEnabled or BrokerError
+            From the factory if a live/testnet unit lacks the opt-in/credentials/
+            risk limits (the usual go-live gates apply on the real build).
+
+        """
+        unit = self._unit(name)
+        if unit.running:
+            return
+        engine = build_engine(unit.config, db_path=unit.config.storage.db_path)
+        if engine.store is not None:
+            engine.router.restore(engine.store.orders())
+        await reconcile(
+            engine.broker, engine.router, engine.tracker, event_bus=engine.bus
+        )
+        if unit.kind == "strategy":
+            runners = build_runners(
+                unit.config, engine, dccd_client=self._dccd_client
+            )
+            unit.runner = runners[0]
+        else:
+            pruns = build_portfolio_runners(
+                unit.config, engine, dccd_client=self._dccd_client
+            )
+            unit.runner = pruns[0]
+        unit.engine = engine
+        unit.running = True
+
+    async def stop(self, name: str) -> None:
+        """Tear down the unit's engine — it is no longer stepped. Idempotent."""
+        unit = self._unit(name)
+        unit.running = False
+        unit.runner = None
+        unit.engine = None
+
+    async def set_mode(
+        self, name: str, mode: StrategyMode, *, confirm_live: bool = False
+    ) -> None:
+        """Switch a unit's mode (paper / testnet / live), restarting if running.
+
+        Real money is gated: ``mode="live"`` requires ``confirm_live=True`` — the
+        deliberate acknowledgement the control API / UI obtains (a typed
+        confirmation). Paper ↔ testnet need none. If the unit was running it is
+        stopped, re-sliced for the new mode, and started again (so the new engine /
+        broker takes effect immediately).
+
+        Raises
+        ------
+        LiveTradingNotEnabled
+            If ``mode == "live"`` without ``confirm_live`` — real money is never
+            engaged by a casual flip.
+
+        """
+        if mode == "live" and not confirm_live:
+            raise LiveTradingNotEnabled(
+                f"refusing to switch {name!r} to live (real money) without an "
+                "explicit confirmation; the control plane requires a deliberate "
+                "acknowledgement (see doc/dev/09-go-live.md). No order placed."
+            )
+        unit = self._unit(name)
+        was_running = unit.running
+        if was_running:
+            await self.stop(name)
+        unit.mode = mode
+        unit.config = self._slice_for(name, unit.kind, mode)
+        if was_running:
+            await self.start(name)
+
+    async def step(self, name: str) -> Order | object | None:
+        """Run **one** re-evaluation of the unit over the latest data.
+
+        Calls :meth:`~trading_bot.application.strategy_runner.StrategyRunner
+        .step_latest` (or
+        :meth:`~trading_bot.application.portfolio_runner.PortfolioRunner
+        .rebalance_latest`). A no-op (returns ``None``) when the unit is stopped.
+        This is what the daemon's scheduler calls per tick.
+        """
+        unit = self._unit(name)
+        if not unit.running or unit.runner is None:
+            return None
+        if unit.kind == "strategy":
+            from trading_bot.application.strategy_runner import StrategyRunner
+
+            assert isinstance(unit.runner, StrategyRunner)
+            return await unit.runner.step_latest()
+        from trading_bot.application.portfolio_runner import PortfolioRunner
+
+        assert isinstance(unit.runner, PortfolioRunner)
+        return await unit.runner.rebalance_latest()
+
+    async def shutdown(self) -> None:
+        """Stop every running unit (the daemon's graceful teardown)."""
+        for name in list(self._units):
+            await self.stop(name)
+
+    # --- read side --------------------------------------------------------- #
+
+    def status(self, name: str | None = None) -> list[StrategyStatus]:
+        """A snapshot of every unit's state (or just ``name`` if given)."""
+        names = [name] if name is not None else list(self._units)
+        return [self._status_of(self._unit(n)) for n in names]
+
+    @staticmethod
+    def _status_of(unit: _Unit) -> StrategyStatus:
+        realised: Money | None = None
+        open_orders = 0
+        if unit.running and unit.engine is not None:
+            realised = unit.engine.perf.realised_pnl()
+            open_orders = sum(
+                1
+                for order in unit.engine.router.tracked_orders().values()
+                if not order.is_terminal
+            )
+        return StrategyStatus(
+            name=unit.name,
+            kind=unit.kind,
+            mode=unit.mode,
+            running=unit.running,
+            realised_pnl=realised,
+            open_orders=open_orders,
+        )
+
+
+def _mode_of(config: AppConfig) -> StrategyMode:
+    """Infer a :data:`StrategyMode` from an :class:`AppConfig`'s mode/brokers."""
+    if config.mode == "paper":
+        return "paper"
+    if any(broker.testnet for broker in config.brokers):
+        return "testnet"
+    return "live"
+
+
+def _config_for_mode(base_slice: AppConfig, mode: StrategyMode) -> AppConfig:
+    """Rewrite a single-unit config for ``mode`` (paper / testnet / live).
+
+    ``testnet`` and ``live`` require at least one configured broker (the venue);
+    a unit with no broker can only run ``paper``.
+    """
+    if mode == "paper":
+        return base_slice.model_copy(
+            update={"mode": "paper", "live_enabled": False}
+        )
+    if not base_slice.brokers:
+        raise ConfigError(
+            f"cannot run mode {mode!r} without a configured broker; add a "
+            "'brokers' entry (the venue) or keep the strategy on paper"
+        )
+    testnet = mode == "testnet"
+    brokers = [b.model_copy(update={"testnet": testnet}) for b in base_slice.brokers]
+    return base_slice.model_copy(
+        update={
+            "mode": "live",
+            "live_enabled": mode == "live",
+            "brokers": brokers,
+        }
+    )

--- a/trading_bot/tests/application/test_supervisor.py
+++ b/trading_bot/tests/application/test_supervisor.py
@@ -1,0 +1,147 @@
+"""Tests for the :class:`StrategySupervisor` — per-strategy lifecycle + modes.
+
+Offline: a paper config + a fake dccd client (canned bars). Proves the supervisor
+splits a config into independently-managed units, starts/steps/stops them in their
+own engine, switches modes (paper ↔ testnet), and **gates real money** (``live``
+needs an explicit confirmation). Async tests run un-decorated (``asyncio_mode =
+"auto"``).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from trading_bot.application.config import AppConfig
+from trading_bot.application.supervisor import StrategySupervisor
+from trading_bot.domain.errors import ConfigError, LiveTradingNotEnabled
+
+
+def _dccd_ohlc(closes: list[float], *, span_s: int = 60) -> pl.DataFrame:
+    span_ns = span_s * 1_000_000_000
+    ts = [i * span_ns for i in range(len(closes))]
+    return pl.DataFrame(
+        {
+            "TS": ts,
+            "open": closes,
+            "high": [c + 0.5 for c in closes],
+            "low": [c - 0.5 for c in closes],
+            "close": closes,
+            "volume": [1.0] * len(closes),
+            "quote_volume": list(closes),
+            "trades": [1] * len(closes),
+        }
+    )
+
+
+class _FakeDccdClient:
+    """A canned offline dccd client keyed by symbol (no network)."""
+
+    def __init__(self, frames: dict[str, pl.DataFrame]) -> None:
+        self._frames = frames
+
+    def read(self, exchange, symbol, data_type="ohlc", span=None, start_ns=None, end_ns=None):  # noqa: ANN001, ANN201
+        return self._frames[symbol]
+
+    def backfill(self, *a, **k):  # noqa: ANN002, ANN003, ANN201  # pragma: no cover
+        return None
+
+
+def _trend() -> list[float]:
+    """A close series that trends up then down (the MA crosses both ways)."""
+    return [100.0 + i for i in range(20)] + [119.0 - i for i in range(1, 21)]
+
+
+def _config(*, with_broker: bool = True) -> AppConfig:
+    """A paper config: one BTC/USD MA-crossover strategy (+ an optional broker)."""
+    raw: dict = {
+        "mode": "paper",
+        "strategies": [
+            {
+                "name": "btc-ma",
+                "symbol": "BTC/USD",
+                "data": {"exchange": "kraken", "span": 60},
+                "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                "reference_qty": "2",
+                "lookback": 6,
+            }
+        ],
+    }
+    if with_broker:
+        raw["brokers"] = [{"name": "kraken", "exchange": "kraken"}]
+    return AppConfig.model_validate(raw)
+
+
+def _supervisor() -> StrategySupervisor:
+    client = _FakeDccdClient({"BTC/USD": _dccd_ohlc(_trend())})
+    return StrategySupervisor(_config(), dccd_client=client)
+
+
+def test_splits_config_into_units() -> None:
+    """The supervisor splits the config into one (stopped, paper) unit per strategy."""
+    sup = _supervisor()
+    assert sup.names() == ["btc-ma"]
+    [status] = sup.status()
+    assert status.name == "btc-ma"
+    assert status.kind == "strategy"
+    assert status.mode == "paper"
+    assert status.running is False
+    assert status.realised_pnl is None
+
+
+async def test_start_step_stop_lifecycle() -> None:
+    """start builds a per-unit engine; step re-evaluates over latest data; stop tears down."""
+    pytest.importorskip("fynance")  # ma_crossover evaluates fynance.sma
+    sup = _supervisor()
+
+    await sup.start("btc-ma")
+    assert sup.status("btc-ma")[0].running is True
+
+    # One re-evaluation over the latest (trend-down tail → short) data trades.
+    order = await sup.step("btc-ma")
+    assert order is not None  # delta != 0 from flat → an order was routed
+
+    await sup.stop("btc-ma")
+    status = sup.status("btc-ma")[0]
+    assert status.running is False
+    # Stopped → nothing to step.
+    assert await sup.step("btc-ma") is None
+
+
+async def test_set_mode_paper_testnet_roundtrip() -> None:
+    """paper ↔ testnet switch needs no confirmation and updates the unit's mode."""
+    sup = _supervisor()
+    await sup.set_mode("btc-ma", "testnet")
+    assert sup.status("btc-ma")[0].mode == "testnet"
+    await sup.set_mode("btc-ma", "paper")
+    assert sup.status("btc-ma")[0].mode == "paper"
+
+
+async def test_set_mode_live_requires_explicit_confirmation() -> None:
+    """Switching to live (real money) without confirmation is refused."""
+    sup = _supervisor()
+    with pytest.raises(LiveTradingNotEnabled):
+        await sup.set_mode("btc-ma", "live")  # no confirm → refused
+    assert sup.status("btc-ma")[0].mode == "paper"  # unchanged
+
+    # With the deliberate acknowledgement the mode flips (the engine is only built
+    # on start, which still enforces credentials + risk limits).
+    await sup.set_mode("btc-ma", "live", confirm_live=True)
+    assert sup.status("btc-ma")[0].mode == "live"
+
+
+async def test_testnet_without_a_broker_is_refused() -> None:
+    """A paper-only unit with no configured broker cannot go testnet/live."""
+    sup = StrategySupervisor(
+        _config(with_broker=False),
+        dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(_trend())}),
+    )
+    with pytest.raises(ConfigError, match="without a configured broker"):
+        await sup.set_mode("btc-ma", "testnet")
+
+
+async def test_unknown_strategy_is_a_config_error() -> None:
+    """Operating on an unknown name raises a clear error."""
+    sup = _supervisor()
+    with pytest.raises(ConfigError, match="unknown strategy"):
+        await sup.start("nope")


### PR DESCRIPTION
## Summary
- `application.StrategySupervisor`: each declared strategy/portfolio is an **independent unit** in its **own** engine (own broker/mode) → `start` / `stop` / `set_mode` / `step` / `status` per unit, restart-safe.
- Per-strategy **mode** (paper / testnet / live) — impossible under the single shared engine. **Real money gated**: `set_mode(..., "live")` needs `confirm_live=True`; paper ↔ testnet are free.

## Why
- The control plane (start/stop + mode switch from the UI) needs per-strategy lifecycle + mode. A per-strategy engine is `build_engine` over a one-strategy slice (the factory already wires it); per-strategy trackers also dissolve commingling.

## Changes
- `application/supervisor.py` (new) + export; tests: split into units, start→step→stop lifecycle, paper↔testnet roundtrip, live-needs-confirmation, testnet-without-broker refused, unknown-name error.
- ADR + CHANGELOG (Added).

## Posture
- Matches the agreed safety posture (paper/testnet free; prod = deliberate confirmation). The factory's credential + mandatory-risk-limit gates still fire on the real `start`.

## Test plan
- [x] `pytest` — 742 passed; `ruff` + `mypy` clean
- [ ] CI green