### PR TITLE
feat: group control dashboard by exchange + per-exchange broker routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Control dashboard groups strategies by exchange**, and each strategy now uses the
+  **broker matching its own venue** on testnet/live (`StrategyStatus.exchange`; a
+  strategy's `data.exchange` / a portfolio's `venue`). Switching to testnet/live is
+  refused if no broker is configured for that exchange. (#101)
+
 - **Control dashboard visual pass** — mode **badges** (paper/testnet/live, colour-coded),
   a running/stopped status pill, start/stop buttons styled by action, a header summary
   (N strategies · M running), and a proper **typed-confirmation modal** for going live

--- a/trading_bot/application/supervisor.py
+++ b/trading_bot/application/supervisor.py
@@ -69,6 +69,10 @@ class StrategyStatus:
         The strategy/portfolio's logical id.
     kind : {"strategy", "portfolio"}
         Whether it is a single-instrument strategy or a multi-asset portfolio.
+    exchange : str
+        The venue this strategy is for (a single-instrument strategy's
+        ``data.exchange``; a portfolio's ``venue``) — the key the dashboard groups
+        by, and the broker the unit uses on testnet/live.
     mode : StrategyMode
         Its current deployment mode (``paper`` / ``testnet`` / ``live``).
     running : bool
@@ -83,6 +87,7 @@ class StrategyStatus:
 
     name: str
     kind: _KIND
+    exchange: str
     mode: StrategyMode
     running: bool
     realised_pnl: Money | None
@@ -95,6 +100,7 @@ class _Unit:
 
     name: str
     kind: _KIND
+    exchange: str
     mode: StrategyMode
     config: AppConfig
     engine: Engine | None = None
@@ -140,8 +146,11 @@ class StrategySupervisor:
                 f"duplicate strategy name {name!r}: each managed unit needs a "
                 "unique name across strategies and portfolios"
             )
-        config = self._slice_for(name, kind, mode)
-        self._units[name] = _Unit(name=name, kind=kind, mode=mode, config=config)
+        exchange = self._exchange_of(name, kind)
+        config = self._slice_for(name, kind, mode, exchange)
+        self._units[name] = _Unit(
+            name=name, kind=kind, exchange=exchange, mode=mode, config=config
+        )
 
     def names(self) -> list[str]:
         """The managed strategy names, in registration order."""
@@ -155,8 +164,24 @@ class StrategySupervisor:
 
     # --- config slicing + mode mapping ------------------------------------- #
 
-    def _slice_for(self, name: str, kind: _KIND, mode: StrategyMode) -> AppConfig:
-        """The single-unit ``AppConfig`` for ``name`` in ``mode``."""
+    def _exchange_of(self, name: str, kind: _KIND) -> str:
+        """The venue a unit is for — a strategy's ``data.exchange``, a portfolio's ``venue``.
+
+        Falls back to the first configured broker's exchange (then ``"paper"``) for
+        a single-instrument strategy that declares no data source.
+        """
+        if kind == "strategy":
+            cfg = next(s for s in self._base.strategies if s.name == name)
+            if cfg.data is not None:
+                return cfg.data.exchange
+            return self._base.brokers[0].exchange if self._base.brokers else "paper"
+        pf = next(p for p in self._base.portfolios if p.name == name)
+        return pf.venue
+
+    def _slice_for(
+        self, name: str, kind: _KIND, mode: StrategyMode, exchange: str
+    ) -> AppConfig:
+        """The single-unit ``AppConfig`` for ``name`` in ``mode`` on ``exchange``."""
         if kind == "strategy":
             only = [s for s in self._base.strategies if s.name == name]
             base_slice = self._base.model_copy(
@@ -167,7 +192,7 @@ class StrategySupervisor:
             base_slice = self._base.model_copy(
                 update={"strategies": [], "portfolios": only_p}
             )
-        return _config_for_mode(base_slice, mode)
+        return _config_for_mode(base_slice, mode, exchange)
 
     # --- lifecycle --------------------------------------------------------- #
 
@@ -245,7 +270,7 @@ class StrategySupervisor:
         if was_running:
             await self.stop(name)
         unit.mode = mode
-        unit.config = self._slice_for(name, unit.kind, mode)
+        unit.config = self._slice_for(name, unit.kind, mode, unit.exchange)
         if was_running:
             await self.start(name)
 
@@ -316,6 +341,7 @@ class StrategySupervisor:
         return StrategyStatus(
             name=unit.name,
             kind=unit.kind,
+            exchange=unit.exchange,
             mode=unit.mode,
             running=unit.running,
             realised_pnl=realised,
@@ -332,23 +358,31 @@ def _mode_of(config: AppConfig) -> StrategyMode:
     return "live"
 
 
-def _config_for_mode(base_slice: AppConfig, mode: StrategyMode) -> AppConfig:
-    """Rewrite a single-unit config for ``mode`` (paper / testnet / live).
+def _config_for_mode(
+    base_slice: AppConfig, mode: StrategyMode, exchange: str
+) -> AppConfig:
+    """Rewrite a single-unit config for ``mode`` (paper / testnet / live) + ``exchange``.
 
-    ``testnet`` and ``live`` require at least one configured broker (the venue);
-    a unit with no broker can only run ``paper``.
+    ``testnet`` and ``live`` select **only the broker whose exchange matches** the
+    unit's venue — so a strategy on Kraken uses the Kraken broker and one on Binance
+    the Binance broker (each unit has its own engine). A unit with no matching broker
+    can only run ``paper``.
     """
     if mode == "paper":
         return base_slice.model_copy(
             update={"mode": "paper", "live_enabled": False}
         )
-    if not base_slice.brokers:
+    matching = [
+        b for b in base_slice.brokers if b.exchange.lower() == exchange.lower()
+    ]
+    if not matching:
         raise ConfigError(
-            f"cannot run mode {mode!r} without a configured broker; add a "
-            "'brokers' entry (the venue) or keep the strategy on paper"
+            f"cannot run mode {mode!r} on exchange {exchange!r}: no matching broker "
+            f"configured (have {[b.exchange for b in base_slice.brokers]!r}); add a "
+            "'brokers' entry for that venue, or keep the strategy on paper"
         )
     testnet = mode == "testnet"
-    brokers = [b.model_copy(update={"testnet": testnet}) for b in base_slice.brokers]
+    brokers = [b.model_copy(update={"testnet": testnet}) for b in matching]
     return base_slice.model_copy(
         update={
             "mode": "live",

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -442,6 +442,7 @@ def _status_dict(status: StrategyStatus) -> dict[str, Any]:
     return {
         "name": status.name,
         "kind": status.kind,
+        "exchange": status.exchange,
         "mode": status.mode,
         "running": status.running,
         "realised_pnl": (

--- a/trading_bot/interfaces/ui/static/control.js
+++ b/trading_bot/interfaces/ui/static/control.js
@@ -72,15 +72,32 @@ function row(s) {
   </tr>`;
 }
 
+function groupHeader(exchange, count) {
+  return `<tr class="group"><td colspan="7">
+    <span class="group-name">${escapeHtml(exchange)}</span>
+    <span class="group-count">${count}</span>
+  </td></tr>`;
+}
+
 async function refresh() {
   try {
     const list = await api("/api/strategies");
     setConn(true);
     sumTotal.textContent = list.length;
     sumRunning.textContent = list.filter((s) => s.running).length;
-    body.innerHTML = list.length
-      ? list.map(row).join("")
-      : '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
+    if (!list.length) {
+      body.innerHTML = '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
+      return;
+    }
+    // Group strategies by exchange (alphabetical), each under a header row.
+    const byEx = {};
+    for (const s of list) (byEx[s.exchange] = byEx[s.exchange] || []).push(s);
+    let html = "";
+    for (const ex of Object.keys(byEx).sort()) {
+      html += groupHeader(ex, byEx[ex].length);
+      html += byEx[ex].map(row).join("");
+    }
+    body.innerHTML = html;
   } catch (e) {
     setConn(false);
   }

--- a/trading_bot/interfaces/ui/static/style.css
+++ b/trading_bot/interfaces/ui/static/style.css
@@ -139,6 +139,21 @@ footer a { color: var(--muted); }
 }
 .chip b { color: var(--fg); font-weight: 600; }
 
+/* Exchange group-header row in the strategies table. */
+tr.group td {
+  background: var(--accent-soft);
+  border-bottom: 1px solid var(--border);
+  padding: .4rem .6rem;
+}
+tr.group .group-name {
+  font-family: var(--font-display); font-weight: 700; font-size: .74rem;
+  text-transform: uppercase; letter-spacing: .1em; color: var(--accent);
+}
+tr.group .group-count {
+  margin-left: .5rem; color: var(--muted); font-size: .72rem;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Mode badge — paper (calm), testnet (amber), live (red, emphasised). */
 .badge {
   display: inline-block; font-size: .68rem; font-weight: 700;

--- a/trading_bot/tests/application/test_supervisor.py
+++ b/trading_bot/tests/application/test_supervisor.py
@@ -136,7 +136,43 @@ async def test_testnet_without_a_broker_is_refused() -> None:
         _config(with_broker=False),
         dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(_trend())}),
     )
-    with pytest.raises(ConfigError, match="without a configured broker"):
+    with pytest.raises(ConfigError, match="no matching broker"):
+        await sup.set_mode("btc-ma", "testnet")
+
+
+def test_status_includes_the_strategys_exchange() -> None:
+    """Each unit reports the exchange it's for (a strategy's ``data.exchange``)."""
+    sup = _supervisor()
+    assert sup.status("btc-ma")[0].exchange == "kraken"
+
+
+async def test_set_mode_refused_when_no_broker_for_that_exchange() -> None:
+    """testnet/live needs a broker **matching the unit's exchange**, not just any broker.
+
+    The strategy is on Kraken (`data.exchange`), but only a Binance broker is
+    configured — switching it to testnet must be refused (per-exchange routing).
+    """
+    cfg = AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "brokers": [{"name": "bn", "exchange": "binance"}],  # no kraken broker
+            "strategies": [
+                {
+                    "name": "btc-ma",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                    "reference_qty": "2",
+                    "lookback": 6,
+                }
+            ],
+        }
+    )
+    sup = StrategySupervisor(
+        cfg, dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(_trend())})
+    )
+    assert sup.status("btc-ma")[0].exchange == "kraken"
+    with pytest.raises(ConfigError, match="no matching broker"):
         await sup.set_mode("btc-ma", "testnet")
 
 

--- a/trading_bot/tests/interfaces/test_control_api.py
+++ b/trading_bot/tests/interfaces/test_control_api.py
@@ -78,6 +78,7 @@ def test_list_strategies() -> None:
     assert resp.status_code == 200
     [s] = resp.json()
     assert s["name"] == "btc-ma"
+    assert s["exchange"] == "kraken"  # grouped/displayed by exchange
     assert s["mode"] == "paper"
     assert s["running"] is False
     assert s["realised_pnl"] is None


### PR DESCRIPTION
## Summary
- The control dashboard **groups strategies by exchange** (header row per venue).
- `StrategyStatus.exchange` — a strategy's `data.exchange`, a portfolio's `venue`.
- On **testnet/live**, each unit uses the **broker matching its own exchange** (kraken strat → kraken broker, binance → binance); switching is refused if no broker is configured for that exchange.

## Why
- You asked to arrange strategies by exchange. Doing it properly also fixed a latent gap: per-strategy mode now routes to the *right* venue's broker, not just `brokers[0]`.

## Changes
- `application/supervisor.py`: `_exchange_of`, exchange on `_Unit`/`StrategyStatus`, per-exchange broker selection in `_config_for_mode`.
- `api/app.py`: `_status_dict` includes `exchange`.
- `ui/static/control.js` + `style.css`: group-header rows.
- Tests: status exchange; testnet refused without a matching-exchange broker.

## Test plan
- [x] `pytest` — 755 passed; `ruff` + `mypy` clean; `node --check` OK
- [ ] CI green