### PR TITLE
feat: control dashboard visual pass (dccd-flavored)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Control dashboard visual pass** — mode **badges** (paper/testnet/live, colour-coded),
+  a running/stopped status pill, start/stop buttons styled by action, a header summary
+  (N strategies · M running), and a proper **typed-confirmation modal** for going live
+  (replaces the browser `prompt`). Aligned with dccd's dark palette/pill language; no
+  shipped font assets. (#100)
+
 ### Fixed
 
 ### Deprecated

--- a/trading_bot/interfaces/ui/static/control.js
+++ b/trading_bot/interfaces/ui/static/control.js
@@ -1,13 +1,25 @@
 // trading_bot control plane — list strategies, start/stop, switch mode.
-// Pure HTTP client of /api/strategies; switching to LIVE asks for a typed
-// confirmation that maps to {confirm:true} on the mode endpoint (the server
-// also refuses live without it).
+// Pure HTTP client of /api/strategies. Switching to LIVE opens a typed-confirmation
+// modal that maps to {confirm:true} on the mode endpoint (the server also refuses
+// live without it).
 "use strict";
 
 const MODES = ["paper", "testnet", "live"];
+const PHRASE = "I UNDERSTAND";
+
 const body = document.getElementById("strategies-body");
 const conn = document.getElementById("conn");
 const msg = document.getElementById("msg");
+const sumTotal = document.getElementById("sum-total");
+const sumRunning = document.getElementById("sum-running");
+
+const modal = document.getElementById("live-modal");
+const modalName = document.getElementById("live-modal-name");
+const modalInput = document.getElementById("live-modal-input");
+const modalConfirm = document.getElementById("live-modal-confirm");
+const modalCancel = document.getElementById("live-modal-cancel");
+
+let pendingLive = null; // {name} awaiting confirmation
 
 function setConn(ok) {
   conn.className = "conn " + (ok ? "ok" : "down");
@@ -24,32 +36,36 @@ async function api(path, opts) {
   let data = null;
   try { data = await resp.json(); } catch (e) { /* no body */ }
   if (!resp.ok) {
-    const detail = (data && data.detail) || resp.statusText;
-    throw new Error(detail);
+    throw new Error((data && data.detail) || resp.statusText);
   }
   return data;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 }
 
 function modeSelect(s) {
   const opts = MODES.map(
     (m) => `<option value="${m}"${m === s.mode ? " selected" : ""}>${m}</option>`
   ).join("");
-  return `<select data-name="${s.name}" class="mode-select">${opts}</select>`;
+  return `<select data-name="${escapeHtml(s.name)}" class="mode-select" aria-label="mode">${opts}</select>`;
 }
 
 function row(s) {
-  const statusBadge = s.running
-    ? '<span class="side-buy">running</span>'
-    : '<span class="conn">stopped</span>';
+  const status = s.running
+    ? '<span class="run-pill is-running"><span class="dot"></span>running</span>'
+    : '<span class="run-pill is-stopped"><span class="dot"></span>stopped</span>';
   const action = s.running
-    ? `<button data-name="${s.name}" data-act="stop">Stop</button>`
-    : `<button data-name="${s.name}" data-act="start">Start</button>`;
-  const pnl = s.realised_pnl === null ? "—" : s.realised_pnl;
+    ? `<button data-name="${escapeHtml(s.name)}" data-act="stop" class="btn-stop">Stop</button>`
+    : `<button data-name="${escapeHtml(s.name)}" data-act="start" class="btn-start">Start</button>`;
+  const pnl = s.realised_pnl === null ? '<span class="conn">—</span>' : escapeHtml(s.realised_pnl);
   return `<tr>
-    <td>${s.name}</td>
-    <td>${s.kind}</td>
-    <td>${modeSelect(s)}</td>
-    <td>${statusBadge}</td>
+    <td>${escapeHtml(s.name)}</td>
+    <td>${escapeHtml(s.kind)}</td>
+    <td><span class="badge badge-${s.mode}">${s.mode}</span> ${modeSelect(s)}</td>
+    <td>${status}</td>
     <td class="num">${pnl}</td>
     <td class="num">${s.open_orders}</td>
     <td>${action}</td>
@@ -60,13 +76,28 @@ async function refresh() {
   try {
     const list = await api("/api/strategies");
     setConn(true);
-    if (!list.length) {
-      body.innerHTML = '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
-      return;
-    }
-    body.innerHTML = list.map(row).join("");
+    sumTotal.textContent = list.length;
+    sumRunning.textContent = list.filter((s) => s.running).length;
+    body.innerHTML = list.length
+      ? list.map(row).join("")
+      : '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
   } catch (e) {
     setConn(false);
+  }
+}
+
+async function setMode(name, mode, confirm) {
+  try {
+    await api(`/api/strategies/${encodeURIComponent(name)}/mode`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode, confirm: !!confirm }),
+    });
+    flash(`${name}: mode → ${mode}`, false);
+  } catch (e) {
+    flash(`${name}: ${e.message}`, true);
+  } finally {
+    await refresh();
   }
 }
 
@@ -85,37 +116,53 @@ async function onClick(ev) {
   }
 }
 
-async function onModeChange(ev) {
+function onModeChange(ev) {
   const sel = ev.target.closest("select.mode-select");
   if (!sel) return;
   const name = sel.dataset.name;
   const mode = sel.value;
-  let confirm = false;
   if (mode === "live") {
-    // Real money — deliberate, typed acknowledgement (the server also enforces it).
-    const typed = window.prompt(
-      `Switch "${name}" to LIVE (REAL MONEY)?\nType I UNDERSTAND to confirm:`
-    );
-    if (typed !== "I UNDERSTAND") {
-      flash(`${name}: live switch cancelled`, true);
-      await refresh();
-      return;
-    }
-    confirm = true;
+    openLiveModal(name); // deliberate, typed acknowledgement
+    return;
   }
-  try {
-    await api(`/api/strategies/${encodeURIComponent(name)}/mode`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ mode, confirm }),
-    });
-    flash(`${name}: mode → ${mode}`, false);
-  } catch (e) {
-    flash(`${name}: ${e.message}`, true);
-  } finally {
-    await refresh();
-  }
+  setMode(name, mode, false); // paper / testnet — no confirmation
 }
+
+// --- live confirmation modal ---------------------------------------------- //
+
+function openLiveModal(name) {
+  pendingLive = { name };
+  modalName.textContent = name;
+  modalInput.value = "";
+  modalConfirm.disabled = true;
+  modal.classList.add("open");
+  modalInput.focus();
+}
+
+function closeLiveModal() {
+  modal.classList.remove("open");
+  pendingLive = null;
+  refresh(); // re-render so a cancelled select reverts to the server's mode
+}
+
+modalInput.addEventListener("input", () => {
+  modalConfirm.disabled = modalInput.value.trim() !== PHRASE;
+});
+modalInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !modalConfirm.disabled) modalConfirm.click();
+  if (e.key === "Escape") closeLiveModal();
+});
+modalConfirm.addEventListener("click", async () => {
+  const name = pendingLive && pendingLive.name;
+  modal.classList.remove("open");
+  if (name) await setMode(name, "live", true);
+  pendingLive = null;
+});
+modalCancel.addEventListener("click", () => {
+  flash(`${pendingLive ? pendingLive.name : ""}: live switch cancelled`, true);
+  closeLiveModal();
+});
+modal.addEventListener("click", (e) => { if (e.target === modal) closeLiveModal(); });
 
 body.addEventListener("click", onClick);
 body.addEventListener("change", onModeChange);

--- a/trading_bot/interfaces/ui/static/style.css
+++ b/trading_bot/interfaces/ui/static/style.css
@@ -114,3 +114,97 @@ footer a { color: var(--muted); }
   .topbar { padding: .55rem .8rem; }
   main { padding: .9rem .7rem; }
 }
+
+/* ===========================================================================
+   Control plane — summary, mode badges, buttons, the live-confirm modal.
+   (Aligned with dccd's palette + pill/badge language; fonts fall back to the
+   system stack, no shipped assets.)
+   =========================================================================== */
+
+:root {
+  --font-display: "Martian Mono", ui-monospace, "SF Mono", monospace;
+  --accent-soft: rgba(94, 162, 255, .12);
+  --warn-soft: rgba(214, 161, 50, .14);
+  --err-soft: rgba(248, 81, 73, .12);
+  --ok-soft: rgba(63, 185, 80, .14);
+}
+.brand { font-family: var(--font-display); }
+
+/* A small summary chip set in the header (N strategies · M running). */
+.summary { display: inline-flex; gap: .4rem; align-items: center; margin-right: auto; }
+.chip {
+  font-size: .76rem; color: var(--muted);
+  border: 1px solid var(--border); border-radius: 999px;
+  padding: .2rem .6rem; font-variant-numeric: tabular-nums;
+}
+.chip b { color: var(--fg); font-weight: 600; }
+
+/* Mode badge — paper (calm), testnet (amber), live (red, emphasised). */
+.badge {
+  display: inline-block; font-size: .68rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .09em;
+  padding: .18rem .5rem; border-radius: 999px; border: 1px solid var(--border);
+}
+.badge-paper   { color: var(--accent); border-color: rgba(94,162,255,.4); background: var(--accent-soft); }
+.badge-testnet { color: var(--warn);   border-color: rgba(214,161,50,.45); background: var(--warn-soft); }
+.badge-live    { color: var(--err);    border-color: rgba(248,81,73,.5);   background: var(--err-soft); }
+
+/* Running / stopped pill with a status dot. */
+.run-pill { display: inline-flex; align-items: center; gap: .4rem; font-size: .8rem; }
+.run-pill .dot { width: .5rem; height: .5rem; border-radius: 50%; background: var(--muted); }
+.run-pill.is-running { color: var(--ok); }
+.run-pill.is-running .dot { background: var(--ok); box-shadow: 0 0 5px var(--ok); }
+.run-pill.is-stopped { color: var(--muted); }
+
+/* Buttons + the mode <select>. */
+button, .btn {
+  font: inherit; font-size: .82rem; cursor: pointer; color: var(--fg);
+  background: var(--card); border: 1px solid var(--border); border-radius: 7px;
+  padding: .32rem .8rem; transition: background .12s, border-color .12s, color .12s;
+}
+button:hover { background: var(--border); }
+button:disabled { opacity: .5; cursor: not-allowed; }
+button.btn-start { color: var(--ok); border-color: rgba(63,185,80,.45); }
+button.btn-start:hover { background: var(--ok-soft); }
+button.btn-stop { color: var(--err); border-color: rgba(248,81,73,.45); }
+button.btn-stop:hover { background: var(--err-soft); }
+button.btn-primary { color: #08110a; background: var(--ok); border-color: var(--ok); font-weight: 700; }
+button.btn-primary:hover { filter: brightness(1.08); background: var(--ok); }
+
+select.mode-select {
+  font: inherit; font-size: .8rem; color: var(--fg);
+  background: var(--bg); border: 1px solid var(--border); border-radius: 7px;
+  padding: .28rem 1.6rem .28rem .55rem; cursor: pointer;
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position: right .85rem center, right .6rem center;
+  background-size: 5px 5px, 5px 5px; background-repeat: no-repeat;
+}
+select.mode-select:focus { outline: none; border-color: var(--accent); }
+
+/* Modal — the deliberate "go live" confirmation. */
+.modal {
+  position: fixed; inset: 0; display: none; z-index: 50;
+  align-items: center; justify-content: center;
+  background: rgba(4, 7, 12, .68); backdrop-filter: blur(2px);
+}
+.modal.open { display: flex; }
+.modal-card {
+  background: var(--card); border: 1px solid var(--border);
+  border-top: 3px solid var(--err);
+  border-radius: 12px; padding: 1.3rem 1.4rem; max-width: 420px; width: calc(100% - 2rem);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, .55);
+}
+.modal-card h3 { margin: 0 0 .5rem; font-size: 1rem; }
+.modal-card h3 .warn-mark { color: var(--err); }
+.modal-card p { color: var(--muted); margin: .35rem 0 .9rem; }
+.modal-card code { color: var(--fg); background: var(--err-soft); padding: 0 .3rem; border-radius: 4px; }
+.modal-card input {
+  width: 100%; font: inherit; color: var(--fg);
+  background: var(--bg); border: 1px solid var(--border); border-radius: 7px;
+  padding: .5rem .6rem; margin-bottom: 1rem; font-family: ui-monospace, monospace;
+}
+.modal-card input:focus { outline: none; border-color: var(--err); }
+.modal-actions { display: flex; gap: .6rem; justify-content: flex-end; }

--- a/trading_bot/interfaces/ui/templates/control.html
+++ b/trading_bot/interfaces/ui/templates/control.html
@@ -8,13 +8,17 @@
 </head>
 <body>
   <!-- Control plane: lists the daemon's managed strategies and lets you start /
-       stop them and switch mode (paper / testnet / live). Switching to LIVE asks
-       for a typed confirmation; all state is fetched/changed via /api/strategies. -->
+       stop them and switch mode (paper / testnet / live). Switching to LIVE opens
+       a typed confirmation; all state is fetched/changed via /api/strategies. -->
   <header class="topbar">
     <div class="brand-group">
       <span class="brand">trading_bot</span>
       <span class="ver">v{{ version }}</span>
     </div>
+    <span class="summary">
+      <span class="chip"><b id="sum-total">—</b> strategies</span>
+      <span class="chip"><b id="sum-running">—</b> running</span>
+    </span>
     <span class="mode-badge mode-paper">control</span>
     <span id="conn" class="conn"><span class="dot"></span>connecting…</span>
   </header>
@@ -48,6 +52,22 @@
     trading_bot v{{ version }} — control plane (loopback). Switching to <b>live</b>
     trades real money and requires a typed confirmation.
   </footer>
+
+  <!-- Live confirmation modal: the deliberate "go real money" acknowledgement. -->
+  <div id="live-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="live-modal-title">
+    <div class="modal-card">
+      <h3 id="live-modal-title"><span class="warn-mark">⚠</span> Switch to LIVE — real money</h3>
+      <p>
+        You are about to switch <b id="live-modal-name">—</b> to <b>live</b>. This
+        trades <b>real money</b> on the venue. Type <code>I UNDERSTAND</code> to confirm.
+      </p>
+      <input id="live-modal-input" type="text" placeholder="I UNDERSTAND" autocomplete="off" spellcheck="false">
+      <div class="modal-actions">
+        <button id="live-modal-cancel" type="button">Cancel</button>
+        <button id="live-modal-confirm" class="btn-primary" type="button" disabled>Go live</button>
+      </div>
+    </div>
+  </div>
 
   <script src="/static/control.js"></script>
 </body>

--- a/trading_bot/tests/interfaces/test_control_api.py
+++ b/trading_bot/tests/interfaces/test_control_api.py
@@ -122,6 +122,23 @@ def test_unknown_mode_is_400() -> None:
     assert r.status_code == 400
 
 
+def test_control_dashboard_renders() -> None:
+    """`GET /` returns the control dashboard shell (brand + table + live modal)."""
+    resp = _client().get("/")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "trading_bot" in html
+    assert 'id="strategies-body"' in html  # the table control.js fills
+    assert 'id="live-modal"' in html  # the deliberate go-live confirmation
+
+
+def test_control_js_is_served() -> None:
+    """The control dashboard's script is served and carries the confirm phrase."""
+    resp = _client().get("/static/control.js")
+    assert resp.status_code == 200
+    assert "I UNDERSTAND" in resp.text
+
+
 def test_start_then_stop() -> None:
     """`POST start` runs the strategy in its own engine; `POST stop` tears it down."""
     pytest.importorskip("fynance")  # ma_crossover evaluates fynance.sma


### PR DESCRIPTION
## Summary
- Visual polish of the control dashboard: mode **badges** (paper/testnet/live, colour-coded), a running/stopped **status pill**, action-styled **start/stop** buttons, a header **summary** (N strategies · M running), and a proper **typed-confirmation modal** for going live (replaces `window.prompt`).
- Aligned with dccd's dark palette + pill/badge language; **no shipped font assets** (system stack with mono fallbacks).

## Changes
- `ui/static/style.css`: buttons, `select`, badges, run-pill, summary chips, modal.
- `ui/templates/control.html`: header summary + the live-confirm modal markup.
- `ui/static/control.js`: render with the new classes, summary, modal-driven live confirmation (still maps to `confirm:true`; server still enforces).
- Tests: dashboard `GET /` renders; `control.js` is served.

## Test plan
- [x] `pytest` — 753 passed; `ruff` + `mypy` clean; `node --check control.js` OK
- [ ] CI green