### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`trading_bot.__version__` now reads from installed metadata** instead of a
+  hand-bumped constant that the release flow never updated — it had been stuck at
+  `"0.2.0"` across 0.3/0.4/0.5, so `trading-bot version` and the dashboard showed a
+  stale version. Now always matches `pyproject.toml` (the single release source). (#92)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `StrategyRunner.step_latest()` / `PortfolioRunner.rebalance_latest()` — a single,
+  idempotent re-evaluation over the feed's **latest** data (vs `run`, which drains the
+  feed once). The primitive a scheduler-driven daemon calls each tick: a tick over
+  unchanged data trades nothing (already on target). Foundation for the control-plane
+  daemon. (#93)
+
 ### Changed
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `application.StrategySupervisor` — manages each declared strategy/portfolio as an
+  **independent unit** in its **own** engine (own broker/mode), so a strategy can be
+  started/stopped and switched between **paper / testnet / live independently**
+  (`start` / `stop` / `set_mode` / `step` / `status`). Restart-safe (restore + reconcile
+  per engine on start). **Real money is gated**: `set_mode(..., "live")` raises unless an
+  explicit `confirm_live=True` is passed (the control plane's deliberate acknowledgement);
+  paper ↔ testnet need none. The control-plane core behind the daemon + dashboard. (#94)
 - `StrategyRunner.step_latest()` / `PortfolioRunner.rebalance_latest()` — a single,
   idempotent re-evaluation over the feed's **latest** data (vs `run`, which drains the
   feed once). The primitive a scheduler-driven daemon calls each tick: a tick over

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **systemd deployment** — `deploy/trading-bot.service` (a unit modelled on dccd's,
+  `Restart=on-failure`, hardened, **pyenv**-based `ExecStart`, loopback control UI) plus
+  `doc/dev/10-deploy.md` (install recipe, SSH-tunnel to the dashboard, operational
+  notes). The daemon is restart-safe, so the supervisor recovers state on every restart.
+  Completes the control-plane daemon. (#97)
 - **Control plane — the daemon's dashboard can start/stop strategies and switch mode.**
   `interfaces.api.create_control_app(supervisor)` serves a **read+write** dashboard over
   the `StrategySupervisor`: `GET /api/strategies`, `POST /api/strategies/{name}/start`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Control plane — the daemon's dashboard can start/stop strategies and switch mode.**
+  `interfaces.api.create_control_app(supervisor)` serves a **read+write** dashboard over
+  the `StrategySupervisor`: `GET /api/strategies`, `POST /api/strategies/{name}/start`,
+  `.../stop`, `.../mode`. `trading-bot start --serve` runs it (loopback by default — it
+  can change what trades) alongside the scheduler. The dashboard (`control.html` +
+  `control.js`) lists each strategy with a mode selector + start/stop buttons.
+  **Real money is gated**: switching to `live` requires a typed confirmation in the UI
+  and `confirm: true` on the endpoint — the server returns `403` otherwise, changing
+  nothing. (#96)
 - **`trading-bot start` — the trading daemon.** A long-running process (systemd's
   `ExecStart`) that builds a `StrategySupervisor`, starts every declared strategy (in its
   configured mode — **paper by default**), and re-evaluates them on an `--interval`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`trading-bot start` — the trading daemon.** A long-running process (systemd's
+  `ExecStart`) that builds a `StrategySupervisor`, starts every declared strategy (in its
+  configured mode — **paper by default**), and re-evaluates them on an `--interval`
+  (idempotent ticks) or `--cron` schedule via `apscheduler`, until `SIGINT`/`SIGTERM`
+  (then shuts every unit down gracefully). Each strategy runs in its own engine, so they
+  can be switched paper/testnet/live independently from the control plane. Starting never
+  trades real money by itself (the live gates still apply). `StrategySupervisor` gains
+  `start_all` / `step_all` for the daemon's boot/tick. (#95)
 - `application.StrategySupervisor` — manages each declared strategy/portfolio as an
   **independent unit** in its **own** engine (own broker/mode), so a strategy can be
   started/stopped and switched between **paper / testnet / live independently**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [0.6.0] - 2026-06-30
+
+### Added
+
 - **systemd deployment** — `deploy/trading-bot.service` (a unit modelled on dccd's,
   `Restart=on-failure`, hardened, **pyenv**-based `ExecStart`, loopback control UI) plus
   `doc/dev/10-deploy.md` (install recipe, SSH-tunnel to the dashboard, operational

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,34 +57,22 @@ ruff check trading_bot/
 mypy trading_bot/
 ```
 
-## Git Flow
+## Common conventions
 
-**Branch model:**
-```
-master          ← stable releases only (tagged vX.Y.Z)
-  └── develop   ← integration branch
-        ├── feat/<topic>   new feature or rewrite axis
-        ├── fix/<topic>    bug fix
-        ├── chore/<topic>  tooling, CI, deps
-        └── docs/<topic>   documentation only
-```
+Shared across my repos, mirrored from `~/.claude/CLAUDE.md` (the single source of
+truth — if they ever disagree, the global file wins). Restated here so the repo
+stays self-contained:
 
-**Rules — always follow these before committing or pushing:**
-1. **Never commit directly to `master`.**
-2. **Never commit directly to `develop`** — always use a feature branch + PR.
-3. Branch off `develop`: `git checkout develop && git checkout -b feat/my-topic`
-4. Open a PR into `develop` when done. `develop` → `master` only at release time.
-
-**Commit style (Conventional Commits):** `feat:`, `fix:`, `chore:`, `docs:`.
-
-Do not add `Co-Authored-By` trailers to commits — this is a personal repo (parity
-with dccd/fynance).
-
-**Before every commit:** run `pytest` and `ruff check trading_bot/`. Both must pass.
-
-**One PR = one concern, small and disposable.** Even a large plan ships as
-*several* small atomic PRs — never one fourre-tout branch. This is what makes
-`/abandon-task` (kill a bad PR, keep the lesson) viable.
+- **Git Flow** — `master` (tagged releases) ← `develop` (integration) ←
+  `feat|fix|chore|docs/<topic>`. **Never commit directly to `develop` or `master`**
+  — always a feature branch + PR into `develop`; `develop` → `master` only at release.
+- **Conventional Commits** — `feat:` `fix:` `chore:` `docs:`. **Never add
+  `Co-Authored-By` trailers** (personal repo).
+- **One PR = one concern**, small and disposable — a big plan ships as several small
+  atomic PRs, never one catch-all branch.
+- **Model: `opus`, always** — interactive sessions and every spawned subagent; a plan
+  leaf's `complexity` is effort/ordering only and never downgrades the model.
+- **Before every commit** — `.venv/bin/python -m pytest` and `.venv/bin/ruff check trading_bot/` must pass.
 
 ### Dev loop & docs of record
 
@@ -98,7 +86,9 @@ sources of truth:
 | `doc/dev/03-decisions.md` | the *why* — ADR journal | `/finish-task` (accepted), `/abandon-task` (rejected/tombstone) |
 | `doc/dev/06-status.md` | where things stand | `/finish-task`, `/groom-docs` |
 
-`CHANGELOG.md` + git log stay authoritative for *what* shipped. The loop:
+`CHANGELOG.md` + git log stay authoritative for *what* shipped. The "one PR = one
+concern" rule is what makes `/abandon-task` (kill a bad PR, keep the lesson)
+viable. The loop:
 
 `/pick-task` (smallest coherent slice; **no branch yet**) →
 `/plan` (decompose into a `doc/dev/plans/<epic>/` tree — single leaf for a trivial
@@ -111,12 +101,6 @@ real data**) →
 checklist) → … per leaf … → last leaf removes the roadmap line → `/release`.
 
 The full plan-tree format lives in [`doc/dev/plans/README.md`](doc/dev/plans/README.md).
-
-**Model: `opus`, always.** Per the maintainer's standing preference, **all work on
-this repo runs on `opus`** — interactive sessions *and* every spawned subagent
-(including `/execute-leaf`), regardless of a leaf's `complexity`. The `complexity`
-tag still records effort/risk and orders the execution queue, but it **does not
-downgrade the model**: treat `low | medium | high` all as `opus`.
 
 ## Architecture (target — hexagonal, mirrors dccd)
 

--- a/deploy/trading-bot.service
+++ b/deploy/trading-bot.service
@@ -1,0 +1,73 @@
+# systemd unit for the trading_bot daemon (supervisor + scheduler + control UI).
+#
+# Install (pyenv — the blessed path on this machine; adjust the version/paths):
+#
+#   # 1) a pyenv interpreter/venv with trading_bot installed:
+#   pyenv install -s 3.12.13
+#   pyenv virtualenv 3.12.13 trading-bot           # (optional) a named venv
+#   ~/.pyenv/versions/trading-bot/bin/pip install -e /home/arthur/dev/Trading_Bot[daemon]
+#   #   …or a plain version: ~/.pyenv/versions/3.12.13/bin/pip install -e .[daemon]
+#
+#   # 2) config + credentials (NEVER world-readable):
+#   sudo install -d -m 0750 /etc/trading-bot
+#   sudo cp your-config.yaml      /etc/trading-bot/config.yaml      # paper by default
+#   sudo install -m 0600 your.env /etc/trading-bot/trading-bot.env  # KRAKEN_/BINANCE_ keys
+#
+#   # 3) edit ExecStart below to YOUR pyenv path + User=, then:
+#   sudo cp deploy/trading-bot.service /etc/systemd/system/trading-bot.service
+#   sudo systemctl daemon-reload && sudo systemctl enable --now trading-bot
+#   journalctl -u trading-bot -f                                    # watch it
+#
+# The daemon boots every declared strategy in its configured mode (PAPER by
+# default — it never trades real money by merely starting). Switch a strategy to
+# testnet/live from the control dashboard (http://127.0.0.1:8000) — going live
+# needs the typed confirmation there. The control UI binds loopback; reach it over
+# an SSH tunnel (ssh -L 8000:127.0.0.1:8000 host), never expose it publicly.
+
+[Unit]
+Description=trading_bot — execution daemon (supervisor + scheduler + control UI)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+# Run as a real user whose pyenv holds the install (simplest with pyenv in $HOME);
+# or create a dedicated 'trading-bot' system user and point the paths at its home.
+User=arthur
+Group=arthur
+
+# Credentials (Kraken/Binance keys) — kept out of the unit, 0600, never logged.
+EnvironmentFile=/etc/trading-bot/trading-bot.env
+
+# The pyenv-managed console script — adjust the version/venv name to your install.
+ExecStart=%h/.pyenv/versions/trading-bot/bin/trading-bot start \
+    --config /etc/trading-bot/config.yaml \
+    --serve --serve-host 127.0.0.1 --serve-port 8000
+
+WorkingDirectory=%S/trading-bot
+Restart=on-failure
+RestartSec=5
+# Give the daemon time to drain (reconcile/shut down each engine) before SIGKILL.
+TimeoutStopSec=60
+
+# Logs go to the journal: `journalctl -u trading-bot [-f]`. The daemon writes no
+# log files of its own; journald handles rotation.
+
+# Resource limits — uncomment and tune for your host.
+#MemoryMax=1G
+#CPUQuota=150%
+#TasksMax=256
+
+# State dir: systemd creates/owns /var/lib/trading-bot (the engine's SqliteStore,
+# if storage.db_path points here).
+StateDirectory=trading-bot
+
+# Hardening
+NoNewPrivileges=true
+ProtectSystem=strict
+ProtectHome=read-only
+PrivateTmp=true
+ReadWritePaths=%S/trading-bot
+
+[Install]
+WantedBy=multi-user.target

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,35 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-30 Control plane: per-strategy engines + a gated `StrategySupervisor` (PR #94)  [accepted]
+
+**Choice.** The control plane (start/stop a strategy, switch its mode from the UI) is
+built on a `StrategySupervisor` that splits the config into one **unit per strategy/
+portfolio**, each running in its **own** `build_engine` (own broker / mode / tracker /
+PnL). `start` / `stop` / `set_mode` / `step` / `status` per unit; `step` calls
+`step_latest` / `rebalance_latest`. Real money is gated: `set_mode(..., "live")` raises
+`LiveTradingNotEnabled` unless `confirm_live=True` (the UI's typed acknowledgement);
+paper ↔ testnet are free. The factory's existing gates (credentials, mandatory risk
+limits) still fire when the live engine is actually built on `start`.
+
+**Why.** Per-strategy **mode** (one strategy in testnet, another in live) is impossible
+under the single shared engine (`run_app`), which has one broker for the whole system.
+A per-strategy engine is just `build_engine` over a one-strategy config slice — the
+factory already does the wiring — so the supervisor is a thin manager over N engines.
+Per-strategy engines also dissolve the commingling problem (each unit has its own
+tracker), so the single-engine `_reject_commingled` concern doesn't arise. Gating live
+at `set_mode` preserves the "no real order by accident" invariant now that a UI can flip
+modes — matching the chosen posture (paper/testnet free, prod a deliberate confirmation).
+
+**Rejected alternatives.** One engine with multiple brokers and per-strategy routing
+(the `OrderRouter` binds to one broker; per-strategy routing is effectively per-strategy
+engines anyway, with more coupling); letting the UI flip to real money with no
+confirmation (rejected by the maintainer — keep prod deliberate); a heavyweight
+process-per-strategy supervisor (in-process units are lighter and share the daemon's
+loop/scheduler — wired next).
+
+---
+
 ### 2026-06-29 Live monitoring via `run --serve` over the same engine (PR #89)  [accepted]
 
 **Choice.** A `--serve` flag on `trading-bot run` serves the read-only dashboard

--- a/doc/dev/10-deploy.md
+++ b/doc/dev/10-deploy.md
@@ -1,0 +1,80 @@
+# Deploy — running the daemon under systemd
+
+How to keep `trading_bot` running as a supervised daemon (like dccd's `dccd start`
++ `dccd.service`), with the control dashboard for start/stop + mode switching.
+
+> **Paper by default.** The daemon boots every declared strategy in its configured
+> mode — **paper** unless you say otherwise. It **never trades real money by merely
+> starting**: going live is a deliberate act from the control dashboard (a typed
+> confirmation) and still requires the `live_enabled` + credentials + risk-limit
+> gates (`09-go-live.md`).
+
+## What the daemon is
+
+`trading-bot start` is the long-running process:
+
+- builds a `StrategySupervisor` — **one engine per strategy** (own broker/mode), so
+  strategies can be started/stopped and switched **paper / testnet / live**
+  independently;
+- starts every declared strategy and **re-evaluates** them on a schedule
+  (`--interval SECONDS`, idempotent ticks, or `--cron "m h * * *"`);
+- with `--serve`, serves the **control dashboard** over HTTP (loopback by default).
+
+```bash
+# foreground, for a quick look (paper):
+trading-bot start -c config.yaml --serve            # dashboard on http://127.0.0.1:8000
+trading-bot start -c config.yaml --cron "5 0 * * *" # re-evaluate daily at 00:05
+```
+
+The dashboard lists each strategy with a **mode selector** and **start/stop**
+buttons. Switching a strategy to **live** prompts for a typed `I UNDERSTAND` and
+sends `confirm: true`; the server refuses live without it (`403`).
+
+## systemd (pyenv)
+
+The repo ships [`deploy/trading-bot.service`](../../deploy/trading-bot.service) — a
+unit modelled on dccd's, using a **pyenv**-managed console script (this machine
+prefers pyenv over a project venv). Its header has the full install recipe; the
+essentials:
+
+```bash
+# 1) a pyenv interpreter/venv with trading_bot installed:
+pyenv install -s 3.12.13
+pyenv virtualenv 3.12.13 trading-bot
+~/.pyenv/versions/trading-bot/bin/pip install -e ~/dev/Trading_Bot[daemon]
+
+# 2) config + credentials (never world-readable):
+sudo install -d -m 0750 /etc/trading-bot
+sudo cp config.yaml      /etc/trading-bot/config.yaml         # paper by default
+sudo install -m 0600 .env /etc/trading-bot/trading-bot.env    # KRAKEN_/BINANCE_ keys
+
+# 3) edit ExecStart (your pyenv path) + User= in the unit, then:
+sudo cp deploy/trading-bot.service /etc/systemd/system/trading-bot.service
+sudo systemctl daemon-reload && sudo systemctl enable --now trading-bot
+journalctl -u trading-bot -f                                   # watch it
+```
+
+`Restart=on-failure` keeps it alive across crashes; the engine is **restart-safe**
+(on each (re)start it restores the router's dedup map from the store and reconciles
+to the venue), so a restart converges state rather than duplicating orders.
+
+### Reaching the dashboard
+
+The control UI binds **loopback** (`127.0.0.1`) on purpose — it can change what
+trades. Reach it over an SSH tunnel, never expose it publicly:
+
+```bash
+ssh -L 8000:127.0.0.1:8000 your-host    # then open http://localhost:8000
+```
+
+### Operational notes
+
+- **Logs**: `journalctl -u trading-bot [-f]` (the daemon writes no log files of its
+  own).
+- **State / DB**: point `storage.db_path` at `/var/lib/trading-bot/…` (the unit's
+  `StateDirectory`, which is the only writable path under the hardening directives).
+- **Stop / restart**: `systemctl stop|restart trading-bot` — the daemon drains and
+  shuts every engine down gracefully within `TimeoutStopSec`.
+- **Going live**: flip a strategy to `live` from the dashboard (typed confirmation),
+  with credentials present and `RiskConfig` limits set — see `09-go-live.md`. Until
+  you do, every strategy stays in paper/testnet (no real order).

--- a/doc/dev/README.md
+++ b/doc/dev/README.md
@@ -28,6 +28,10 @@ done. The authoritative working rules live in the repo-root `CLAUDE.md`.
 5. [`05-testing.md`](05-testing.md) — testing layers and the "test the chain on
    real data" discipline for an execution engine.
 6. [`06-status.md`](06-status.md) — what's done, what's pending, known gaps.
+7. [`09-go-live.md`](09-go-live.md) — the go-live runbook (opt-in gates, pre-trade
+   checklist, proven-vs-pending) — read before trading real money.
+8. [`10-deploy.md`](10-deploy.md) — running the daemon under systemd (pyenv) + the
+   control dashboard.
 
 ## Tools kept here
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trading_bot"
-version = "0.5.0"
+version = "0.6.0"
 description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first."
 readme = "README.md"
 license = { text = "MIT" }

--- a/trading_bot/__init__.py
+++ b/trading_bot/__init__.py
@@ -10,6 +10,14 @@ package). See ``doc/dev/07-roadmap.md`` for the rewrite roadmap.
 """
 from __future__ import annotations
 
-__version__ = "0.2.0"
+from importlib import metadata
+
+try:
+    #: The installed package version — read from metadata so it always matches
+    #: ``pyproject.toml`` (the single release source) instead of a hand-bumped
+    #: string that silently goes stale across releases.
+    __version__ = metadata.version("trading_bot")
+except metadata.PackageNotFoundError:  # pragma: no cover - not installed (raw checkout)
+    __version__ = "0.0.0+unknown"
 
 __all__ = ["__version__"]

--- a/trading_bot/application/__init__.py
+++ b/trading_bot/application/__init__.py
@@ -176,6 +176,10 @@ from trading_bot.application.strategy import (
     ma_crossover_signal,
 )
 from trading_bot.application.strategy_runner import OrderFactory, StrategyRunner
+from trading_bot.application.supervisor import (
+    StrategyStatus,
+    StrategySupervisor,
+)
 
 __all__ = [
     # config
@@ -199,6 +203,8 @@ __all__ = [
     "RiskManager",
     "LiveFillStreamer",
     "FillSource",
+    "StrategySupervisor",
+    "StrategyStatus",
     "reconcile",
     "ReconResult",
     # data feed

--- a/trading_bot/application/portfolio_runner.py
+++ b/trading_bot/application/portfolio_runner.py
@@ -430,6 +430,32 @@ class PortfolioRunner:
 
         return RebalanceResult(submitted=submitted, failures=failures)
 
+    async def rebalance_latest(self) -> RebalanceResult | None:
+        """Rebalance the book over the feed's **latest** cross-section — for a daemon.
+
+        Reads the feed's most recent causal cross-section (the last one a fresh
+        iteration yields — a live :class:`~trading_bot.application.portfolio_feed
+        .PortfolioFeed` re-reads the dccd store each iteration) and runs **one**
+        :meth:`rebalance` over it. Where :meth:`run` *drains* the feed once
+        (replay/backtest), this is the single, on-demand rebalance a
+        **scheduler-driven daemon** calls each tick: per-coin deltas are computed
+        against the live tracker, so a tick over unchanged weights/data submits
+        nothing and only changed targets trade. Idempotent under repetition.
+
+        Returns
+        -------
+        RebalanceResult or None
+            The tick's result, or ``None`` if the feed currently yields no closed
+            cross-section (e.g. the universe has no common closed bar yet).
+
+        """
+        latest: Mapping[Symbol, pl.DataFrame] | None = None
+        for frames in self._feed:  # type: ignore[attr-defined]
+            latest = frames
+        if latest is None:
+            return None
+        return await self.rebalance(latest)
+
     def _build_order(
         self,
         symbol: Symbol,

--- a/trading_bot/application/strategy_runner.py
+++ b/trading_bot/application/strategy_runner.py
@@ -319,6 +319,28 @@ class StrategyRunner:
             )
         return submitted
 
+    async def step_latest(self) -> Order | None:
+        """Process **one** step over the feed's **latest** window — for a daemon.
+
+        Reads the feed's full known frame (:meth:`~trading_bot.application.data_feed
+        .DataFeed.latest`, which re-reads the dccd store for a live feed) and runs
+        one :meth:`step` over it. Where :meth:`run` *drains* the feed once
+        (replay/backtest), this is the single, on-demand re-evaluation a
+        **scheduler-driven daemon** calls each tick: the delta is computed against
+        the live tracker position, so a tick over unchanged data submits nothing
+        (already on target) and only a changed target trades. Idempotent under
+        repetition. The step index still advances (so a tick that *does* trade
+        carries a fresh, unique ``client_order_id``).
+
+        Returns
+        -------
+        Order or None
+            The submitted order, or ``None`` if the latest re-evaluation was on
+            target (``delta == 0``) or in warmup.
+
+        """
+        return await self.step(self._feed.latest())
+
     def _build_order(self, delta: Money, bars: pl.DataFrame, step: int) -> Order:
         """Build the step's order, stamping the deterministic per-step id.
 

--- a/trading_bot/application/supervisor.py
+++ b/trading_bot/application/supervisor.py
@@ -1,0 +1,339 @@
+"""The :class:`StrategySupervisor` — each declared strategy as an independent unit.
+
+Where :func:`~trading_bot.application.run_app.run_app` builds **one** shared engine
+for the whole config, the supervisor splits the config into per-strategy /
+per-portfolio **units**, each running in its **own**
+:func:`~trading_bot.application.service_factory.build_engine` (its own broker,
+mode, tracker, PnL). That is what lets a strategy be **started, stopped and
+switched between paper / testnet / live independently** — the control plane behind
+the daemon and the dashboard. Because each unit owns its engine, there is no
+cross-unit commingling (the single-engine path's
+:func:`~trading_bot.application.run_app._reject_commingled` concern does not arise
+here).
+
+Modes (carried into the ADR)
+----------------------------
+A unit's :data:`StrategyMode` maps to an :class:`~trading_bot.application.config.
+AppConfig` slice:
+
+* ``"paper"`` — ``mode: paper`` (the simulator; no venue, no key).
+* ``"testnet"`` — ``mode: live`` + every broker ``testnet: true`` (paper money on
+  the real sandbox; mainnet-incapable, so no ``live_enabled`` needed).
+* ``"live"`` — ``mode: live`` + ``live_enabled: true`` + brokers ``testnet: false``
+  (**real money**).
+
+**Real money is gated.** :meth:`set_mode` to ``"live"`` raises unless an explicit
+``confirm_live=True`` is passed — the deliberate acknowledgement the control API /
+UI obtains (a typed confirmation), never a casual flip. Paper ↔ testnet need no
+confirmation. The usual factory gates (credentials, the risk-limit requirement)
+still apply when the live engine is actually built on :meth:`start`.
+
+This module is part of the application layer: it composes the factory and the
+runners, holds money as :class:`~decimal.Decimal`, and performs venue I/O only
+through the engines it builds (reconcile on start; the runners' router/broker).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+from trading_bot.application.reconcile import reconcile
+from trading_bot.application.run_app import build_portfolio_runners, build_runners
+from trading_bot.application.service_factory import Engine, build_engine
+from trading_bot.domain.errors import ConfigError, LiveTradingNotEnabled
+
+if TYPE_CHECKING:
+    from trading_bot.application.config import AppConfig
+    from trading_bot.application.data_provider import DccdClient
+    from trading_bot.application.portfolio_runner import PortfolioRunner
+    from trading_bot.application.strategy_runner import StrategyRunner
+    from trading_bot.domain.money import Money
+    from trading_bot.domain.order import Order
+
+__all__ = ["StrategyMode", "StrategyStatus", "StrategySupervisor"]
+
+#: The deployment mode of a managed strategy.
+StrategyMode = Literal["paper", "testnet", "live"]
+
+_KIND = Literal["strategy", "portfolio"]
+
+
+@dataclass(frozen=True, slots=True)
+class StrategyStatus:
+    """A read-only snapshot of one managed strategy's state (for the API / UI).
+
+    Attributes
+    ----------
+    name : str
+        The strategy/portfolio's logical id.
+    kind : {"strategy", "portfolio"}
+        Whether it is a single-instrument strategy or a multi-asset portfolio.
+    mode : StrategyMode
+        Its current deployment mode (``paper`` / ``testnet`` / ``live``).
+    running : bool
+        Whether it is started (its engine is built and steppable).
+    realised_pnl : Money or None
+        The unit engine's realised PnL when running, else ``None``.
+    open_orders : int
+        The number of orders the unit's router currently tracks as non-terminal
+        (``0`` when stopped).
+
+    """
+
+    name: str
+    kind: _KIND
+    mode: StrategyMode
+    running: bool
+    realised_pnl: Money | None
+    open_orders: int
+
+
+@dataclass
+class _Unit:
+    """One managed strategy: its config slice, mode, and (when running) engine."""
+
+    name: str
+    kind: _KIND
+    mode: StrategyMode
+    config: AppConfig
+    engine: Engine | None = None
+    runner: StrategyRunner | PortfolioRunner | None = None
+    running: bool = False
+
+
+class StrategySupervisor:
+    """Manage each declared strategy as an independently-deployable unit.
+
+    Splits ``base_config`` into one unit per declared strategy and portfolio, each
+    with its own engine and mode. Drive them with :meth:`start` / :meth:`stop` /
+    :meth:`set_mode` / :meth:`step`, and read state with :meth:`status`.
+
+    Parameters
+    ----------
+    base_config : AppConfig
+        The declared system. Its mode seeds every unit's initial mode; each unit
+        can then be switched independently.
+    dccd_client : DccdClient or None, optional
+        The dccd client every unit's feed reads through (injected for an offline
+        run/test). ``None`` lets each feed construct a real client.
+
+    """
+
+    def __init__(
+        self, base_config: AppConfig, *, dccd_client: DccdClient | None = None
+    ) -> None:
+        self._base = base_config
+        self._dccd_client = dccd_client
+        self._units: dict[str, _Unit] = {}
+        seed = _mode_of(base_config)
+        for strategy in base_config.strategies:
+            self._add_unit(strategy.name, "strategy", seed)
+        for portfolio in base_config.portfolios:
+            self._add_unit(portfolio.name, "portfolio", seed)
+
+    # --- registry ---------------------------------------------------------- #
+
+    def _add_unit(self, name: str, kind: _KIND, mode: StrategyMode) -> None:
+        if name in self._units:
+            raise ConfigError(
+                f"duplicate strategy name {name!r}: each managed unit needs a "
+                "unique name across strategies and portfolios"
+            )
+        config = self._slice_for(name, kind, mode)
+        self._units[name] = _Unit(name=name, kind=kind, mode=mode, config=config)
+
+    def names(self) -> list[str]:
+        """The managed strategy names, in registration order."""
+        return list(self._units)
+
+    def _unit(self, name: str) -> _Unit:
+        try:
+            return self._units[name]
+        except KeyError:
+            raise ConfigError(f"unknown strategy {name!r}") from None
+
+    # --- config slicing + mode mapping ------------------------------------- #
+
+    def _slice_for(self, name: str, kind: _KIND, mode: StrategyMode) -> AppConfig:
+        """The single-unit ``AppConfig`` for ``name`` in ``mode``."""
+        if kind == "strategy":
+            only = [s for s in self._base.strategies if s.name == name]
+            base_slice = self._base.model_copy(
+                update={"strategies": only, "portfolios": []}
+            )
+        else:
+            only_p = [p for p in self._base.portfolios if p.name == name]
+            base_slice = self._base.model_copy(
+                update={"strategies": [], "portfolios": only_p}
+            )
+        return _config_for_mode(base_slice, mode)
+
+    # --- lifecycle --------------------------------------------------------- #
+
+    async def start(self, name: str) -> None:
+        """Build the unit's engine (in its mode) and make it steppable.
+
+        Builds a fresh :class:`~trading_bot.application.service_factory.Engine` from
+        the unit's config, **restores** the router's dedup map from the store (if
+        any) and **reconciles** to the broker (a no-op on paper; the safety
+        backstop on a live/testnet venue), then builds the unit's runner. Idempotent
+        — starting an already-running unit is a no-op.
+
+        Raises
+        ------
+        LiveTradingNotEnabled or BrokerError
+            From the factory if a live/testnet unit lacks the opt-in/credentials/
+            risk limits (the usual go-live gates apply on the real build).
+
+        """
+        unit = self._unit(name)
+        if unit.running:
+            return
+        engine = build_engine(unit.config, db_path=unit.config.storage.db_path)
+        if engine.store is not None:
+            engine.router.restore(engine.store.orders())
+        await reconcile(
+            engine.broker, engine.router, engine.tracker, event_bus=engine.bus
+        )
+        if unit.kind == "strategy":
+            runners = build_runners(
+                unit.config, engine, dccd_client=self._dccd_client
+            )
+            unit.runner = runners[0]
+        else:
+            pruns = build_portfolio_runners(
+                unit.config, engine, dccd_client=self._dccd_client
+            )
+            unit.runner = pruns[0]
+        unit.engine = engine
+        unit.running = True
+
+    async def stop(self, name: str) -> None:
+        """Tear down the unit's engine — it is no longer stepped. Idempotent."""
+        unit = self._unit(name)
+        unit.running = False
+        unit.runner = None
+        unit.engine = None
+
+    async def set_mode(
+        self, name: str, mode: StrategyMode, *, confirm_live: bool = False
+    ) -> None:
+        """Switch a unit's mode (paper / testnet / live), restarting if running.
+
+        Real money is gated: ``mode="live"`` requires ``confirm_live=True`` — the
+        deliberate acknowledgement the control API / UI obtains (a typed
+        confirmation). Paper ↔ testnet need none. If the unit was running it is
+        stopped, re-sliced for the new mode, and started again (so the new engine /
+        broker takes effect immediately).
+
+        Raises
+        ------
+        LiveTradingNotEnabled
+            If ``mode == "live"`` without ``confirm_live`` — real money is never
+            engaged by a casual flip.
+
+        """
+        if mode == "live" and not confirm_live:
+            raise LiveTradingNotEnabled(
+                f"refusing to switch {name!r} to live (real money) without an "
+                "explicit confirmation; the control plane requires a deliberate "
+                "acknowledgement (see doc/dev/09-go-live.md). No order placed."
+            )
+        unit = self._unit(name)
+        was_running = unit.running
+        if was_running:
+            await self.stop(name)
+        unit.mode = mode
+        unit.config = self._slice_for(name, unit.kind, mode)
+        if was_running:
+            await self.start(name)
+
+    async def step(self, name: str) -> Order | object | None:
+        """Run **one** re-evaluation of the unit over the latest data.
+
+        Calls :meth:`~trading_bot.application.strategy_runner.StrategyRunner
+        .step_latest` (or
+        :meth:`~trading_bot.application.portfolio_runner.PortfolioRunner
+        .rebalance_latest`). A no-op (returns ``None``) when the unit is stopped.
+        This is what the daemon's scheduler calls per tick.
+        """
+        unit = self._unit(name)
+        if not unit.running or unit.runner is None:
+            return None
+        if unit.kind == "strategy":
+            from trading_bot.application.strategy_runner import StrategyRunner
+
+            assert isinstance(unit.runner, StrategyRunner)
+            return await unit.runner.step_latest()
+        from trading_bot.application.portfolio_runner import PortfolioRunner
+
+        assert isinstance(unit.runner, PortfolioRunner)
+        return await unit.runner.rebalance_latest()
+
+    async def shutdown(self) -> None:
+        """Stop every running unit (the daemon's graceful teardown)."""
+        for name in list(self._units):
+            await self.stop(name)
+
+    # --- read side --------------------------------------------------------- #
+
+    def status(self, name: str | None = None) -> list[StrategyStatus]:
+        """A snapshot of every unit's state (or just ``name`` if given)."""
+        names = [name] if name is not None else list(self._units)
+        return [self._status_of(self._unit(n)) for n in names]
+
+    @staticmethod
+    def _status_of(unit: _Unit) -> StrategyStatus:
+        realised: Money | None = None
+        open_orders = 0
+        if unit.running and unit.engine is not None:
+            realised = unit.engine.perf.realised_pnl()
+            open_orders = sum(
+                1
+                for order in unit.engine.router.tracked_orders().values()
+                if not order.is_terminal
+            )
+        return StrategyStatus(
+            name=unit.name,
+            kind=unit.kind,
+            mode=unit.mode,
+            running=unit.running,
+            realised_pnl=realised,
+            open_orders=open_orders,
+        )
+
+
+def _mode_of(config: AppConfig) -> StrategyMode:
+    """Infer a :data:`StrategyMode` from an :class:`AppConfig`'s mode/brokers."""
+    if config.mode == "paper":
+        return "paper"
+    if any(broker.testnet for broker in config.brokers):
+        return "testnet"
+    return "live"
+
+
+def _config_for_mode(base_slice: AppConfig, mode: StrategyMode) -> AppConfig:
+    """Rewrite a single-unit config for ``mode`` (paper / testnet / live).
+
+    ``testnet`` and ``live`` require at least one configured broker (the venue);
+    a unit with no broker can only run ``paper``.
+    """
+    if mode == "paper":
+        return base_slice.model_copy(
+            update={"mode": "paper", "live_enabled": False}
+        )
+    if not base_slice.brokers:
+        raise ConfigError(
+            f"cannot run mode {mode!r} without a configured broker; add a "
+            "'brokers' entry (the venue) or keep the strategy on paper"
+        )
+    testnet = mode == "testnet"
+    brokers = [b.model_copy(update={"testnet": testnet}) for b in base_slice.brokers]
+    return base_slice.model_copy(
+        update={
+            "mode": "live",
+            "live_enabled": mode == "live",
+            "brokers": brokers,
+        }
+    )

--- a/trading_bot/application/supervisor.py
+++ b/trading_bot/application/supervisor.py
@@ -271,6 +271,25 @@ class StrategySupervisor:
         assert isinstance(unit.runner, PortfolioRunner)
         return await unit.runner.rebalance_latest()
 
+    async def start_all(self) -> None:
+        """Start every managed unit (the daemon's boot — each in its config mode)."""
+        for name in list(self._units):
+            await self.start(name)
+
+    async def step_all(self) -> int:
+        """Step every **running** unit once — the daemon's per-tick action.
+
+        Returns the number of units stepped (running units; stopped units are
+        skipped). Each unit's :meth:`step` is idempotent over unchanged data, so a
+        tick that finds nothing to do trades nothing.
+        """
+        stepped = 0
+        for name in list(self._units):
+            if self._units[name].running:
+                await self.step(name)
+                stepped += 1
+        return stepped
+
     async def shutdown(self) -> None:
         """Stop every running unit (the daemon's graceful teardown)."""
         for name in list(self._units):

--- a/trading_bot/interfaces/api/__init__.py
+++ b/trading_bot/interfaces/api/__init__.py
@@ -13,6 +13,6 @@ The single entrypoint is :func:`~trading_bot.interfaces.api.app.create_app`.
 
 from __future__ import annotations
 
-from trading_bot.interfaces.api.app import create_app
+from trading_bot.interfaces.api.app import create_app, create_control_app
 
-__all__ = ["create_app"]
+__all__ = ["create_app", "create_control_app"]

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -70,6 +70,7 @@ from fastapi import FastAPI, Request
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
 
 import trading_bot
 from trading_bot.application.events import (
@@ -82,11 +83,15 @@ from trading_bot.interfaces.ui import STATIC_DIR, TEMPLATES_DIR
 
 if TYPE_CHECKING:
     from trading_bot.application.service_factory import Engine
+    from trading_bot.application.supervisor import (
+        StrategyStatus,
+        StrategySupervisor,
+    )
     from trading_bot.domain.fill import Fill
     from trading_bot.domain.order import Order
     from trading_bot.domain.position import Position
 
-__all__ = ["create_app"]
+__all__ = ["create_app", "create_control_app"]
 
 
 # ---------------------------------------------------------------------------
@@ -408,5 +413,155 @@ def create_app(engine: Engine) -> FastAPI:
                 bus.remove_queue(queue)
 
         return StreamingResponse(_generator(), media_type="text/event-stream")
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# The control app — the daemon's read+write dashboard over a StrategySupervisor
+# ---------------------------------------------------------------------------
+
+
+#: Valid deployment modes the control API accepts.
+_CONTROL_MODES = ("paper", "testnet", "live")
+
+
+class _ModeBody(BaseModel):
+    """Request body for ``POST /api/strategies/{name}/mode``.
+
+    ``confirm`` must be ``true`` to switch to ``live`` (real money) — the
+    deliberate acknowledgement; the endpoint refuses live without it.
+    """
+
+    mode: str
+    confirm: bool = False
+
+
+def _status_dict(status: StrategyStatus) -> dict[str, Any]:
+    """Render a :class:`StrategyStatus` for JSON (money as exact Decimal string)."""
+    return {
+        "name": status.name,
+        "kind": status.kind,
+        "mode": status.mode,
+        "running": status.running,
+        "realised_pnl": (
+            str(status.realised_pnl) if status.realised_pnl is not None else None
+        ),
+        "open_orders": status.open_orders,
+    }
+
+
+def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
+    """Build the daemon's **control** FastAPI over a :class:`StrategySupervisor`.
+
+    Unlike :func:`create_app` (a *read-only* view of one engine), this app is the
+    **control plane**: it lists the managed strategies and lets a client **start /
+    stop** them and **switch mode** (paper / testnet / live). It is meant to be
+    served **loopback-only** by the daemon, since it can change what trades.
+
+    **Real money is gated.** Switching a strategy to ``live`` requires
+    ``confirm: true`` in the request body — the deliberate acknowledgement the UI
+    obtains (a typed confirmation); otherwise the endpoint returns **403** and
+    nothing changes. The factory's credential + risk-limit gates still apply when a
+    live unit is actually started.
+
+    Parameters
+    ----------
+    supervisor : StrategySupervisor
+        The supervisor to expose, read+controlled through ``app.state.supervisor``.
+
+    Returns
+    -------
+    FastAPI
+        The control application (serve via uvicorn, or a ``TestClient``).
+
+    """
+    from fastapi import HTTPException
+
+    from trading_bot.domain.errors import (
+        BrokerError,
+        ConfigError,
+        LiveTradingNotEnabled,
+    )
+
+    app = FastAPI(
+        title="trading_bot control",
+        summary="Supervise + control the declared strategies (loopback-only).",
+        default_response_class=_DecimalJSONResponse,
+    )
+    app.state.supervisor = supervisor
+
+    def _sup(request: Request) -> StrategySupervisor:
+        return request.app.state.supervisor  # type: ignore[no-any-return]
+
+    if STATIC_DIR.is_dir():
+        app.mount("/static", StaticFiles(directory=str(STATIC_DIR)), name="static")
+    templates = (
+        Jinja2Templates(directory=str(TEMPLATES_DIR))
+        if TEMPLATES_DIR.is_dir()
+        else None
+    )
+
+    if templates is not None:
+
+        @app.get("/", response_class=HTMLResponse)
+        async def control_dashboard(request: Request) -> Any:
+            """Render the control dashboard shell (data fetched client-side)."""
+            return templates.TemplateResponse(
+                request, "control.html", {"version": trading_bot.__version__}
+            )
+
+    @app.get("/api/health")
+    async def health(request: Request) -> dict[str, Any]:
+        names = _sup(request).names()
+        running = sum(1 for s in _sup(request).status() if s.running)
+        return {"status": "ok", "strategies": len(names), "running": running}
+
+    @app.get("/api/strategies")
+    async def strategies(request: Request) -> list[dict[str, Any]]:
+        """List every managed strategy with its mode / running / PnL."""
+        return [_status_dict(s) for s in _sup(request).status()]
+
+    @app.post("/api/strategies/{name}/start")
+    async def start_strategy(name: str, request: Request) -> dict[str, Any]:
+        try:
+            await _sup(request).start(name)
+        except ConfigError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        except (BrokerError, LiveTradingNotEnabled) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"ok": True, "status": _status_dict(_sup(request).status(name)[0])}
+
+    @app.post("/api/strategies/{name}/stop")
+    async def stop_strategy(name: str, request: Request) -> dict[str, Any]:
+        try:
+            await _sup(request).stop(name)
+        except ConfigError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+        return {"ok": True, "status": _status_dict(_sup(request).status(name)[0])}
+
+    @app.post("/api/strategies/{name}/mode")
+    async def set_strategy_mode(
+        name: str, body: _ModeBody, request: Request
+    ) -> dict[str, Any]:
+        if body.mode not in _CONTROL_MODES:
+            raise HTTPException(
+                status_code=400,
+                detail=f"unknown mode {body.mode!r}; expected one of {_CONTROL_MODES}",
+            )
+        try:
+            await _sup(request).set_mode(
+                name,
+                body.mode,  # type: ignore[arg-type]
+                confirm_live=body.confirm,
+            )
+        except LiveTradingNotEnabled as exc:
+            # Real money without the deliberate confirmation — refuse, change nothing.
+            raise HTTPException(status_code=403, detail=str(exc)) from exc
+        except ConfigError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except (BrokerError, LiveTradingNotEnabled) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        return {"ok": True, "status": _status_dict(_sup(request).status(name)[0])}
 
     return app

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -49,6 +49,7 @@ import contextlib
 import dataclasses
 import math
 import pathlib
+import signal
 from collections.abc import Callable
 from decimal import Decimal
 from typing import TYPE_CHECKING
@@ -709,6 +710,107 @@ def serve(
         f"(mode={config.mode}) on http://{host}:{port}"
     )
     uvicorn.run(application, host=host, port=port)
+
+
+# --- start (daemon) -------------------------------------------------------- #
+
+
+async def _run_daemon(
+    config: AppConfig,
+    *,
+    interval: float,
+    cron: str | None,
+    dccd_client: object | None = None,
+) -> None:
+    """Supervise the declared strategies and step them on a schedule until stopped.
+
+    Builds a :class:`~trading_bot.application.supervisor.StrategySupervisor`, starts
+    every unit (each in its configured mode — paper by default), then steps the
+    running units on an **interval** (or **cron**) via an ``apscheduler``
+    ``AsyncIOScheduler``. Runs until ``SIGINT``/``SIGTERM`` (systemd's stop), then
+    shuts every unit down gracefully. Each step is idempotent over unchanged data,
+    so a tick that finds nothing to do trades nothing.
+    """
+    from apscheduler.schedulers.asyncio import AsyncIOScheduler
+    from apscheduler.triggers.cron import CronTrigger
+    from apscheduler.triggers.interval import IntervalTrigger
+
+    from trading_bot.application.supervisor import StrategySupervisor
+
+    supervisor = StrategySupervisor(config, dccd_client=dccd_client)  # type: ignore[arg-type]
+    await supervisor.start_all()
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with contextlib.suppress(NotImplementedError, RuntimeError):
+            loop.add_signal_handler(sig, stop.set)
+
+    async def _tick() -> None:
+        try:
+            stepped = await supervisor.step_all()
+            if stepped:
+                _console.print(f"[dim]daemon tick: stepped {stepped} strategy(ies)[/dim]")
+        except Exception as exc:  # noqa: BLE001 - never let a tick kill the daemon
+            _console.print(f"[red]daemon tick error:[/red] {exc}")
+
+    trigger = (
+        CronTrigger.from_crontab(cron)
+        if cron is not None
+        else IntervalTrigger(seconds=interval)
+    )
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(_tick, trigger)
+    scheduler.start()
+    _console.print(
+        f"[green]daemon started[/green] (mode={config.mode}): "
+        f"{len(supervisor.names())} strateg(ies), "
+        f"tick={cron or f'every {interval:g}s'}  —  Ctrl-C / SIGTERM to stop"
+    )
+    try:
+        await stop.wait()
+    finally:
+        scheduler.shutdown(wait=False)
+        await supervisor.shutdown()
+        _console.print("[green]daemon stopped[/green] (all strategies shut down)")
+
+
+@app.command()
+def start(
+    config_path: pathlib.Path | None = typer.Option(
+        None, "--config", "-c", help="YAML AppConfig path. Defaults to a paper config."
+    ),
+    interval: float = typer.Option(
+        60.0,
+        "--interval",
+        help="Seconds between re-evaluations (idempotent ticks). Ignored if --cron.",
+    ),
+    cron: str | None = typer.Option(
+        None,
+        "--cron",
+        help="Crontab expression for re-evaluation (e.g. '5 0 * * *' = 00:05 daily).",
+    ),
+) -> None:
+    """Run the trading **daemon**: supervise the declared strategies, step on a schedule.
+
+    The long-running process (systemd's ``ExecStart``): it builds a per-strategy
+    supervisor, starts every declared strategy (in its configured mode — **paper by
+    default**), and re-evaluates them on an interval or cron until stopped. Each
+    strategy runs in its **own** engine, so they can later be switched between
+    paper / testnet / live independently from the control plane (the dashboard).
+    Going live still requires the explicit gates — the daemon never trades real
+    money by merely starting.
+    """
+    config = (
+        AppConfig.from_yaml(config_path)
+        if config_path is not None
+        else AppConfig()
+    )
+    try:
+        asyncio.run(_run_daemon(config, interval=interval, cron=cron))
+    except Exception as exc:  # noqa: BLE001 - surface any build/config failure cleanly
+        _console.print(f"[red]refusing to start daemon:[/red] {exc}")
+        raise typer.Exit(code=1) from exc
 
 
 if __name__ == "__main__":  # pragma: no cover - manual invocation only

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -720,6 +720,9 @@ async def _run_daemon(
     *,
     interval: float,
     cron: str | None,
+    serve: bool = False,
+    host: str = "127.0.0.1",
+    port: int = 8000,
     dccd_client: object | None = None,
 ) -> None:
     """Supervise the declared strategies and step them on a schedule until stopped.
@@ -727,9 +730,13 @@ async def _run_daemon(
     Builds a :class:`~trading_bot.application.supervisor.StrategySupervisor`, starts
     every unit (each in its configured mode — paper by default), then steps the
     running units on an **interval** (or **cron**) via an ``apscheduler``
-    ``AsyncIOScheduler``. Runs until ``SIGINT``/``SIGTERM`` (systemd's stop), then
-    shuts every unit down gracefully. Each step is idempotent over unchanged data,
-    so a tick that finds nothing to do trades nothing.
+    ``AsyncIOScheduler``. When ``serve`` is set, the control dashboard
+    (:func:`~trading_bot.interfaces.api.create_control_app`) is served over the same
+    supervisor on ``host:port`` (loopback by default — it can change what trades),
+    and **uvicorn owns the signal** (Ctrl-C ends serve, then the daemon tears down);
+    headless, the daemon installs its own ``SIGINT``/``SIGTERM`` handlers. Each step
+    is idempotent over unchanged data, so a tick that finds nothing to do trades
+    nothing.
     """
     from apscheduler.schedulers.asyncio import AsyncIOScheduler
     from apscheduler.triggers.cron import CronTrigger
@@ -739,12 +746,6 @@ async def _run_daemon(
 
     supervisor = StrategySupervisor(config, dccd_client=dccd_client)  # type: ignore[arg-type]
     await supervisor.start_all()
-
-    stop = asyncio.Event()
-    loop = asyncio.get_running_loop()
-    for sig in (signal.SIGINT, signal.SIGTERM):
-        with contextlib.suppress(NotImplementedError, RuntimeError):
-            loop.add_signal_handler(sig, stop.set)
 
     async def _tick() -> None:
         try:
@@ -765,10 +766,31 @@ async def _run_daemon(
     _console.print(
         f"[green]daemon started[/green] (mode={config.mode}): "
         f"{len(supervisor.names())} strateg(ies), "
-        f"tick={cron or f'every {interval:g}s'}  —  Ctrl-C / SIGTERM to stop"
+        f"tick={cron or f'every {interval:g}s'}"
     )
     try:
-        await stop.wait()
+        if serve:
+            import uvicorn
+
+            from trading_bot.interfaces.api import create_control_app
+
+            api = create_control_app(supervisor)
+            server = uvicorn.Server(
+                uvicorn.Config(api, host=host, port=port, log_level="warning")
+            )
+            _console.print(
+                f"[green]control dashboard[/green] on http://{host}:{port}"
+                "  —  Ctrl-C to stop"
+            )
+            await server.serve()  # uvicorn owns SIGINT; blocks until Ctrl-C
+        else:
+            stop = asyncio.Event()
+            loop = asyncio.get_running_loop()
+            for sig in (signal.SIGINT, signal.SIGTERM):
+                with contextlib.suppress(NotImplementedError, RuntimeError):
+                    loop.add_signal_handler(sig, stop.set)
+            _console.print("[dim]Ctrl-C / SIGTERM to stop[/dim]")
+            await stop.wait()
     finally:
         scheduler.shutdown(wait=False)
         await supervisor.shutdown()
@@ -790,16 +812,28 @@ def start(
         "--cron",
         help="Crontab expression for re-evaluation (e.g. '5 0 * * *' = 00:05 daily).",
     ),
+    serve: bool = typer.Option(
+        False,
+        "--serve",
+        help="Also serve the control dashboard (start/stop strategies, switch mode) "
+        "over HTTP — loopback by default, since it can change what trades.",
+    ),
+    serve_host: str = typer.Option(
+        "127.0.0.1", "--serve-host", help="Control dashboard bind interface (loopback)."
+    ),
+    serve_port: int = typer.Option(
+        8000, "--serve-port", help="Control dashboard TCP port."
+    ),
 ) -> None:
     """Run the trading **daemon**: supervise the declared strategies, step on a schedule.
 
     The long-running process (systemd's ``ExecStart``): it builds a per-strategy
     supervisor, starts every declared strategy (in its configured mode — **paper by
     default**), and re-evaluates them on an interval or cron until stopped. Each
-    strategy runs in its **own** engine, so they can later be switched between
-    paper / testnet / live independently from the control plane (the dashboard).
-    Going live still requires the explicit gates — the daemon never trades real
-    money by merely starting.
+    strategy runs in its **own** engine, so they can be switched between paper /
+    testnet / live independently from the **control dashboard** (``--serve``). Going
+    live still requires the explicit gates — the daemon never trades real money by
+    merely starting, and the dashboard requires a typed confirmation to go live.
     """
     config = (
         AppConfig.from_yaml(config_path)
@@ -807,7 +841,16 @@ def start(
         else AppConfig()
     )
     try:
-        asyncio.run(_run_daemon(config, interval=interval, cron=cron))
+        asyncio.run(
+            _run_daemon(
+                config,
+                interval=interval,
+                cron=cron,
+                serve=serve,
+                host=serve_host,
+                port=serve_port,
+            )
+        )
     except Exception as exc:  # noqa: BLE001 - surface any build/config failure cleanly
         _console.print(f"[red]refusing to start daemon:[/red] {exc}")
         raise typer.Exit(code=1) from exc

--- a/trading_bot/interfaces/ui/static/control.js
+++ b/trading_bot/interfaces/ui/static/control.js
@@ -1,0 +1,123 @@
+// trading_bot control plane — list strategies, start/stop, switch mode.
+// Pure HTTP client of /api/strategies; switching to LIVE asks for a typed
+// confirmation that maps to {confirm:true} on the mode endpoint (the server
+// also refuses live without it).
+"use strict";
+
+const MODES = ["paper", "testnet", "live"];
+const body = document.getElementById("strategies-body");
+const conn = document.getElementById("conn");
+const msg = document.getElementById("msg");
+
+function setConn(ok) {
+  conn.className = "conn " + (ok ? "ok" : "down");
+  conn.innerHTML = '<span class="dot"></span>' + (ok ? "connected" : "disconnected");
+}
+
+function flash(text, isError) {
+  msg.textContent = text;
+  msg.style.color = isError ? "var(--err)" : "var(--muted)";
+}
+
+async function api(path, opts) {
+  const resp = await fetch(path, opts);
+  let data = null;
+  try { data = await resp.json(); } catch (e) { /* no body */ }
+  if (!resp.ok) {
+    const detail = (data && data.detail) || resp.statusText;
+    throw new Error(detail);
+  }
+  return data;
+}
+
+function modeSelect(s) {
+  const opts = MODES.map(
+    (m) => `<option value="${m}"${m === s.mode ? " selected" : ""}>${m}</option>`
+  ).join("");
+  return `<select data-name="${s.name}" class="mode-select">${opts}</select>`;
+}
+
+function row(s) {
+  const statusBadge = s.running
+    ? '<span class="side-buy">running</span>'
+    : '<span class="conn">stopped</span>';
+  const action = s.running
+    ? `<button data-name="${s.name}" data-act="stop">Stop</button>`
+    : `<button data-name="${s.name}" data-act="start">Start</button>`;
+  const pnl = s.realised_pnl === null ? "—" : s.realised_pnl;
+  return `<tr>
+    <td>${s.name}</td>
+    <td>${s.kind}</td>
+    <td>${modeSelect(s)}</td>
+    <td>${statusBadge}</td>
+    <td class="num">${pnl}</td>
+    <td class="num">${s.open_orders}</td>
+    <td>${action}</td>
+  </tr>`;
+}
+
+async function refresh() {
+  try {
+    const list = await api("/api/strategies");
+    setConn(true);
+    if (!list.length) {
+      body.innerHTML = '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
+      return;
+    }
+    body.innerHTML = list.map(row).join("");
+  } catch (e) {
+    setConn(false);
+  }
+}
+
+async function onClick(ev) {
+  const btn = ev.target.closest("button[data-act]");
+  if (!btn) return;
+  const { name, act } = btn.dataset;
+  btn.disabled = true;
+  try {
+    await api(`/api/strategies/${encodeURIComponent(name)}/${act}`, { method: "POST" });
+    flash(`${name}: ${act}ed`, false);
+  } catch (e) {
+    flash(`${name}: ${e.message}`, true);
+  } finally {
+    await refresh();
+  }
+}
+
+async function onModeChange(ev) {
+  const sel = ev.target.closest("select.mode-select");
+  if (!sel) return;
+  const name = sel.dataset.name;
+  const mode = sel.value;
+  let confirm = false;
+  if (mode === "live") {
+    // Real money — deliberate, typed acknowledgement (the server also enforces it).
+    const typed = window.prompt(
+      `Switch "${name}" to LIVE (REAL MONEY)?\nType I UNDERSTAND to confirm:`
+    );
+    if (typed !== "I UNDERSTAND") {
+      flash(`${name}: live switch cancelled`, true);
+      await refresh();
+      return;
+    }
+    confirm = true;
+  }
+  try {
+    await api(`/api/strategies/${encodeURIComponent(name)}/mode`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode, confirm }),
+    });
+    flash(`${name}: mode → ${mode}`, false);
+  } catch (e) {
+    flash(`${name}: ${e.message}`, true);
+  } finally {
+    await refresh();
+  }
+}
+
+body.addEventListener("click", onClick);
+body.addEventListener("change", onModeChange);
+refresh();
+setInterval(refresh, 3000);

--- a/trading_bot/interfaces/ui/templates/control.html
+++ b/trading_bot/interfaces/ui/templates/control.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>trading_bot — control</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body>
+  <!-- Control plane: lists the daemon's managed strategies and lets you start /
+       stop them and switch mode (paper / testnet / live). Switching to LIVE asks
+       for a typed confirmation; all state is fetched/changed via /api/strategies. -->
+  <header class="topbar">
+    <div class="brand-group">
+      <span class="brand">trading_bot</span>
+      <span class="ver">v{{ version }}</span>
+    </div>
+    <span class="mode-badge mode-paper">control</span>
+    <span id="conn" class="conn"><span class="dot"></span>connecting…</span>
+  </header>
+
+  <main>
+    <section class="card">
+      <h2>Strategies</h2>
+      <div class="table-wrap">
+        <table>
+          <thead>
+            <tr>
+              <th>Strategy</th>
+              <th>Kind</th>
+              <th>Mode</th>
+              <th>Status</th>
+              <th class="num">Realised PnL</th>
+              <th class="num">Open orders</th>
+              <th>Action</th>
+            </tr>
+          </thead>
+          <tbody id="strategies-body">
+            <tr class="empty"><td colspan="7">Loading…</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <p id="msg" class="conn"></p>
+    </section>
+  </main>
+
+  <footer>
+    trading_bot v{{ version }} — control plane (loopback). Switching to <b>live</b>
+    trades real money and requires a typed confirmation.
+  </footer>
+
+  <script src="/static/control.js"></script>
+</body>
+</html>

--- a/trading_bot/tests/application/test_portfolio_runner.py
+++ b/trading_bot/tests/application/test_portfolio_runner.py
@@ -471,3 +471,38 @@ async def test_money_read_off_frame_is_exact_decimal() -> None:
     assert btc_leg.limit_price == Decimal("50000.5")
     expected = money(str(money("0.5") * CAPITAL / money("50000.5")))
     assert btc_leg.qty == abs(expected)
+
+
+# --- rebalance_latest: single rebalance over the latest cross-section ------- #
+
+
+async def test_rebalance_latest_rebalances_over_the_feeds_latest_cross_section() -> None:
+    """`rebalance_latest` takes the feed's latest cross-section and rebalances once."""
+    weights = {BTC: money("0.5"), ETH: money("-0.25")}
+    router, tracker, bus, _broker = _engine()
+    runner = PortfolioRunner(
+        _strategy(_weights_signal(weights)),
+        _ListFeed([_frames()], asof=1_700),
+        router,
+        tracker,
+        event_bus=bus,
+    )
+
+    result = await runner.rebalance_latest()
+
+    assert result is not None
+    assert result.submitted == 2  # one leg per coin, from flat
+
+
+async def test_rebalance_latest_returns_none_on_empty_feed() -> None:
+    """`rebalance_latest` returns None when the feed yields no cross-section yet."""
+    router, tracker, bus, _broker = _engine()
+    runner = PortfolioRunner(
+        _strategy(_weights_signal({BTC: money("0.5")})),
+        _ListFeed([], asof=1_700),
+        router,
+        tracker,
+        event_bus=bus,
+    )
+
+    assert await runner.rebalance_latest() is None

--- a/trading_bot/tests/application/test_strategy_runner.py
+++ b/trading_bot/tests/application/test_strategy_runner.py
@@ -583,3 +583,39 @@ async def test_order_factory_and_log_events() -> None:
     # The orders were LIMITs (from the factory), filled at the close.
     fills = await broker.fills()
     assert fills
+
+
+# --- step_latest: single re-evaluation over the latest data (daemon hook) --- #
+
+
+async def test_step_latest_evaluates_latest_window_and_is_idempotent() -> None:
+    """`step_latest` steps over `feed.latest()`; a repeat on unchanged data no-ops.
+
+    The scheduler-driven daemon hook: one re-evaluation over the freshest data
+    trades to the latest target, and calling it again over the same data submits
+    nothing (already on target) — idempotent under repetition.
+    """
+    pytest.importorskip("fynance")  # ma_crossover_signal evaluates fynance.sma
+    up = [float(100 + i) for i in range(20)]
+    down = [float(120 - i) for i in range(1, 21)]
+    frame = _bars(up + down)
+    strat = Strategy(
+        name="ma",
+        instrument=BTC_USD,
+        signal_fn=ma_crossover_signal(BTC_USD, fast=3, slow=6),
+        reference_qty=money("2"),
+        lookback=6,
+    )
+    runner, _broker, tracker, _bus = _wire(strat, frame, mark="100")
+
+    first = await runner.step_latest()  # from flat → trades to the latest target
+    assert first is not None
+    pos = tracker.position(BTC_USD)
+    assert pos is not None
+    assert pos.net_qty == Decimal("-2")  # latest signal is short on the down tail
+
+    second = await runner.step_latest()  # already on target → no order
+    assert second is None
+    again = tracker.position(BTC_USD)
+    assert again is not None
+    assert again.net_qty == Decimal("-2")  # unchanged

--- a/trading_bot/tests/application/test_supervisor.py
+++ b/trading_bot/tests/application/test_supervisor.py
@@ -1,0 +1,147 @@
+"""Tests for the :class:`StrategySupervisor` — per-strategy lifecycle + modes.
+
+Offline: a paper config + a fake dccd client (canned bars). Proves the supervisor
+splits a config into independently-managed units, starts/steps/stops them in their
+own engine, switches modes (paper ↔ testnet), and **gates real money** (``live``
+needs an explicit confirmation). Async tests run un-decorated (``asyncio_mode =
+"auto"``).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from trading_bot.application.config import AppConfig
+from trading_bot.application.supervisor import StrategySupervisor
+from trading_bot.domain.errors import ConfigError, LiveTradingNotEnabled
+
+
+def _dccd_ohlc(closes: list[float], *, span_s: int = 60) -> pl.DataFrame:
+    span_ns = span_s * 1_000_000_000
+    ts = [i * span_ns for i in range(len(closes))]
+    return pl.DataFrame(
+        {
+            "TS": ts,
+            "open": closes,
+            "high": [c + 0.5 for c in closes],
+            "low": [c - 0.5 for c in closes],
+            "close": closes,
+            "volume": [1.0] * len(closes),
+            "quote_volume": list(closes),
+            "trades": [1] * len(closes),
+        }
+    )
+
+
+class _FakeDccdClient:
+    """A canned offline dccd client keyed by symbol (no network)."""
+
+    def __init__(self, frames: dict[str, pl.DataFrame]) -> None:
+        self._frames = frames
+
+    def read(self, exchange, symbol, data_type="ohlc", span=None, start_ns=None, end_ns=None):  # noqa: ANN001, ANN201
+        return self._frames[symbol]
+
+    def backfill(self, *a, **k):  # noqa: ANN002, ANN003, ANN201  # pragma: no cover
+        return None
+
+
+def _trend() -> list[float]:
+    """A close series that trends up then down (the MA crosses both ways)."""
+    return [100.0 + i for i in range(20)] + [119.0 - i for i in range(1, 21)]
+
+
+def _config(*, with_broker: bool = True) -> AppConfig:
+    """A paper config: one BTC/USD MA-crossover strategy (+ an optional broker)."""
+    raw: dict = {
+        "mode": "paper",
+        "strategies": [
+            {
+                "name": "btc-ma",
+                "symbol": "BTC/USD",
+                "data": {"exchange": "kraken", "span": 60},
+                "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                "reference_qty": "2",
+                "lookback": 6,
+            }
+        ],
+    }
+    if with_broker:
+        raw["brokers"] = [{"name": "kraken", "exchange": "kraken"}]
+    return AppConfig.model_validate(raw)
+
+
+def _supervisor() -> StrategySupervisor:
+    client = _FakeDccdClient({"BTC/USD": _dccd_ohlc(_trend())})
+    return StrategySupervisor(_config(), dccd_client=client)
+
+
+def test_splits_config_into_units() -> None:
+    """The supervisor splits the config into one (stopped, paper) unit per strategy."""
+    sup = _supervisor()
+    assert sup.names() == ["btc-ma"]
+    [status] = sup.status()
+    assert status.name == "btc-ma"
+    assert status.kind == "strategy"
+    assert status.mode == "paper"
+    assert status.running is False
+    assert status.realised_pnl is None
+
+
+async def test_start_step_stop_lifecycle() -> None:
+    """start builds a per-unit engine; step re-evaluates over latest data; stop tears down."""
+    pytest.importorskip("fynance")  # ma_crossover evaluates fynance.sma
+    sup = _supervisor()
+
+    await sup.start("btc-ma")
+    assert sup.status("btc-ma")[0].running is True
+
+    # One re-evaluation over the latest (trend-down tail → short) data trades.
+    order = await sup.step("btc-ma")
+    assert order is not None  # delta != 0 from flat → an order was routed
+
+    await sup.stop("btc-ma")
+    status = sup.status("btc-ma")[0]
+    assert status.running is False
+    # Stopped → nothing to step.
+    assert await sup.step("btc-ma") is None
+
+
+async def test_set_mode_paper_testnet_roundtrip() -> None:
+    """paper ↔ testnet switch needs no confirmation and updates the unit's mode."""
+    sup = _supervisor()
+    await sup.set_mode("btc-ma", "testnet")
+    assert sup.status("btc-ma")[0].mode == "testnet"
+    await sup.set_mode("btc-ma", "paper")
+    assert sup.status("btc-ma")[0].mode == "paper"
+
+
+async def test_set_mode_live_requires_explicit_confirmation() -> None:
+    """Switching to live (real money) without confirmation is refused."""
+    sup = _supervisor()
+    with pytest.raises(LiveTradingNotEnabled):
+        await sup.set_mode("btc-ma", "live")  # no confirm → refused
+    assert sup.status("btc-ma")[0].mode == "paper"  # unchanged
+
+    # With the deliberate acknowledgement the mode flips (the engine is only built
+    # on start, which still enforces credentials + risk limits).
+    await sup.set_mode("btc-ma", "live", confirm_live=True)
+    assert sup.status("btc-ma")[0].mode == "live"
+
+
+async def test_testnet_without_a_broker_is_refused() -> None:
+    """A paper-only unit with no configured broker cannot go testnet/live."""
+    sup = StrategySupervisor(
+        _config(with_broker=False),
+        dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(_trend())}),
+    )
+    with pytest.raises(ConfigError, match="without a configured broker"):
+        await sup.set_mode("btc-ma", "testnet")
+
+
+async def test_unknown_strategy_is_a_config_error() -> None:
+    """Operating on an unknown name raises a clear error."""
+    sup = _supervisor()
+    with pytest.raises(ConfigError, match="unknown strategy"):
+        await sup.start("nope")

--- a/trading_bot/tests/application/test_supervisor.py
+++ b/trading_bot/tests/application/test_supervisor.py
@@ -145,3 +145,19 @@ async def test_unknown_strategy_is_a_config_error() -> None:
     sup = _supervisor()
     with pytest.raises(ConfigError, match="unknown strategy"):
         await sup.start("nope")
+
+
+async def test_start_all_step_all_shutdown() -> None:
+    """The daemon's boot/tick/teardown: start every unit, step the running ones, stop."""
+    pytest.importorskip("fynance")
+    sup = _supervisor()
+
+    await sup.start_all()
+    assert all(s.running for s in sup.status())
+
+    stepped = await sup.step_all()
+    assert stepped == 1  # the one running unit stepped once
+
+    await sup.shutdown()
+    assert not any(s.running for s in sup.status())
+    assert await sup.step_all() == 0  # nothing running → nothing stepped

--- a/trading_bot/tests/interfaces/test_cli_commands.py
+++ b/trading_bot/tests/interfaces/test_cli_commands.py
@@ -407,3 +407,28 @@ def _render_to_text(renderable: object) -> str:
     console = Console(width=200, record=True)
     console.print(renderable)
     return console.export_text()
+
+
+# --- daemon (`start`) smoke ------------------------------------------------- #
+
+
+async def test_daemon_starts_ticks_and_stops_cleanly() -> None:
+    """`_run_daemon` builds the supervisor, schedules ticks, and tears down on cancel.
+
+    Drives the daemon coroutine over an empty paper config (no strategies): it must
+    start the scheduler, tick (a no-op with zero units), and shut down cleanly when
+    cancelled — no exception leaks. Proves the daemon loop is wired without binding a
+    real signal/port.
+    """
+    import asyncio
+    import contextlib
+
+    from trading_bot.application.config import AppConfig
+    from trading_bot.interfaces.cli.main import _run_daemon
+
+    task = asyncio.create_task(_run_daemon(AppConfig(), interval=0.05, cron=None))
+    await asyncio.sleep(0.12)  # let it start + tick a couple of times
+    assert not task.done()  # the daemon stays up until stopped
+    task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await task

--- a/trading_bot/tests/interfaces/test_control_api.py
+++ b/trading_bot/tests/interfaces/test_control_api.py
@@ -1,0 +1,136 @@
+"""Tests for the daemon's **control** API — start/stop/mode over a supervisor.
+
+Drives :func:`~trading_bot.interfaces.api.create_control_app` with a
+:class:`fastapi.testclient.TestClient` (no real server) over a
+:class:`~trading_bot.application.supervisor.StrategySupervisor` built from a paper
+config + a fake dccd client. Proves the read+write control plane, and that **real
+money is gated** (live needs an explicit confirmation → ``403`` otherwise).
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+from fastapi.testclient import TestClient
+
+from trading_bot.application.config import AppConfig
+from trading_bot.application.supervisor import StrategySupervisor
+from trading_bot.interfaces.api import create_control_app
+
+
+def _dccd_ohlc(closes: list[float]) -> pl.DataFrame:
+    span_ns = 60 * 1_000_000_000
+    return pl.DataFrame(
+        {
+            "TS": [i * span_ns for i in range(len(closes))],
+            "open": closes,
+            "high": [c + 0.5 for c in closes],
+            "low": [c - 0.5 for c in closes],
+            "close": closes,
+            "volume": [1.0] * len(closes),
+            "quote_volume": list(closes),
+            "trades": [1] * len(closes),
+        }
+    )
+
+
+class _FakeDccdClient:
+    def __init__(self, frames: dict[str, pl.DataFrame]) -> None:
+        self._frames = frames
+
+    def read(self, exchange, symbol, data_type="ohlc", span=None, start_ns=None, end_ns=None):  # noqa: ANN001, ANN201
+        return self._frames[symbol]
+
+    def backfill(self, *a, **k):  # noqa: ANN002, ANN003, ANN201  # pragma: no cover
+        return None
+
+
+def _config() -> AppConfig:
+    return AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "brokers": [{"name": "kraken", "exchange": "kraken"}],
+            "strategies": [
+                {
+                    "name": "btc-ma",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                    "reference_qty": "2",
+                    "lookback": 6,
+                }
+            ],
+        }
+    )
+
+
+def _client() -> TestClient:
+    trend = [100.0 + i for i in range(20)] + [119.0 - i for i in range(1, 21)]
+    sup = StrategySupervisor(
+        _config(), dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(trend)})
+    )
+    return TestClient(create_control_app(sup))
+
+
+def test_list_strategies() -> None:
+    """`GET /api/strategies` lists the managed units (stopped, paper to start)."""
+    resp = _client().get("/api/strategies")
+    assert resp.status_code == 200
+    [s] = resp.json()
+    assert s["name"] == "btc-ma"
+    assert s["mode"] == "paper"
+    assert s["running"] is False
+    assert s["realised_pnl"] is None
+
+
+def test_set_mode_testnet_then_paper() -> None:
+    """Switching paper ↔ testnet needs no confirmation and updates the mode."""
+    client = _client()
+    r = client.post("/api/strategies/btc-ma/mode", json={"mode": "testnet"})
+    assert r.status_code == 200
+    assert r.json()["status"]["mode"] == "testnet"
+    r = client.post("/api/strategies/btc-ma/mode", json={"mode": "paper"})
+    assert r.json()["status"]["mode"] == "paper"
+
+
+def test_set_mode_live_without_confirmation_is_403() -> None:
+    """Switching to live (real money) without confirmation is refused — nothing changes."""
+    client = _client()
+    r = client.post("/api/strategies/btc-ma/mode", json={"mode": "live"})
+    assert r.status_code == 403
+    # Mode unchanged.
+    assert client.get("/api/strategies").json()[0]["mode"] == "paper"
+
+
+def test_set_mode_live_with_confirmation_flips() -> None:
+    """With the deliberate confirmation, the mode flips to live."""
+    client = _client()
+    r = client.post(
+        "/api/strategies/btc-ma/mode", json={"mode": "live", "confirm": True}
+    )
+    assert r.status_code == 200
+    assert r.json()["status"]["mode"] == "live"
+
+
+def test_unknown_strategy_is_404() -> None:
+    r = _client().post("/api/strategies/nope/start")
+    assert r.status_code == 404
+
+
+def test_unknown_mode_is_400() -> None:
+    r = _client().post("/api/strategies/btc-ma/mode", json={"mode": "bogus"})
+    assert r.status_code == 400
+
+
+def test_start_then_stop() -> None:
+    """`POST start` runs the strategy in its own engine; `POST stop` tears it down."""
+    pytest.importorskip("fynance")  # ma_crossover evaluates fynance.sma
+    client = _client()
+
+    r = client.post("/api/strategies/btc-ma/start")
+    assert r.status_code == 200
+    assert r.json()["status"]["running"] is True
+
+    r = client.post("/api/strategies/btc-ma/stop")
+    assert r.status_code == 200
+    assert r.json()["status"]["running"] is False

--- a/trading_bot/tests/test_smoke.py
+++ b/trading_bot/tests/test_smoke.py
@@ -6,9 +6,21 @@ those layers are built (see ``doc/dev/07-roadmap.md``).
 """
 from __future__ import annotations
 
+from importlib import metadata
+
 import trading_bot
 
 
 def test_package_exposes_version() -> None:
     assert isinstance(trading_bot.__version__, str)
     assert trading_bot.__version__
+
+
+def test_version_reads_from_installed_metadata_not_a_stale_constant() -> None:
+    """`__version__` tracks the installed package metadata (i.e. pyproject).
+
+    Regression: it used to be a hand-bumped constant (`"0.2.0"`) that the release
+    flow never updated, so `trading-bot version` / the dashboard went stale across
+    releases. It must now equal the installed metadata version.
+    """
+    assert trading_bot.__version__ == metadata.version("trading_bot")


### PR DESCRIPTION
Release **v0.6.0** — the control-plane daemon: `trading-bot start` (supervisor + scheduler + control dashboard), per-strategy paper/testnet/live with gated live, systemd deploy (pyenv). After merge: `git fetch origin && git tag v0.6.0 origin/master && git push origin v0.6.0`. See CHANGELOG `[0.6.0]`.