### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [0.6.0] - 2026-06-30
+
+### Added
+
 - **systemd deployment** — `deploy/trading-bot.service` (a unit modelled on dccd's,
   `Restart=on-failure`, hardened, **pyenv**-based `ExecStart`, loopback control UI) plus
   `doc/dev/10-deploy.md` (install recipe, SSH-tunnel to the dashboard, operational

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trading_bot"
-version = "0.5.0"
+version = "0.6.0"
 description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first."
 readme = "README.md"
 license = { text = "MIT" }


### PR DESCRIPTION
## Release v0.6.0 — the control-plane daemon

Freezes `[Unreleased]` into `## [0.6.0] - 2026-06-30`, bumps `pyproject.toml` to `0.6.0`.

### Highlights — keep-it-running + control from the UI
- **`trading-bot start`** — the supervised daemon (per-strategy engines, scheduler), with `--serve` for the control dashboard.
- **Control plane** — start/stop strategies + switch **paper/testnet/live** from the dashboard; **real money gated** (typed confirmation).
- **`StrategySupervisor`** + `step_latest`/`rebalance_latest` (the per-strategy lifecycle + scheduler primitive).
- **systemd** unit (`deploy/trading-bot.service`, pyenv) + `doc/dev/10-deploy.md`.
- **Fixed**: `__version__` reads from metadata (was stuck at 0.2.0).

751 tests green; ruff + mypy clean.