### PR TITLE
feat: systemd unit + deployment doc (pyenv) — completes the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **systemd deployment** — `deploy/trading-bot.service` (a unit modelled on dccd's,
+  `Restart=on-failure`, hardened, **pyenv**-based `ExecStart`, loopback control UI) plus
+  `doc/dev/10-deploy.md` (install recipe, SSH-tunnel to the dashboard, operational
+  notes). The daemon is restart-safe, so the supervisor recovers state on every restart.
+  Completes the control-plane daemon. (#97)
 - **Control plane — the daemon's dashboard can start/stop strategies and switch mode.**
   `interfaces.api.create_control_app(supervisor)` serves a **read+write** dashboard over
   the `StrategySupervisor`: `GET /api/strategies`, `POST /api/strategies/{name}/start`,

--- a/deploy/trading-bot.service
+++ b/deploy/trading-bot.service
@@ -1,0 +1,73 @@
+# systemd unit for the trading_bot daemon (supervisor + scheduler + control UI).
+#
+# Install (pyenv — the blessed path on this machine; adjust the version/paths):
+#
+#   # 1) a pyenv interpreter/venv with trading_bot installed:
+#   pyenv install -s 3.12.13
+#   pyenv virtualenv 3.12.13 trading-bot           # (optional) a named venv
+#   ~/.pyenv/versions/trading-bot/bin/pip install -e /home/arthur/dev/Trading_Bot[daemon]
+#   #   …or a plain version: ~/.pyenv/versions/3.12.13/bin/pip install -e .[daemon]
+#
+#   # 2) config + credentials (NEVER world-readable):
+#   sudo install -d -m 0750 /etc/trading-bot
+#   sudo cp your-config.yaml      /etc/trading-bot/config.yaml      # paper by default
+#   sudo install -m 0600 your.env /etc/trading-bot/trading-bot.env  # KRAKEN_/BINANCE_ keys
+#
+#   # 3) edit ExecStart below to YOUR pyenv path + User=, then:
+#   sudo cp deploy/trading-bot.service /etc/systemd/system/trading-bot.service
+#   sudo systemctl daemon-reload && sudo systemctl enable --now trading-bot
+#   journalctl -u trading-bot -f                                    # watch it
+#
+# The daemon boots every declared strategy in its configured mode (PAPER by
+# default — it never trades real money by merely starting). Switch a strategy to
+# testnet/live from the control dashboard (http://127.0.0.1:8000) — going live
+# needs the typed confirmation there. The control UI binds loopback; reach it over
+# an SSH tunnel (ssh -L 8000:127.0.0.1:8000 host), never expose it publicly.
+
+[Unit]
+Description=trading_bot — execution daemon (supervisor + scheduler + control UI)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Run as a real user whose pyenv holds the install (simplest with pyenv in $HOME);
+# or create a dedicated 'trading-bot' system user and point the paths at its home.
+User=arthur
+Group=arthur
+
+# Credentials (Kraken/Binance keys) — kept out of the unit, 0600, never logged.
+EnvironmentFile=/etc/trading-bot/trading-bot.env
+
+# The pyenv-managed console script — adjust the version/venv name to your install.
+ExecStart=%h/.pyenv/versions/trading-bot/bin/trading-bot start \
+    --config /etc/trading-bot/config.yaml \
+    --serve --serve-host 127.0.0.1 --serve-port 8000
+
+WorkingDirectory=%S/trading-bot
+Restart=on-failure
+RestartSec=5
+# Give the daemon time to drain (reconcile/shut down each engine) before SIGKILL.
+TimeoutStopSec=60
+
+# Logs go to the journal: `journalctl -u trading-bot [-f]`. The daemon writes no
+# log files of its own; journald handles rotation.
+
+# Resource limits — uncomment and tune for your host.
+#MemoryMax=1G
+#CPUQuota=150%
+#TasksMax=256
+
+# State dir: systemd creates/owns /var/lib/trading-bot (the engine's SqliteStore,
+# if storage.db_path points here).
+StateDirectory=trading-bot
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+ReadWritePaths=%S/trading-bot
+
+[Install]
+WantedBy=multi-user.target

--- a/doc/dev/10-deploy.md
+++ b/doc/dev/10-deploy.md
@@ -1,0 +1,80 @@
+# Deploy — running the daemon under systemd
+
+How to keep `trading_bot` running as a supervised daemon (like dccd's `dccd start`
++ `dccd.service`), with the control dashboard for start/stop + mode switching.
+
+> **Paper by default.** The daemon boots every declared strategy in its configured
+> mode — **paper** unless you say otherwise. It **never trades real money by merely
+> starting**: going live is a deliberate act from the control dashboard (a typed
+> confirmation) and still requires the `live_enabled` + credentials + risk-limit
+> gates (`09-go-live.md`).
+
+## What the daemon is
+
+`trading-bot start` is the long-running process:
+
+- builds a `StrategySupervisor` — **one engine per strategy** (own broker/mode), so
+  strategies can be started/stopped and switched **paper / testnet / live**
+  independently;
+- starts every declared strategy and **re-evaluates** them on a schedule
+  (`--interval SECONDS`, idempotent ticks, or `--cron "m h * * *"`);
+- with `--serve`, serves the **control dashboard** over HTTP (loopback by default).
+
+```bash
+# foreground, for a quick look (paper):
+trading-bot start -c config.yaml --serve            # dashboard on http://127.0.0.1:8000
+trading-bot start -c config.yaml --cron "5 0 * * *" # re-evaluate daily at 00:05
+```
+
+The dashboard lists each strategy with a **mode selector** and **start/stop**
+buttons. Switching a strategy to **live** prompts for a typed `I UNDERSTAND` and
+sends `confirm: true`; the server refuses live without it (`403`).
+
+## systemd (pyenv)
+
+The repo ships [`deploy/trading-bot.service`](../../deploy/trading-bot.service) — a
+unit modelled on dccd's, using a **pyenv**-managed console script (this machine
+prefers pyenv over a project venv). Its header has the full install recipe; the
+essentials:
+
+```bash
+# 1) a pyenv interpreter/venv with trading_bot installed:
+pyenv install -s 3.12.13
+pyenv virtualenv 3.12.13 trading-bot
+~/.pyenv/versions/trading-bot/bin/pip install -e ~/dev/Trading_Bot[daemon]
+
+# 2) config + credentials (never world-readable):
+sudo install -d -m 0750 /etc/trading-bot
+sudo cp config.yaml      /etc/trading-bot/config.yaml         # paper by default
+sudo install -m 0600 .env /etc/trading-bot/trading-bot.env    # KRAKEN_/BINANCE_ keys
+
+# 3) edit ExecStart (your pyenv path) + User= in the unit, then:
+sudo cp deploy/trading-bot.service /etc/systemd/system/trading-bot.service
+sudo systemctl daemon-reload && sudo systemctl enable --now trading-bot
+journalctl -u trading-bot -f                                   # watch it
+```
+
+`Restart=on-failure` keeps it alive across crashes; the engine is **restart-safe**
+(on each (re)start it restores the router's dedup map from the store and reconciles
+to the venue), so a restart converges state rather than duplicating orders.
+
+### Reaching the dashboard
+
+The control UI binds **loopback** (`127.0.0.1`) on purpose — it can change what
+trades. Reach it over an SSH tunnel, never expose it publicly:
+
+```bash
+ssh -L 8000:127.0.0.1:8000 your-host    # then open http://localhost:8000
+```
+
+### Operational notes
+
+- **Logs**: `journalctl -u trading-bot [-f]` (the daemon writes no log files of its
+  own).
+- **State / DB**: point `storage.db_path` at `/var/lib/trading-bot/…` (the unit's
+  `StateDirectory`, which is the only writable path under the hardening directives).
+- **Stop / restart**: `systemctl stop|restart trading-bot` — the daemon drains and
+  shuts every engine down gracefully within `TimeoutStopSec`.
+- **Going live**: flip a strategy to `live` from the dashboard (typed confirmation),
+  with credentials present and `RiskConfig` limits set — see `09-go-live.md`. Until
+  you do, every strategy stays in paper/testnet (no real order).

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -28,6 +28,10 @@ done. The authoritative working rules live in the repo-root `CLAUDE.md`.
 5. [`05-testing.md`](05-testing.md) — testing layers and the "test the chain on
    real data" discipline for an execution engine.
 6. [`06-status.md`](06-status.md) — what's done, what's pending, known gaps.
+7. [`09-go-live.md`](09-go-live.md) — the go-live runbook (opt-in gates, pre-trade
+   checklist, proven-vs-pending) — read before trading real money.
+8. [`10-deploy.md`](10-deploy.md) — running the daemon under systemd (pyenv) + the
+   control dashboard.
 
 ## Tools kept here
 


### PR DESCRIPTION
## Summary
- `deploy/trading-bot.service` — a hardened systemd unit (`Restart=on-failure`, `NoNewPrivileges`/`ProtectSystem`/…, `StateDirectory`), **pyenv**-based `ExecStart`, running `trading-bot start --serve` (loopback control UI). Modelled on dccd's unit.
- `doc/dev/10-deploy.md` — install recipe (pyenv), SSH-tunnel to the dashboard, operational notes (logs, state/DB, going live).

## Why
- The "keep it active comme dccd" ask: a supervised, kept-alive daemon. The engine is restart-safe (restore + reconcile per engine), so `Restart=on-failure` converges state rather than duplicating orders. Loopback-only UI (it can change what trades) — reach it over SSH.

## Notes
- Uses **pyenv** paths (the user prefers pyenv over a project venv).
- Paper by default; going live is deliberate from the dashboard (typed confirmation) + the usual gates.

## Test plan
- [x] docs/deploy only; `pytest` 751 passed; `ruff` clean
- [ ] CI green