### PR TITLE
fix: add apscheduler to the dev extra (green CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI was red since the daemon landed** — `apscheduler` was in the `daemon` extra but
+  missing from `dev`, while the daemon test (`test_daemon_starts_ticks_and_stops_cleanly`)
+  drives `_run_daemon`, which imports it. CI installs `.[dev]`, so it hit
+  `ModuleNotFoundError: No module named 'apscheduler'` (masked locally by a dev env that
+  also had `[daemon]`). Added `apscheduler` to the `dev` extra, like the other daemon
+  runtime deps the suite already exercises. (#103)
+
 ### Deprecated
 
 ### Removed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ dev = [
     "uvicorn[standard]>=0.29",
     # The web UI templating so the unit suite / CI can render the dashboard shell.
     "jinja2>=3.1",
+    # The daemon scheduler so the unit suite / CI can exercise `trading-bot start`
+    # (the daemon test drives `_run_daemon`, which imports apscheduler).
+    "apscheduler>=3.10,<4",
 ]
 doc = [
     "sphinx>=7.0",


### PR DESCRIPTION
## Summary
- CI has been **red since the daemon landed** (#95): `apscheduler` was in the `daemon` extra only, but CI installs `.[dev]` and `test_daemon_starts_ticks_and_stops_cleanly` drives `_run_daemon`, which imports `apscheduler` → `ModuleNotFoundError`.
- Masked locally because the dev env also had `[daemon]` installed.

## Fix
- Add `apscheduler>=3.10,<4` to the **`dev`** extra, consistent with the other daemon runtime deps the suite already exercises (`typer`/`fastapi`/`uvicorn`/`jinja2`).

## Test plan
- [x] `test_daemon_starts_ticks_and_stops_cleanly` passes
- [x] `ruff check trading_bot/` clean
- [ ] CI green (the point of this PR)