### PR TITLE
feat: control dashboard auth — token login (remote access, dccd-style)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Control dashboard authentication (for remote access).** `create_control_app(...,
+  auth_token=…)` gates the dashboard behind a **token login** (dccd-style): `/login`
+  exchanges the token for an HttpOnly, `Secure`-over-HTTPS session cookie; an auth-guard
+  middleware refuses unauthenticated requests (`401` for `/api/*`, redirect to `/login`
+  for pages); login is **rate-limited**; `/api/*` also accepts `Bearer <token>` / `?token=`
+  for scripts; constant-time token check; a **sign-out** in the header. `trading-bot start
+  --serve --serve-token …` (or `TRADING_BOT_UI_TOKEN`) enables it and **refuses a
+  non-loopback bind without a token**. With no token (default) the app stays open —
+  loopback / SSH-tunnel only. `doc/dev/10-deploy.md` covers the token + HTTPS reverse
+  proxy. (#102)
+
 ### Changed
 
 - **Control dashboard groups strategies by exchange**, and each strategy now uses the

--- a/deploy/trading-bot.service
+++ b/deploy/trading-bot.service
@@ -22,7 +22,10 @@
 # default — it never trades real money by merely starting). Switch a strategy to
 # testnet/live from the control dashboard (http://127.0.0.1:8000) — going live
 # needs the typed confirmation there. The control UI binds loopback; reach it over
-# an SSH tunnel (ssh -L 8000:127.0.0.1:8000 host), never expose it publicly.
+# an SSH tunnel (ssh -L 8000:127.0.0.1:8000 host). To access it directly instead,
+# put TRADING_BOT_UI_TOKEN=… in the env file, change --serve-host to 0.0.0.0 below
+# (the daemon refuses a non-loopback bind WITHOUT a token), and run behind HTTPS.
+# See doc/dev/10-deploy.md.
 
 [Unit]
 Description=trading_bot — execution daemon (supervisor + scheduler + control UI)

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,29 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-30 Control dashboard auth — token login + sessions (dccd-style) (PR #102)  [accepted]
+
+**Choice.** The control dashboard gains an **optional** token auth (off by default):
+`create_control_app(supervisor, auth_token=…)`. With a token set, `/login` exchanges it
+for an HttpOnly session cookie, an auth-guard middleware gates every route except the
+login flow + `/static` (`401` for `/api/*`, redirect to `/login` for pages), login is
+rate-limited (token bucket per client), and `/api/*` also accepts `Bearer`/`?token=`.
+Constant-time comparison; `Secure` cookie over HTTPS. The CLI refuses a **non-loopback**
+`--serve-host` **without** a token. Sessions are in-process (reset on restart).
+
+**Why.** The control plane can **trade** — exposing it remotely needs auth (more than
+dccd's read-mostly UI). This mirrors dccd's proven approach so deployment is familiar.
+Off-by-default keeps the common loopback/SSH-tunnel path zero-friction; the
+non-loopback-without-token refusal makes the unsafe configuration impossible by accident.
+
+**Rejected alternatives.** HTTP Basic auth (no logout/session, credentials on every
+request); a full user/password DB (overkill for a single-operator daemon — a shared
+token is enough, rotated via the env file); `request.form()` for the login POST (pulls in
+`python-multipart` — parsed the urlencoded body directly instead); binding non-loopback
+with no auth (refused). TLS is delegated to a reverse proxy (documented), not built in.
+
+---
+
 ### 2026-06-30 Control plane: per-strategy engines + a gated `StrategySupervisor` (PR #94)  [accepted]
 
 **Choice.** The control plane (start/stop a strategy, switch its mode from the UI) is

--- a/doc/dev/10-deploy.md
+++ b/doc/dev/10-deploy.md
@@ -60,12 +60,35 @@ to the venue), so a restart converges state rather than duplicating orders.
 
 ### Reaching the dashboard
 
-The control UI binds **loopback** (`127.0.0.1`) on purpose — it can change what
-trades. Reach it over an SSH tunnel, never expose it publicly:
+The control UI binds **loopback** (`127.0.0.1`) by default — it can change what
+trades. Two ways to reach it remotely:
+
+**1. SSH tunnel (simplest, most secure).** Keep it loopback, forward a port:
 
 ```bash
 ssh -L 8000:127.0.0.1:8000 your-host    # then open http://localhost:8000
 ```
+
+**2. Direct access with a token (like dccd).** Set a token and bind a reachable
+interface; the daemon then refuses to bind non-loopback **without** a token:
+
+```bash
+export TRADING_BOT_UI_TOKEN="$(openssl rand -hex 24)"   # a strong secret
+trading-bot start -c config.yaml --serve \
+    --serve-host 0.0.0.0 --serve-port 8000 --serve-token "$TRADING_BOT_UI_TOKEN"
+```
+
+With a token set, the dashboard requires a **login**: `/login` exchanges the token
+for an HttpOnly session cookie; every other route is gated (401 for `/api/*`,
+redirect to `/login` for pages), login attempts are rate-limited, and `/api/*` also
+accepts a `Bearer <token>` header or `?token=` query for scripts. In the systemd
+unit, put `TRADING_BOT_UI_TOKEN=…` in the `EnvironmentFile` (0600) and add
+`--serve-token "$TRADING_BOT_UI_TOKEN"` (or rely on the env var) to `ExecStart`.
+
+> **Put it behind HTTPS.** The token + session protect access, but run the daemon
+> behind a TLS reverse proxy (Caddy / nginx / a Tailscale serve) so credentials and
+> the session cookie are encrypted in transit. The cookie is marked `Secure`
+> automatically when the request arrives over HTTPS (incl. `X-Forwarded-Proto`).
 
 ### Operational notes
 

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -425,6 +425,15 @@ def create_app(engine: Engine) -> FastAPI:
 #: Valid deployment modes the control API accepts.
 _CONTROL_MODES = ("paper", "testnet", "live")
 
+#: Browser session cookie set on a successful /login (opaque, HttpOnly).
+_SESSION_COOKIE = "tb_session"
+#: How long a control session stays valid (seconds).
+_SESSION_TTL_SECONDS = 12 * 3600
+#: Login attempts per minute per client (brute-force throttle).
+_LOGIN_RATE_PER_MIN = 10
+#: Path prefixes reachable without a session (the login flow + assets).
+_OPEN_PREFIXES = ("/login", "/logout", "/static")
+
 
 class _ModeBody(BaseModel):
     """Request body for ``POST /api/strategies/{name}/mode``.
@@ -452,13 +461,15 @@ def _status_dict(status: StrategyStatus) -> dict[str, Any]:
     }
 
 
-def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
+def create_control_app(
+    supervisor: StrategySupervisor, *, auth_token: str | None = None
+) -> FastAPI:
     """Build the daemon's **control** FastAPI over a :class:`StrategySupervisor`.
 
     Unlike :func:`create_app` (a *read-only* view of one engine), this app is the
     **control plane**: it lists the managed strategies and lets a client **start /
-    stop** them and **switch mode** (paper / testnet / live). It is meant to be
-    served **loopback-only** by the daemon, since it can change what trades.
+    stop** them and **switch mode** (paper / testnet / live). It binds **loopback**
+    by default; to reach it remotely, either tunnel (SSH) or set ``auth_token``.
 
     **Real money is gated.** Switching a strategy to ``live`` requires
     ``confirm: true`` in the request body — the deliberate acknowledgement the UI
@@ -466,10 +477,21 @@ def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
     nothing changes. The factory's credential + risk-limit gates still apply when a
     live unit is actually started.
 
+    **Authentication (for remote exposure).** With ``auth_token`` set, the app gates
+    every route behind a token login: ``/login`` exchanges the token for an
+    HttpOnly session cookie, an auth-guard middleware then refuses unauthenticated
+    requests (``401`` for ``/api/*``; redirect to ``/login`` for pages), and login
+    attempts are rate-limited. ``/api/*`` also accepts a ``Bearer <token>`` header
+    or ``?token=`` query (for non-browser clients). With ``auth_token`` ``None`` (the
+    default) there is **no** auth — only safe behind loopback / an SSH tunnel.
+
     Parameters
     ----------
     supervisor : StrategySupervisor
         The supervisor to expose, read+controlled through ``app.state.supervisor``.
+    auth_token : str or None, optional
+        When set, require this token to log in (enables the auth guard). ``None``
+        (default) leaves the app unauthenticated — loopback / tunnel only.
 
     Returns
     -------
@@ -487,10 +509,11 @@ def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
 
     app = FastAPI(
         title="trading_bot control",
-        summary="Supervise + control the declared strategies (loopback-only).",
+        summary="Supervise + control the declared strategies.",
         default_response_class=_DecimalJSONResponse,
     )
     app.state.supervisor = supervisor
+    app.state.auth_enabled = bool(auth_token)
 
     def _sup(request: Request) -> StrategySupervisor:
         return request.app.state.supervisor  # type: ignore[no-any-return]
@@ -509,7 +532,12 @@ def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
         async def control_dashboard(request: Request) -> Any:
             """Render the control dashboard shell (data fetched client-side)."""
             return templates.TemplateResponse(
-                request, "control.html", {"version": trading_bot.__version__}
+                request,
+                "control.html",
+                {
+                    "version": trading_bot.__version__,
+                    "auth": request.app.state.auth_enabled,
+                },
             )
 
     @app.get("/api/health")
@@ -565,4 +593,140 @@ def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {"ok": True, "status": _status_dict(_sup(request).status(name)[0])}
 
+    if auth_token:
+        _install_control_auth(app, auth_token=auth_token, templates=templates)
+
     return app
+
+
+def _install_control_auth(
+    app: FastAPI, *, auth_token: str, templates: Jinja2Templates | None
+) -> None:
+    """Gate ``app`` behind a token login — for remote exposure (dccd-style).
+
+    Adds an in-memory session store, an auth-guard middleware (``401`` for
+    ``/api/*``, redirect to ``/login`` for pages — except the open prefixes), a
+    rate-limited ``/login`` (token → HttpOnly session cookie) and ``/logout``.
+    ``/api/*`` also accepts a ``Bearer <token>`` header or ``?token=`` query for
+    non-browser clients. Constant-time token comparison; ``Secure`` cookie behind
+    HTTPS. Sessions are in-process (reset on restart — fine for a single daemon).
+    """
+    import secrets
+    import time
+
+    from fastapi.responses import RedirectResponse
+
+    app.state.sessions = {}  # sid -> created_ns
+    app.state.login_buckets = {}  # client -> (tokens, last monotonic)
+
+    def _prune() -> None:
+        cutoff = time.time_ns() - _SESSION_TTL_SECONDS * 1_000_000_000
+        for sid in [s for s, ts in app.state.sessions.items() if ts < cutoff]:
+            app.state.sessions.pop(sid, None)
+
+    def _new_session() -> str:
+        sid = secrets.token_urlsafe(32)
+        app.state.sessions[sid] = time.time_ns()
+        return sid
+
+    def _valid_session(request: Request) -> bool:
+        sid = request.cookies.get(_SESSION_COOKIE)
+        if not sid:
+            return False
+        _prune()
+        return sid in app.state.sessions
+
+    def _is_https(request: Request) -> bool:
+        if request.url.scheme == "https":
+            return True
+        fwd = request.headers.get("x-forwarded-proto", "")
+        return fwd.split(",", 1)[0].strip() == "https"
+
+    def _safe_next(nxt: str | None) -> str:
+        if nxt and nxt.startswith("/") and not nxt.startswith("//") and "\\" not in nxt:
+            return nxt
+        return "/"
+
+    def _rate_allow(key: str) -> bool:
+        buckets = app.state.login_buckets
+        now = time.monotonic()
+        rate = _LOGIN_RATE_PER_MIN / 60.0
+        tokens, last = buckets.get(key, (float(_LOGIN_RATE_PER_MIN), now))
+        tokens = min(float(_LOGIN_RATE_PER_MIN), tokens + (now - last) * rate)
+        if tokens < 1.0:
+            buckets[key] = (tokens, now)
+            return False
+        buckets[key] = (tokens - 1.0, now)
+        return True
+
+    @app.middleware("http")
+    async def _auth_guard(request: Request, call_next: Any) -> Any:
+        path = request.url.path
+        if request.method == "OPTIONS" or path.startswith(_OPEN_PREFIXES):
+            return await call_next(request)
+        if path.startswith("/api/"):
+            bearer = request.headers.get("Authorization") == f"Bearer {auth_token}"
+            query = request.query_params.get("token") == auth_token
+            if not (bearer or query or _valid_session(request)):
+                return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+        elif not _valid_session(request):
+            return RedirectResponse(f"/login?next={path}", status_code=303)
+        return await call_next(request)
+
+    def _login_page(request: Request, *, error: str = "", status: int = 200) -> Any:
+        nxt = _safe_next(request.query_params.get("next"))
+        if templates is not None:
+            return templates.TemplateResponse(
+                request,
+                "login.html",
+                {"version": trading_bot.__version__, "next": nxt, "error": error},
+                status_code=status,
+            )
+        return HTMLResponse(
+            '<form method="post" action="/login">'
+            f'<input type="hidden" name="next" value="{nxt}">'
+            '<input name="token" type="password" placeholder="token">'
+            "<button>Sign in</button></form>",
+            status_code=status,
+        )
+
+    @app.get("/login", response_class=HTMLResponse)
+    async def login_form(request: Request) -> Any:
+        return _login_page(request)
+
+    @app.post("/login")
+    async def login_submit(request: Request) -> Any:
+        client = request.client
+        if not _rate_allow(client.host if client else "unknown"):
+            return JSONResponse(
+                {"detail": "too many attempts"},
+                status_code=429,
+                headers={"Retry-After": "5"},
+            )
+        # Parse the urlencoded login form directly (no python-multipart dep).
+        from urllib.parse import parse_qs
+
+        form = parse_qs((await request.body()).decode("utf-8", "replace"))
+        token = (form.get("token") or [""])[0]
+        nxt = _safe_next((form.get("next") or ["/"])[0])
+        if not secrets.compare_digest(token, auth_token):
+            return _login_page(request, error="Invalid token.", status=401)
+        resp = RedirectResponse(nxt, status_code=303)
+        resp.set_cookie(
+            _SESSION_COOKIE,
+            _new_session(),
+            httponly=True,
+            samesite="lax",
+            secure=_is_https(request),
+            max_age=_SESSION_TTL_SECONDS,
+        )
+        return resp
+
+    @app.post("/logout")
+    async def logout(request: Request) -> Any:
+        sid = request.cookies.get(_SESSION_COOKIE)
+        if sid:
+            app.state.sessions.pop(sid, None)
+        resp = RedirectResponse("/login", status_code=303)
+        resp.delete_cookie(_SESSION_COOKIE)
+        return resp

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -723,6 +723,7 @@ async def _run_daemon(
     serve: bool = False,
     host: str = "127.0.0.1",
     port: int = 8000,
+    auth_token: str | None = None,
     dccd_client: object | None = None,
 ) -> None:
     """Supervise the declared strategies and step them on a schedule until stopped.
@@ -774,7 +775,16 @@ async def _run_daemon(
 
             from trading_bot.interfaces.api import create_control_app
 
-            api = create_control_app(supervisor)
+            if host not in ("127.0.0.1", "localhost", "::1") and not auth_token:
+                _console.print(
+                    "[red]refusing to bind a non-loopback control dashboard with no "
+                    "auth token[/red] — set --serve-token / TRADING_BOT_UI_TOKEN, or "
+                    "bind 127.0.0.1 and tunnel (the control plane can trade)."
+                )
+                raise typer.Exit(code=1)
+            api = create_control_app(supervisor, auth_token=auth_token)
+            if auth_token:
+                _console.print("[dim]control dashboard auth: token login enabled[/dim]")
             server = uvicorn.Server(
                 uvicorn.Config(api, host=host, port=port, log_level="warning")
             )
@@ -824,6 +834,13 @@ def start(
     serve_port: int = typer.Option(
         8000, "--serve-port", help="Control dashboard TCP port."
     ),
+    serve_token: str | None = typer.Option(
+        None,
+        "--serve-token",
+        envvar="TRADING_BOT_UI_TOKEN",
+        help="Require this token to log in to the control dashboard (enables auth). "
+        "Mandatory to bind a non-loopback --serve-host. Reads TRADING_BOT_UI_TOKEN.",
+    ),
 ) -> None:
     """Run the trading **daemon**: supervise the declared strategies, step on a schedule.
 
@@ -849,6 +866,7 @@ def start(
                 serve=serve,
                 host=serve_host,
                 port=serve_port,
+                auth_token=serve_token,
             )
         )
     except Exception as exc:  # noqa: BLE001 - surface any build/config failure cleanly

--- a/trading_bot/interfaces/ui/static/style.css
+++ b/trading_bot/interfaces/ui/static/style.css
@@ -139,6 +139,30 @@ footer a { color: var(--muted); }
 }
 .chip b { color: var(--fg); font-weight: 600; }
 
+/* Sign-out in the control header. */
+.logout-form { margin: 0; }
+.logout-btn {
+  font-size: .76rem; color: var(--muted); background: transparent;
+  border: 1px solid var(--border); border-radius: 7px; padding: .28rem .65rem;
+}
+.logout-btn:hover { color: var(--err); border-color: rgba(248,81,73,.45); background: var(--err-soft); }
+
+/* Login page — centred card. */
+.login-body { display: flex; min-height: 100vh; align-items: center; justify-content: center; }
+.login-card { width: min(92vw, 360px); }
+.login-card h2 {
+  margin: 0 0 1rem; font-size: .82rem; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+}
+.login-card label { display: block; font-size: .82rem; color: var(--muted); margin-bottom: .35rem; }
+.login-card input[type="password"] {
+  width: 100%; font: inherit; color: var(--fg); font-family: ui-monospace, monospace;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
+  padding: .6rem .7rem;
+}
+.login-card input[type="password"]:focus { outline: none; border-color: var(--accent); }
+.login-err { margin: .9rem 0 0; color: var(--err); font-size: .85rem; }
+
 /* Exchange group-header row in the strategies table. */
 tr.group td {
   background: var(--accent-soft);

--- a/trading_bot/interfaces/ui/templates/control.html
+++ b/trading_bot/interfaces/ui/templates/control.html
@@ -21,6 +21,11 @@
     </span>
     <span class="mode-badge mode-paper">control</span>
     <span id="conn" class="conn"><span class="dot"></span>connecting…</span>
+    {% if auth %}
+    <form method="post" action="/logout" class="logout-form">
+      <button type="submit" class="logout-btn">sign out</button>
+    </form>
+    {% endif %}
   </header>
 
   <main>

--- a/trading_bot/interfaces/ui/templates/login.html
+++ b/trading_bot/interfaces/ui/templates/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>trading_bot — sign in</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body class="login-body">
+  <form class="login-card card" method="post" action="/login" autocomplete="off">
+    <div class="brand-group" style="margin-bottom: 1rem;">
+      <span class="brand">trading_bot</span>
+      <span class="ver">v{{ version }}</span>
+    </div>
+    <h2>Control — sign in</h2>
+    <input type="hidden" name="next" value="{{ next }}">
+    <label for="token">Access token</label>
+    <input id="token" name="token" type="password" autocomplete="current-password" autofocus spellcheck="false">
+    <button class="btn-primary" type="submit" style="width: 100%; margin-top: .9rem;">Sign in</button>
+    {% if error %}<p class="login-err">{{ error }}</p>{% endif %}
+  </form>
+</body>
+</html>

--- a/trading_bot/tests/interfaces/test_control_api.py
+++ b/trading_bot/tests/interfaces/test_control_api.py
@@ -152,3 +152,75 @@ def test_start_then_stop() -> None:
     r = client.post("/api/strategies/btc-ma/stop")
     assert r.status_code == 200
     assert r.json()["status"]["running"] is False
+
+
+# --- auth (token login, for remote exposure) ------------------------------- #
+
+
+def _auth_client(token: str = "secret-token") -> tuple[TestClient, str]:
+    trend = [100.0 + i for i in range(20)] + [119.0 - i for i in range(1, 21)]
+    sup = StrategySupervisor(
+        _config(), dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(trend)})
+    )
+    return TestClient(create_control_app(sup, auth_token=token)), token
+
+
+def test_no_token_means_no_auth() -> None:
+    """Default (no `auth_token`) — the app is open (loopback/tunnel use)."""
+    assert _client().get("/api/strategies").status_code == 200
+
+
+def test_auth_api_requires_a_token() -> None:
+    """With auth on, an unauthenticated `/api/*` call is 401."""
+    client, _ = _auth_client()
+    assert client.get("/api/strategies").status_code == 401
+
+
+def test_auth_bearer_and_query_token_work() -> None:
+    """`/api/*` accepts a Bearer header or `?token=` (non-browser clients)."""
+    client, token = _auth_client()
+    assert client.get(
+        "/api/strategies", headers={"Authorization": f"Bearer {token}"}
+    ).status_code == 200
+    assert client.get(f"/api/strategies?token={token}").status_code == 200
+
+
+def test_auth_page_redirects_to_login() -> None:
+    """An unauthenticated page request redirects to /login."""
+    client, _ = _auth_client()
+    r = client.get("/", follow_redirects=False)
+    assert r.status_code == 303
+    assert "/login" in r.headers["location"]
+
+
+def test_auth_login_flow_sets_session_cookie() -> None:
+    """A correct token at /login mints a session cookie that authenticates; logout clears it."""
+    client, token = _auth_client()
+    assert client.get("/login").status_code == 200  # the form is open
+
+    bad = client.post(
+        "/login", data={"token": "nope", "next": "/"}, follow_redirects=False
+    )
+    assert bad.status_code == 401
+    assert client.get("/api/strategies").status_code == 401  # still no session
+
+    ok = client.post(
+        "/login", data={"token": token, "next": "/"}, follow_redirects=False
+    )
+    assert ok.status_code == 303
+    assert client.get("/api/strategies").status_code == 200  # session cookie works
+
+    client.post("/logout", follow_redirects=False)
+    assert client.get("/api/strategies").status_code == 401  # cleared
+
+
+def test_auth_login_is_rate_limited() -> None:
+    """Repeated login attempts are throttled (429) — brute-force guard."""
+    client, _ = _auth_client()
+    statuses = [
+        client.post(
+            "/login", data={"token": "x", "next": "/"}, follow_redirects=False
+        ).status_code
+        for _ in range(20)
+    ]
+    assert 429 in statuses


### PR DESCRIPTION
## Summary
- `create_control_app(..., auth_token=…)` gates the control dashboard behind a **token login**: `/login` → HttpOnly (`Secure`-over-HTTPS) session cookie, an auth-guard middleware (`401` for `/api/*`, redirect to `/login` for pages), **rate-limited** login, `Bearer`/`?token=` for scripts, constant-time check, a header **sign-out**.
- `trading-bot start --serve --serve-token …` (or `TRADING_BOT_UI_TOKEN`) enables it and **refuses a non-loopback bind without a token**.
- Off by default → the loopback / SSH-tunnel path is unchanged.

## Why
- You chose direct remote access "comme dccd". The control plane can **trade**, so exposing it needs auth. Mirrors dccd's approach.

## Changes
- `api/app.py`: `_install_control_auth` (sessions, middleware, `/login`, `/logout`); urlencoded body parsed directly (no `python-multipart` dep).
- `cli/main.py`: `--serve-token` (`envvar=TRADING_BOT_UI_TOKEN`) + the non-loopback refusal.
- `ui/templates/login.html` + sign-out in `control.html` + CSS.
- `doc/dev/10-deploy.md` + the systemd unit note (token + HTTPS reverse proxy).
- Tests: 401 without auth; Bearer/query; page→/login redirect; login→cookie→authed→logout; rate-limit 429; default (no token) stays open.

## Test plan
- [x] `pytest` — 761 passed; `ruff` + `mypy` clean
- [ ] CI green