### PR TITLE
feat: control plane — start/stop + switch mode from the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Control plane — the daemon's dashboard can start/stop strategies and switch mode.**
+  `interfaces.api.create_control_app(supervisor)` serves a **read+write** dashboard over
+  the `StrategySupervisor`: `GET /api/strategies`, `POST /api/strategies/{name}/start`,
+  `.../stop`, `.../mode`. `trading-bot start --serve` runs it (loopback by default — it
+  can change what trades) alongside the scheduler. The dashboard (`control.html` +
+  `control.js`) lists each strategy with a mode selector + start/stop buttons.
+  **Real money is gated**: switching to `live` requires a typed confirmation in the UI
+  and `confirm: true` on the endpoint — the server returns `403` otherwise, changing
+  nothing. (#96)
 - **`trading-bot start` — the trading daemon.** A long-running process (systemd's
   `ExecStart`) that builds a `StrategySupervisor`, starts every declared strategy (in its
   configured mode — **paper by default**), and re-evaluates them on an `--interval`

--- a/trading_bot/interfaces/api/__init__.py
+++ b/trading_bot/interfaces/api/__init__.py
@@ -13,6 +13,6 @@ The single entrypoint is :func:`~trading_bot.interfaces.api.app.create_app`.
 
 from __future__ import annotations
 
-from trading_bot.interfaces.api.app import create_app
+from trading_bot.interfaces.api.app import create_app, create_control_app
 
-__all__ = ["create_app"]
+__all__ = ["create_app", "create_control_app"]

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -70,6 +70,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
 
 import trading_bot
 from trading_bot.application.events import (
@@ -82,11 +83,15 @@ from trading_bot.interfaces.ui import STATIC_DIR, TEMPLATES_DIR
 
 if TYPE_CHECKING:
     from trading_bot.application.service_factory import Engine
+    from trading_bot.application.supervisor import (
+        StrategyStatus,
+        StrategySupervisor,
+    )
     from trading_bot.domain.fill import Fill
     from trading_bot.domain.order import Order
     from trading_bot.domain.position import Position
 
-__all__ = ["create_app"]
+__all__ = ["create_app", "create_control_app"]
 
 
 # ---------------------------------------------------------------------------
@@ -408,5 +413,155 @@ def create_app(engine: Engine) -> FastAPI:
                 bus.remove_queue(queue)
 
         return StreamingResponse(_generator(), media_type="text/event-stream")
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# The control app — the daemon's read+write dashboard over a StrategySupervisor
+# ---------------------------------------------------------------------------
+
+
+#: Valid deployment modes the control API accepts.
+_CONTROL_MODES = ("paper", "testnet", "live")
+
+
+class _ModeBody(BaseModel):
+    """Request body for ``POST /api/strategies/{name}/mode``.
+
+    ``confirm`` must be ``true`` to switch to ``live`` (real money) — the
+    deliberate acknowledgement; the endpoint refuses live without it.
+    """
+
+    mode: str
+    confirm: bool = False
+
+
+def _status_dict(status: StrategyStatus) -> dict[str, Any]:
+    """Render a :class:`StrategyStatus` for JSON (money as exact Decimal string)."""
+    return {
+        "name": status.name,
+        "kind": status.kind,
+        "mode": status.mode,
+        "running": status.running,
+        "realised_pnl": (
+            str(status.realised_pnl) if status.realised_pnl is not None else None
+        ),
+        "open_orders": status.open_orders,
+    }
+
+
+def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
+    """Build the daemon's **control** FastAPI over a :class:`StrategySupervisor`.
+
+    Unlike :func:`create_app` (a *read-only* view of one engine), this app is the
+    **control plane**: it lists the managed strategies and lets a client **start /
+    stop** them and **switch mode** (paper / testnet / live). It is meant to be
+    served **loopback-only** by the daemon, since it can change what trades.
+
+    **Real money is gated.** Switching a strategy to ``live`` requires
+    ``confirm: true`` in the request body — the deliberate acknowledgement the UI
+    obtains (a typed confirmation); otherwise the endpoint returns **403** and
+    nothing changes. The factory's credential + risk-limit gates still apply when a
+    live unit is actually started.
+
+    Parameters
+    ----------
+    supervisor : StrategySupervisor
+        The supervisor to expose, read+controlled through ``app.state.supervisor``.
+
+    Returns
+    -------
+    FastAPI
+        The control application (serve via uvicorn, or a ``TestClient``).
+
+    """
+    from fastapi import HTTPException
+
+    from trading_bot.domain.errors import (
+        BrokerError,
+        ConfigError,
+        LiveTradingNotEnabled,
+    )
+
+    app = FastAPI(
+        title="trading_bot control",
+        summary="Supervise + control the declared strategies (loopback-only).",
+        default_response_class=_DecimalJSONResponse,
+    )
+    app.state.supervisor = supervisor
+
+    def _sup(request: Request) -> StrategySupervisor:
+        return request.app.state.supervisor  # type: ignore[no-any-return]
+
+    if STATIC_DIR.is_dir():
+        app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+    templates = (
+        Jinja2Templates(directory=str(TEMPLATES_DIR))
+        if TEMPLATES_DIR.is_dir()
+        else None
+    )
+
+    if templates is not None:
+
+        @app.get("/", response_class=HTMLResponse)
+        async def control_dashboard(request: Request) -> Any:
+            """Render the control dashboard shell (data fetched client-side)."""
+            return templates.TemplateResponse(
+                request, "control.html", {"version": trading_bot.__version__}
+            )
+
+    @app.get("/api/health")
+    async def health(request: Request) -> dict[str, Any]:
+        names = _sup(request).names()
+        running = sum(1 for s in _sup(request).status() if s.running)
+        return {"status": "ok", "strategies": len(names), "running": running}
+
+    @app.get("/api/strategies")
+    async def strategies(request: Request) -> list[dict[str, Any]]:
+        """List every managed strategy with its mode / running / PnL."""
+        return [_status_dict(s) for s in _sup(request).status()]
+
+    @app.post("/api/strategies/{name}/start")
+    async def start_strategy(name: str, request: Request) -> dict[str, Any]:
+        try:
+            await _sup(request).start(name)
+        except ConfigError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except (BrokerError, LiveTradingNotEnabled) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"ok": True, "status": _status_dict(_sup(request).status(name)[0])}
+
+    @app.post("/api/strategies/{name}/stop")
+    async def stop_strategy(name: str, request: Request) -> dict[str, Any]:
+        try:
+            await _sup(request).stop(name)
+        except ConfigError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True, "status": _status_dict(_sup(request).status(name)[0])}
+
+    @app.post("/api/strategies/{name}/mode")
+    async def set_strategy_mode(
+        name: str, body: _ModeBody, request: Request
+    ) -> dict[str, Any]:
+        if body.mode not in _CONTROL_MODES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"unknown mode {body.mode!r}; expected one of {_CONTROL_MODES}",
+            )
+        try:
+            await _sup(request).set_mode(
+                name,
+                body.mode,  # type: ignore[arg-type]
+                confirm_live=body.confirm,
+            )
+        except LiveTradingNotEnabled as exc:
+            # Real money without the deliberate confirmation — refuse, change nothing.
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except ConfigError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except (BrokerError, LiveTradingNotEnabled) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"ok": True, "status": _status_dict(_sup(request).status(name)[0])}
 
     return app

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -720,6 +720,9 @@ async def _run_daemon(
     *,
     interval: float,
     cron: str | None,
+    serve: bool = False,
+    host: str = "127.0.0.1",
+    port: int = 8000,
     dccd_client: object | None = None,
 ) -> None:
     """Supervise the declared strategies and step them on a schedule until stopped.
@@ -727,9 +730,13 @@ async def _run_daemon(
     Builds a :class:`~trading_bot.application.supervisor.StrategySupervisor`, starts
     every unit (each in its configured mode — paper by default), then steps the
     running units on an **interval** (or **cron**) via an ``apscheduler``
-    ``AsyncIOScheduler``. Runs until ``SIGINT``/``SIGTERM`` (systemd's stop), then
-    shuts every unit down gracefully. Each step is idempotent over unchanged data,
-    so a tick that finds nothing to do trades nothing.
+    ``AsyncIOScheduler``. When ``serve`` is set, the control dashboard
+    (:func:`~trading_bot.interfaces.api.create_control_app`) is served over the same
+    supervisor on ``host:port`` (loopback by default — it can change what trades),
+    and **uvicorn owns the signal** (Ctrl-C ends serve, then the daemon tears down);
+    headless, the daemon installs its own ``SIGINT``/``SIGTERM`` handlers. Each step
+    is idempotent over unchanged data, so a tick that finds nothing to do trades
+    nothing.
     """
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
     from apscheduler.triggers.cron import CronTrigger
@@ -739,12 +746,6 @@ async def _run_daemon(
 
     supervisor = StrategySupervisor(config, dccd_client=dccd_client)  # type: ignore[arg-type]
     await supervisor.start_all()
-
-    stop = asyncio.Event()
-    loop = asyncio.get_running_loop()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        with contextlib.suppress(NotImplementedError, RuntimeError):
-            loop.add_signal_handler(sig, stop.set)
 
     async def _tick() -> None:
         try:
@@ -765,10 +766,31 @@ async def _run_daemon(
     _console.print(
         f"[green]daemon started[/green] (mode={config.mode}): "
         f"{len(supervisor.names())} strateg(ies), "
-        f"tick={cron or f'every {interval:g}s'}  —  Ctrl-C / SIGTERM to stop"
+        f"tick={cron or f'every {interval:g}s'}"
     )
     try:
-        await stop.wait()
+        if serve:
+            import uvicorn
+
+            from trading_bot.interfaces.api import create_control_app
+
+            api = create_control_app(supervisor)
+            server = uvicorn.Server(
+                uvicorn.Config(api, host=host, port=port, log_level="warning")
+            )
+            _console.print(
+                f"[green]control dashboard[/green] on http://{host}:{port}"
+                "  —  Ctrl-C to stop"
+            )
+            await server.serve()  # uvicorn owns SIGINT; blocks until Ctrl-C
+        else:
+            stop = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                with contextlib.suppress(NotImplementedError, RuntimeError):
+                    loop.add_signal_handler(sig, stop.set)
+            _console.print("[dim]Ctrl-C / SIGTERM to stop[/dim]")
+            await stop.wait()
     finally:
         scheduler.shutdown(wait=False)
         await supervisor.shutdown()
@@ -790,16 +812,28 @@ def start(
         "--cron",
         help="Crontab expression for re-evaluation (e.g. '5 0 * * *' = 00:05 daily).",
     ),
+    serve: bool = typer.Option(
+        False,
+        "--serve",
+        help="Also serve the control dashboard (start/stop strategies, switch mode) "
+        "over HTTP — loopback by default, since it can change what trades.",
+    ),
+    serve_host: str = typer.Option(
+        "127.0.0.1", "--serve-host", help="Control dashboard bind interface (loopback)."
+    ),
+    serve_port: int = typer.Option(
+        8000, "--serve-port", help="Control dashboard TCP port."
+    ),
 ) -> None:
     """Run the trading **daemon**: supervise the declared strategies, step on a schedule.
 
     The long-running process (systemd's ``ExecStart``): it builds a per-strategy
     supervisor, starts every declared strategy (in its configured mode — **paper by
     default**), and re-evaluates them on an interval or cron until stopped. Each
-    strategy runs in its **own** engine, so they can later be switched between
-    paper / testnet / live independently from the control plane (the dashboard).
-    Going live still requires the explicit gates — the daemon never trades real
-    money by merely starting.
+    strategy runs in its **own** engine, so they can be switched between paper /
+    testnet / live independently from the **control dashboard** (``--serve``). Going
+    live still requires the explicit gates — the daemon never trades real money by
+    merely starting, and the dashboard requires a typed confirmation to go live.
     """
     config = (
         AppConfig.from_yaml(config_path)
@@ -807,7 +841,16 @@ def start(
         else AppConfig()
     )
     try:
-        asyncio.run(_run_daemon(config, interval=interval, cron=cron))
+        asyncio.run(
+            _run_daemon(
+                config,
+                interval=interval,
+                cron=cron,
+                serve=serve,
+                host=serve_host,
+                port=serve_port,
+            )
+        )
     except Exception as exc:  # noqa: BLE001 - surface any build/config failure cleanly
         _console.print(f"[red]refusing to start daemon:[/red] {exc}")
         raise typer.Exit(code=1) from exc

--- a/trading_bot/interfaces/ui/static/control.js
+++ b/trading_bot/interfaces/ui/static/control.js
@@ -1,0 +1,123 @@
+// trading_bot control plane — list strategies, start/stop, switch mode.
+// Pure HTTP client of /api/strategies; switching to LIVE asks for a typed
+// confirmation that maps to {confirm:true} on the mode endpoint (the server
+// also refuses live without it).
+"use strict";
+
+const MODES = ["paper", "testnet", "live"];
+const body = document.getElementById("strategies-body");
+const conn = document.getElementById("conn");
+const msg = document.getElementById("msg");
+
+function setConn(ok) {
+  conn.className = "conn " + (ok ? "ok" : "down");
+  conn.innerHTML = '<span class="dot"></span>' + (ok ? "connected" : "disconnected");
+}
+
+function flash(text, isError) {
+  msg.textContent = text;
+  msg.style.color = isError ? "var(--err)" : "var(--muted)";
+}
+
+async function api(path, opts) {
+  const resp = await fetch(path, opts);
+  let data = null;
+  try { data = await resp.json(); } catch (e) { /* no body */ }
+  if (!resp.ok) {
+    const detail = (data && data.detail) || resp.statusText;
+    throw new Error(detail);
+  }
+  return data;
+}
+
+function modeSelect(s) {
+  const opts = MODES.map(
+    (m) => `<option value="${m}"${m === s.mode ? " selected" : ""}>${m}</option>`
+  ).join("");
+  return `<select data-name="${s.name}" class="mode-select">${opts}</select>`;
+}
+
+function row(s) {
+  const statusBadge = s.running
+    ? '<span class="side-buy">running</span>'
+    : '<span class="conn">stopped</span>';
+  const action = s.running
+    ? `<button data-name="${s.name}" data-act="stop">Stop</button>`
+    : `<button data-name="${s.name}" data-act="start">Start</button>`;
+  const pnl = s.realised_pnl === null ? "—" : s.realised_pnl;
+  return `<tr>
+    <td>${s.name}</td>
+    <td>${s.kind}</td>
+    <td>${modeSelect(s)}</td>
+    <td>${statusBadge}</td>
+    <td class="num">${pnl}</td>
+    <td class="num">${s.open_orders}</td>
+    <td>${action}</td>
+  </tr>`;
+}
+
+async function refresh() {
+  try {
+    const list = await api("/api/strategies");
+    setConn(true);
+    if (!list.length) {
+      body.innerHTML = '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
+      return;
+    }
+    body.innerHTML = list.map(row).join("");
+  } catch (e) {
+    setConn(false);
+  }
+}
+
+async function onClick(ev) {
+  const btn = ev.target.closest("button[data-act]");
+  if (!btn) return;
+  const { name, act } = btn.dataset;
+  btn.disabled = true;
+  try {
+    await api(`/api/strategies/${encodeURIComponent(name)}/${act}`, { method: "POST" });
+    flash(`${name}: ${act}ed`, false);
+  } catch (e) {
+    flash(`${name}: ${e.message}`, true);
+  } finally {
+    await refresh();
+  }
+}
+
+async function onModeChange(ev) {
+  const sel = ev.target.closest("select.mode-select");
+  if (!sel) return;
+  const name = sel.dataset.name;
+  const mode = sel.value;
+  let confirm = false;
+  if (mode === "live") {
+    // Real money — deliberate, typed acknowledgement (the server also enforces it).
+    const typed = window.prompt(
+      `Switch "${name}" to LIVE (REAL MONEY)?\nType I UNDERSTAND to confirm:`
+    );
+    if (typed !== "I UNDERSTAND") {
+      flash(`${name}: live switch cancelled`, true);
+      await refresh();
+      return;
+    }
+    confirm = true;
+  }
+  try {
+    await api(`/api/strategies/${encodeURIComponent(name)}/mode`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode, confirm }),
+    });
+    flash(`${name}: mode → ${mode}`, false);
+  } catch (e) {
+    flash(`${name}: ${e.message}`, true);
+  } finally {
+    await refresh();
+  }
+}
+
+body.addEventListener("click", onClick);
+body.addEventListener("change", onModeChange);
+refresh();
+setInterval(refresh, 3000);

--- a/trading_bot/interfaces/ui/templates/control.html
+++ b/trading_bot/interfaces/ui/templates/control.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>trading_bot — control</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <!-- Control plane: lists the daemon's managed strategies and lets you start /
+       stop them and switch mode (paper / testnet / live). Switching to LIVE asks
+       for a typed confirmation; all state is fetched/changed via /api/strategies. -->
+  <header class="topbar">
+    <div class="brand-group">
+      <span class="brand">trading_bot</span>
+      <span class="ver">v{{ version }}</span>
+    </div>
+    <span class="mode-badge mode-paper">control</span>
+    <span id="conn" class="conn"><span class="dot"></span>connecting…</span>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>Strategies</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Strategy</th>
+              <th>Kind</th>
+              <th>Mode</th>
+              <th>Status</th>
+              <th class="num">Realised PnL</th>
+              <th class="num">Open orders</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody id="strategies-body">
+            <tr class="empty"><td colspan="7">Loading…</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p id="msg" class="conn"></p>
+    </section>
+  </main>
+
+  <footer>
+    trading_bot v{{ version }} — control plane (loopback). Switching to <b>live</b>
+    trades real money and requires a typed confirmation.
+  </footer>
+
+  <script src="/static/control.js"></script>
+</body>
+</html>

--- a/trading_bot/tests/interfaces/test_control_api.py
+++ b/trading_bot/tests/interfaces/test_control_api.py
@@ -1,0 +1,136 @@
+"""Tests for the daemon's **control** API — start/stop/mode over a supervisor.
+
+Drives :func:`~trading_bot.interfaces.api.create_control_app` with a
+:class:`fastapi.testclient.TestClient` (no real server) over a
+:class:`~trading_bot.application.supervisor.StrategySupervisor` built from a paper
+config + a fake dccd client. Proves the read+write control plane, and that **real
+money is gated** (live needs an explicit confirmation → ``403`` otherwise).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from fastapi.testclient import TestClient
+
+from trading_bot.application.config import AppConfig
+from trading_bot.application.supervisor import StrategySupervisor
+from trading_bot.interfaces.api import create_control_app
+
+
+def _dccd_ohlc(closes: list[float]) -> pl.DataFrame:
+    span_ns = 60 * 1_000_000_000
+    return pl.DataFrame(
+        {
+            "TS": [i * span_ns for i in range(len(closes))],
+            "open": closes,
+            "high": [c + 0.5 for c in closes],
+            "low": [c - 0.5 for c in closes],
+            "close": closes,
+            "volume": [1.0] * len(closes),
+            "quote_volume": list(closes),
+            "trades": [1] * len(closes),
+        }
+    )
+
+
+class _FakeDccdClient:
+    def __init__(self, frames: dict[str, pl.DataFrame]) -> None:
+        self._frames = frames
+
+    def read(self, exchange, symbol, data_type="ohlc", span=None, start_ns=None, end_ns=None):  # noqa: ANN001, ANN201
+        return self._frames[symbol]
+
+    def backfill(self, *a, **k):  # noqa: ANN002, ANN003, ANN201  # pragma: no cover
+        return None
+
+
+def _config() -> AppConfig:
+    return AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "brokers": [{"name": "kraken", "exchange": "kraken"}],
+            "strategies": [
+                {
+                    "name": "btc-ma",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                    "reference_qty": "2",
+                    "lookback": 6,
+                }
+            ],
+        }
+    )
+
+
+def _client() -> TestClient:
+    trend = [100.0 + i for i in range(20)] + [119.0 - i for i in range(1, 21)]
+    sup = StrategySupervisor(
+        _config(), dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(trend)})
+    )
+    return TestClient(create_control_app(sup))
+
+
+def test_list_strategies() -> None:
+    """`GET /api/strategies` lists the managed units (stopped, paper to start)."""
+    resp = _client().get("/api/strategies")
+    assert resp.status_code == 200
+    [s] = resp.json()
+    assert s["name"] == "btc-ma"
+    assert s["mode"] == "paper"
+    assert s["running"] is False
+    assert s["realised_pnl"] is None
+
+
+def test_set_mode_testnet_then_paper() -> None:
+    """Switching paper ↔ testnet needs no confirmation and updates the mode."""
+    client = _client()
+    r = client.post("/api/strategies/btc-ma/mode", json={"mode": "testnet"})
+    assert r.status_code == 200
+    assert r.json()["status"]["mode"] == "testnet"
+    r = client.post("/api/strategies/btc-ma/mode", json={"mode": "paper"})
+    assert r.json()["status"]["mode"] == "paper"
+
+
+def test_set_mode_live_without_confirmation_is_403() -> None:
+    """Switching to live (real money) without confirmation is refused — nothing changes."""
+    client = _client()
+    r = client.post("/api/strategies/btc-ma/mode", json={"mode": "live"})
+    assert r.status_code == 403
+    # Mode unchanged.
+    assert client.get("/api/strategies").json()[0]["mode"] == "paper"
+
+
+def test_set_mode_live_with_confirmation_flips() -> None:
+    """With the deliberate confirmation, the mode flips to live."""
+    client = _client()
+    r = client.post(
+        "/api/strategies/btc-ma/mode", json={"mode": "live", "confirm": True}
+    )
+    assert r.status_code == 200
+    assert r.json()["status"]["mode"] == "live"
+
+
+def test_unknown_strategy_is_404() -> None:
+    r = _client().post("/api/strategies/nope/start")
+    assert r.status_code == 404
+
+
+def test_unknown_mode_is_400() -> None:
+    r = _client().post("/api/strategies/btc-ma/mode", json={"mode": "bogus"})
+    assert r.status_code == 400
+
+
+def test_start_then_stop() -> None:
+    """`POST start` runs the strategy in its own engine; `POST stop` tears it down."""
+    pytest.importorskip("fynance")  # ma_crossover evaluates fynance.sma
+    client = _client()
+
+    r = client.post("/api/strategies/btc-ma/start")
+    assert r.status_code == 200
+    assert r.json()["status"]["running"] is True
+
+    r = client.post("/api/strategies/btc-ma/stop")
+    assert r.status_code == 200
+    assert r.json()["status"]["running"] is False


### PR DESCRIPTION
## Summary
- `interfaces.api.create_control_app(supervisor)` — a **read+write** control dashboard over the `StrategySupervisor`: `GET /api/strategies`, `POST /api/strategies/{name}/start|stop|mode`.
- `trading-bot start --serve` serves it (loopback by default) alongside the scheduler.
- `control.html` + `control.js`: list strategies, mode selector, start/stop buttons.

## Safety
- **Real money gated**: switching to `live` needs a typed `I UNDERSTAND` in the UI and `confirm: true` on the endpoint → `403` otherwise (nothing changes). Loopback bind by default (it can change what trades). The factory's credential + risk-limit gates still apply on the real start.

## Changes
- `api/app.py`: `create_control_app` + `_status_dict` + `_ModeBody` (module-level so FastAPI resolves the body under `from __future__ import annotations`).
- `cli/main.py`: `start --serve/--serve-host/--serve-port` (uvicorn owns SIGINT when serving).
- UI: `control.html`, `control.js`.
- Tests: list / start / stop / mode (paper↔testnet) / **live needs confirmation (403)** / unknown name 404 / bad mode 400.

## Test plan
- [x] `pytest` — 751 passed; `ruff` + `mypy` clean
- [ ] CI green