### PR TITLE
feat: trading-bot start — the trading daemon (supervisor + scheduler)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`trading-bot start` — the trading daemon.** A long-running process (systemd's
+  `ExecStart`) that builds a `StrategySupervisor`, starts every declared strategy (in its
+  configured mode — **paper by default**), and re-evaluates them on an `--interval`
+  (idempotent ticks) or `--cron` schedule via `apscheduler`, until `SIGINT`/`SIGTERM`
+  (then shuts every unit down gracefully). Each strategy runs in its own engine, so they
+  can be switched paper/testnet/live independently from the control plane. Starting never
+  trades real money by itself (the live gates still apply). `StrategySupervisor` gains
+  `start_all` / `step_all` for the daemon's boot/tick. (#95)
 - `application.StrategySupervisor` — manages each declared strategy/portfolio as an
   **independent unit** in its **own** engine (own broker/mode), so a strategy can be
   started/stopped and switched between **paper / testnet / live independently**

--- a/trading_bot/application/supervisor.py
+++ b/trading_bot/application/supervisor.py
@@ -271,6 +271,25 @@ class StrategySupervisor:
         assert isinstance(unit.runner, PortfolioRunner)
         return await unit.runner.rebalance_latest()
 
+    async def start_all(self) -> None:
+        """Start every managed unit (the daemon's boot — each in its config mode)."""
+        for name in list(self._units):
+            await self.start(name)
+
+    async def step_all(self) -> int:
+        """Step every **running** unit once — the daemon's per-tick action.
+
+        Returns the number of units stepped (running units; stopped units are
+        skipped). Each unit's :meth:`step` is idempotent over unchanged data, so a
+        tick that finds nothing to do trades nothing.
+        """
+        stepped = 0
+        for name in list(self._units):
+            if self._units[name].running:
+                await self.step(name)
+                stepped += 1
+        return stepped
+
     async def shutdown(self) -> None:
         """Stop every running unit (the daemon's graceful teardown)."""
         for name in list(self._units):

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -49,6 +49,7 @@ import contextlib
 import dataclasses
 import math
 import pathlib
+import signal
 from collections.abc import Callable
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -709,6 +710,107 @@ def serve(
         f"(mode={config.mode}) on http://{host}:{port}"
     )
     uvicorn.run(application, host=host, port=port)
+
+
+# --- start (daemon) -------------------------------------------------------- #
+
+
+async def _run_daemon(
+    config: AppConfig,
+    *,
+    interval: float,
+    cron: str | None,
+    dccd_client: object | None = None,
+) -> None:
+    """Supervise the declared strategies and step them on a schedule until stopped.
+
+    Builds a :class:`~trading_bot.application.supervisor.StrategySupervisor`, starts
+    every unit (each in its configured mode — paper by default), then steps the
+    running units on an **interval** (or **cron**) via an ``apscheduler``
+    ``AsyncIOScheduler``. Runs until ``SIGINT``/``SIGTERM`` (systemd's stop), then
+    shuts every unit down gracefully. Each step is idempotent over unchanged data,
+    so a tick that finds nothing to do trades nothing.
+    """
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    from apscheduler.triggers.cron import CronTrigger
+    from apscheduler.triggers.interval import IntervalTrigger
+
+    from trading_bot.application.supervisor import StrategySupervisor
+
+    supervisor = StrategySupervisor(config, dccd_client=dccd_client)  # type: ignore[arg-type]
+    await supervisor.start_all()
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(NotImplementedError, RuntimeError):
+            loop.add_signal_handler(sig, stop.set)
+
+    async def _tick() -> None:
+        try:
+            stepped = await supervisor.step_all()
+            if stepped:
+                _console.print(f"[dim]daemon tick: stepped {stepped} strategy(ies)[/dim]")
+        except Exception as exc:  # noqa: BLE001 - never let a tick kill the daemon
+            _console.print(f"[red]daemon tick error:[/red] {exc}")
+
+    trigger = (
+        CronTrigger.from_crontab(cron)
+        if cron is not None
+        else IntervalTrigger(seconds=interval)
+    )
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(_tick, trigger)
+    scheduler.start()
+    _console.print(
+        f"[green]daemon started[/green] (mode={config.mode}): "
+        f"{len(supervisor.names())} strateg(ies), "
+        f"tick={cron or f'every {interval:g}s'}  —  Ctrl-C / SIGTERM to stop"
+    )
+    try:
+        await stop.wait()
+    finally:
+        scheduler.shutdown(wait=False)
+        await supervisor.shutdown()
+        _console.print("[green]daemon stopped[/green] (all strategies shut down)")
+
+
+@app.command()
+def start(
+    config_path: pathlib.Path | None = typer.Option(
+        None, "--config", "-c", help="YAML AppConfig path. Defaults to a paper config."
+    ),
+    interval: float = typer.Option(
+        60.0,
+        "--interval",
+        help="Seconds between re-evaluations (idempotent ticks). Ignored if --cron.",
+    ),
+    cron: str | None = typer.Option(
+        None,
+        "--cron",
+        help="Crontab expression for re-evaluation (e.g. '5 0 * * *' = 00:05 daily).",
+    ),
+) -> None:
+    """Run the trading **daemon**: supervise the declared strategies, step on a schedule.
+
+    The long-running process (systemd's ``ExecStart``): it builds a per-strategy
+    supervisor, starts every declared strategy (in its configured mode — **paper by
+    default**), and re-evaluates them on an interval or cron until stopped. Each
+    strategy runs in its **own** engine, so they can later be switched between
+    paper / testnet / live independently from the control plane (the dashboard).
+    Going live still requires the explicit gates — the daemon never trades real
+    money by merely starting.
+    """
+    config = (
+        AppConfig.from_yaml(config_path)
+        if config_path is not None
+        else AppConfig()
+    )
+    try:
+        asyncio.run(_run_daemon(config, interval=interval, cron=cron))
+    except Exception as exc:  # noqa: BLE001 - surface any build/config failure cleanly
+        _console.print(f"[red]refusing to start daemon:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation only

--- a/trading_bot/tests/application/test_supervisor.py
+++ b/trading_bot/tests/application/test_supervisor.py
@@ -145,3 +145,19 @@ async def test_unknown_strategy_is_a_config_error() -> None:
     sup = _supervisor()
     with pytest.raises(ConfigError, match="unknown strategy"):
         await sup.start("nope")
+
+
+async def test_start_all_step_all_shutdown() -> None:
+    """The daemon's boot/tick/teardown: start every unit, step the running ones, stop."""
+    pytest.importorskip("fynance")
+    sup = _supervisor()
+
+    await sup.start_all()
+    assert all(s.running for s in sup.status())
+
+    stepped = await sup.step_all()
+    assert stepped == 1  # the one running unit stepped once
+
+    await sup.shutdown()
+    assert not any(s.running for s in sup.status())
+    assert await sup.step_all() == 0  # nothing running → nothing stepped

--- a/trading_bot/tests/interfaces/test_cli_commands.py
+++ b/trading_bot/tests/interfaces/test_cli_commands.py
@@ -407,3 +407,28 @@ def _render_to_text(renderable: object) -> str:
     console = Console(width=200, record=True)
     console.print(renderable)
     return console.export_text()
+
+
+# --- daemon (`start`) smoke ------------------------------------------------- #
+
+
+async def test_daemon_starts_ticks_and_stops_cleanly() -> None:
+    """`_run_daemon` builds the supervisor, schedules ticks, and tears down on cancel.
+
+    Drives the daemon coroutine over an empty paper config (no strategies): it must
+    start the scheduler, tick (a no-op with zero units), and shut down cleanly when
+    cancelled — no exception leaks. Proves the daemon loop is wired without binding a
+    real signal/port.
+    """
+    import asyncio
+    import contextlib
+
+    from trading_bot.application.config import AppConfig
+    from trading_bot.interfaces.cli.main import _run_daemon
+
+    task = asyncio.create_task(_run_daemon(AppConfig(), interval=0.05, cron=None))
+    await asyncio.sleep(0.12)  # let it start + tick a couple of times
+    assert not task.done()  # the daemon stays up until stopped
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task


### PR DESCRIPTION
## Summary
- `trading-bot start` — the long-running daemon (systemd `ExecStart`): builds a `StrategySupervisor`, starts every declared strategy (its configured mode, **paper by default**), and re-evaluates them on `--interval` (idempotent ticks) or `--cron` via `apscheduler`, until `SIGINT`/`SIGTERM` → graceful shutdown.
- `StrategySupervisor.start_all` / `step_all` (the daemon's boot/tick).

## Why
- The "keep it active comme dccd" piece: a supervised, scheduled process per strategy (each in its own engine, switchable paper/testnet/live later from the control plane). Starting never trades real money by itself — the live gates still apply.

## Changes
- `application/supervisor.py`: `start_all` + `step_all`.
- `interfaces/cli/main.py`: `_run_daemon` + the `start` command (lazy `apscheduler`; `SIGINT`/`SIGTERM` → stop → graceful teardown).
- Tests: supervisor boot/tick/teardown; daemon smoke (starts, ticks, stops cleanly on cancel).

## Next
- D4: the supervisor-aware dashboard + write control endpoints (start/stop/set-mode) so the daemon is monitored + controlled from the UI; D6: the systemd unit (pyenv).

## Test plan
- [x] `pytest` — 744 passed; `ruff` + `mypy` clean
- [ ] CI green