### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Control dashboard groups strategies by exchange**, and each strategy now uses the
+  **broker matching its own venue** on testnet/live (`StrategyStatus.exchange`; a
+  strategy's `data.exchange` / a portfolio's `venue`). Switching to testnet/live is
+  refused if no broker is configured for that exchange. (#101)
+
 - **Control dashboard visual pass** — mode **badges** (paper/testnet/live, colour-coded),
   a running/stopped status pill, start/stop buttons styled by action, a header summary
   (N strategies · M running), and a proper **typed-confirmation modal** for going live

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Deprecated
+
+### Removed
+
+## [0.7.0] - 2026-06-30
+
+### Added
+
 - **Control dashboard authentication (for remote access).** `create_control_app(...,
   auth_token=…)` gates the dashboard behind a **token login** (dccd-style): `/login`
   exchanges the token for an HttpOnly, `Secure`-over-HTTPS session cookie; an auth-guard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **CI was red since the daemon landed** — `apscheduler` was in the `daemon` extra but
+  missing from `dev`, while the daemon test (`test_daemon_starts_ticks_and_stops_cleanly`)
+  drives `_run_daemon`, which imports it. CI installs `.[dev]`, so it hit
+  `ModuleNotFoundError: No module named 'apscheduler'` (masked locally by a dev env that
+  also had `[daemon]`). Added `apscheduler` to the `dev` extra, like the other daemon
+  runtime deps the suite already exercises. (#103)
+
 ### Deprecated
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Control dashboard authentication (for remote access).** `create_control_app(...,
+  auth_token=…)` gates the dashboard behind a **token login** (dccd-style): `/login`
+  exchanges the token for an HttpOnly, `Secure`-over-HTTPS session cookie; an auth-guard
+  middleware refuses unauthenticated requests (`401` for `/api/*`, redirect to `/login`
+  for pages); login is **rate-limited**; `/api/*` also accepts `Bearer <token>` / `?token=`
+  for scripts; constant-time token check; a **sign-out** in the header. `trading-bot start
+  --serve --serve-token …` (or `TRADING_BOT_UI_TOKEN`) enables it and **refuses a
+  non-loopback bind without a token**. With no token (default) the app stays open —
+  loopback / SSH-tunnel only. `doc/dev/10-deploy.md` covers the token + HTTPS reverse
+  proxy. (#102)
+
 ### Changed
 
 - **Control dashboard groups strategies by exchange**, and each strategy now uses the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Control dashboard visual pass** — mode **badges** (paper/testnet/live, colour-coded),
+  a running/stopped status pill, start/stop buttons styled by action, a header summary
+  (N strategies · M running), and a proper **typed-confirmation modal** for going live
+  (replaces the browser `prompt`). Aligned with dccd's dark palette/pill language; no
+  shipped font assets. (#100)
+
 ### Fixed
 
 ### Deprecated

--- a/deploy/trading-bot.service
+++ b/deploy/trading-bot.service
@@ -22,7 +22,10 @@
 # default — it never trades real money by merely starting). Switch a strategy to
 # testnet/live from the control dashboard (http://127.0.0.1:8000) — going live
 # needs the typed confirmation there. The control UI binds loopback; reach it over
-# an SSH tunnel (ssh -L 8000:127.0.0.1:8000 host), never expose it publicly.
+# an SSH tunnel (ssh -L 8000:127.0.0.1:8000 host). To access it directly instead,
+# put TRADING_BOT_UI_TOKEN=… in the env file, change --serve-host to 0.0.0.0 below
+# (the daemon refuses a non-loopback bind WITHOUT a token), and run behind HTTPS.
+# See doc/dev/10-deploy.md.
 
 [Unit]
 Description=trading_bot — execution daemon (supervisor + scheduler + control UI)

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,29 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-06-30 Control dashboard auth — token login + sessions (dccd-style) (PR #102)  [accepted]
+
+**Choice.** The control dashboard gains an **optional** token auth (off by default):
+`create_control_app(supervisor, auth_token=…)`. With a token set, `/login` exchanges it
+for an HttpOnly session cookie, an auth-guard middleware gates every route except the
+login flow + `/static` (`401` for `/api/*`, redirect to `/login` for pages), login is
+rate-limited (token bucket per client), and `/api/*` also accepts `Bearer`/`?token=`.
+Constant-time comparison; `Secure` cookie over HTTPS. The CLI refuses a **non-loopback**
+`--serve-host` **without** a token. Sessions are in-process (reset on restart).
+
+**Why.** The control plane can **trade** — exposing it remotely needs auth (more than
+dccd's read-mostly UI). This mirrors dccd's proven approach so deployment is familiar.
+Off-by-default keeps the common loopback/SSH-tunnel path zero-friction; the
+non-loopback-without-token refusal makes the unsafe configuration impossible by accident.
+
+**Rejected alternatives.** HTTP Basic auth (no logout/session, credentials on every
+request); a full user/password DB (overkill for a single-operator daemon — a shared
+token is enough, rotated via the env file); `request.form()` for the login POST (pulls in
+`python-multipart` — parsed the urlencoded body directly instead); binding non-loopback
+with no auth (refused). TLS is delegated to a reverse proxy (documented), not built in.
+
+---
+
 ### 2026-06-30 Control plane: per-strategy engines + a gated `StrategySupervisor` (PR #94)  [accepted]
 
 **Choice.** The control plane (start/stop a strategy, switch its mode from the UI) is

--- a/doc/dev/10-deploy.md
+++ b/doc/dev/10-deploy.md
@@ -60,12 +60,35 @@ to the venue), so a restart converges state rather than duplicating orders.
 
 ### Reaching the dashboard
 
-The control UI binds **loopback** (`127.0.0.1`) on purpose — it can change what
-trades. Reach it over an SSH tunnel, never expose it publicly:
+The control UI binds **loopback** (`127.0.0.1`) by default — it can change what
+trades. Two ways to reach it remotely:
+
+**1. SSH tunnel (simplest, most secure).** Keep it loopback, forward a port:
 
 ```bash
 ssh -L 8000:127.0.0.1:8000 your-host    # then open http://localhost:8000
 ```
+
+**2. Direct access with a token (like dccd).** Set a token and bind a reachable
+interface; the daemon then refuses to bind non-loopback **without** a token:
+
+```bash
+export TRADING_BOT_UI_TOKEN="$(openssl rand -hex 24)"   # a strong secret
+trading-bot start -c config.yaml --serve \
+    --serve-host 0.0.0.0 --serve-port 8000 --serve-token "$TRADING_BOT_UI_TOKEN"
+```
+
+With a token set, the dashboard requires a **login**: `/login` exchanges the token
+for an HttpOnly session cookie; every other route is gated (401 for `/api/*`,
+redirect to `/login` for pages), login attempts are rate-limited, and `/api/*` also
+accepts a `Bearer <token>` header or `?token=` query for scripts. In the systemd
+unit, put `TRADING_BOT_UI_TOKEN=…` in the `EnvironmentFile` (0600) and add
+`--serve-token "$TRADING_BOT_UI_TOKEN"` (or rely on the env var) to `ExecStart`.
+
+> **Put it behind HTTPS.** The token + session protect access, but run the daemon
+> behind a TLS reverse proxy (Caddy / nginx / a Tailscale serve) so credentials and
+> the session cookie are encrypted in transit. The cookie is marked `Secure`
+> automatically when the request arrives over HTTPS (incl. `X-Forwarded-Proto`).
 
 ### Operational notes
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "trading_bot"
-version = "0.6.0"
+version = "0.7.0"
 description = "Execution & orchestration layer of the trading triptych — live strategies, order routing, risk. Hexagonal, async-first."
 readme = "README.md"
 license = { text = "MIT" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,9 @@ dev = [
     "uvicorn[standard]>=0.29",
     # The web UI templating so the unit suite / CI can render the dashboard shell.
     "jinja2>=3.1",
+    # The daemon scheduler so the unit suite / CI can exercise `trading-bot start`
+    # (the daemon test drives `_run_daemon`, which imports apscheduler).
+    "apscheduler>=3.10,<4",
 ]
 doc = [
     "sphinx>=7.0",

--- a/trading_bot/application/supervisor.py
+++ b/trading_bot/application/supervisor.py
@@ -69,6 +69,10 @@ class StrategyStatus:
         The strategy/portfolio's logical id.
     kind : {"strategy", "portfolio"}
         Whether it is a single-instrument strategy or a multi-asset portfolio.
+    exchange : str
+        The venue this strategy is for (a single-instrument strategy's
+        ``data.exchange``; a portfolio's ``venue``) — the key the dashboard groups
+        by, and the broker the unit uses on testnet/live.
     mode : StrategyMode
         Its current deployment mode (``paper`` / ``testnet`` / ``live``).
     running : bool
@@ -83,6 +87,7 @@ class StrategyStatus:
 
     name: str
     kind: _KIND
+    exchange: str
     mode: StrategyMode
     running: bool
     realised_pnl: Money | None
@@ -95,6 +100,7 @@ class _Unit:
 
     name: str
     kind: _KIND
+    exchange: str
     mode: StrategyMode
     config: AppConfig
     engine: Engine | None = None
@@ -140,8 +146,11 @@ class StrategySupervisor:
                 f"duplicate strategy name {name!r}: each managed unit needs a "
                 "unique name across strategies and portfolios"
             )
-        config = self._slice_for(name, kind, mode)
-        self._units[name] = _Unit(name=name, kind=kind, mode=mode, config=config)
+        exchange = self._exchange_of(name, kind)
+        config = self._slice_for(name, kind, mode, exchange)
+        self._units[name] = _Unit(
+            name=name, kind=kind, exchange=exchange, mode=mode, config=config
+        )
 
     def names(self) -> list[str]:
         """The managed strategy names, in registration order."""
@@ -155,8 +164,24 @@ class StrategySupervisor:
 
     # --- config slicing + mode mapping ------------------------------------- #
 
-    def _slice_for(self, name: str, kind: _KIND, mode: StrategyMode) -> AppConfig:
-        """The single-unit ``AppConfig`` for ``name`` in ``mode``."""
+    def _exchange_of(self, name: str, kind: _KIND) -> str:
+        """The venue a unit is for — a strategy's ``data.exchange``, a portfolio's ``venue``.
+
+        Falls back to the first configured broker's exchange (then ``"paper"``) for
+        a single-instrument strategy that declares no data source.
+        """
+        if kind == "strategy":
+            cfg = next(s for s in self._base.strategies if s.name == name)
+            if cfg.data is not None:
+                return cfg.data.exchange
+            return self._base.brokers[0].exchange if self._base.brokers else "paper"
+        pf = next(p for p in self._base.portfolios if p.name == name)
+        return pf.venue
+
+    def _slice_for(
+        self, name: str, kind: _KIND, mode: StrategyMode, exchange: str
+    ) -> AppConfig:
+        """The single-unit ``AppConfig`` for ``name`` in ``mode`` on ``exchange``."""
         if kind == "strategy":
             only = [s for s in self._base.strategies if s.name == name]
             base_slice = self._base.model_copy(
@@ -167,7 +192,7 @@ class StrategySupervisor:
             base_slice = self._base.model_copy(
                 update={"strategies": [], "portfolios": only_p}
             )
-        return _config_for_mode(base_slice, mode)
+        return _config_for_mode(base_slice, mode, exchange)
 
     # --- lifecycle --------------------------------------------------------- #
 
@@ -245,7 +270,7 @@ class StrategySupervisor:
         if was_running:
             await self.stop(name)
         unit.mode = mode
-        unit.config = self._slice_for(name, unit.kind, mode)
+        unit.config = self._slice_for(name, unit.kind, mode, unit.exchange)
         if was_running:
             await self.start(name)
 
@@ -316,6 +341,7 @@ class StrategySupervisor:
         return StrategyStatus(
             name=unit.name,
             kind=unit.kind,
+            exchange=unit.exchange,
             mode=unit.mode,
             running=unit.running,
             realised_pnl=realised,
@@ -332,23 +358,31 @@ def _mode_of(config: AppConfig) -> StrategyMode:
     return "live"
 
 
-def _config_for_mode(base_slice: AppConfig, mode: StrategyMode) -> AppConfig:
-    """Rewrite a single-unit config for ``mode`` (paper / testnet / live).
+def _config_for_mode(
+    base_slice: AppConfig, mode: StrategyMode, exchange: str
+) -> AppConfig:
+    """Rewrite a single-unit config for ``mode`` (paper / testnet / live) + ``exchange``.
 
-    ``testnet`` and ``live`` require at least one configured broker (the venue);
-    a unit with no broker can only run ``paper``.
+    ``testnet`` and ``live`` select **only the broker whose exchange matches** the
+    unit's venue — so a strategy on Kraken uses the Kraken broker and one on Binance
+    the Binance broker (each unit has its own engine). A unit with no matching broker
+    can only run ``paper``.
     """
     if mode == "paper":
         return base_slice.model_copy(
             update={"mode": "paper", "live_enabled": False}
         )
-    if not base_slice.brokers:
+    matching = [
+        b for b in base_slice.brokers if b.exchange.lower() == exchange.lower()
+    ]
+    if not matching:
         raise ConfigError(
-            f"cannot run mode {mode!r} without a configured broker; add a "
-            "'brokers' entry (the venue) or keep the strategy on paper"
+            f"cannot run mode {mode!r} on exchange {exchange!r}: no matching broker "
+            f"configured (have {[b.exchange for b in base_slice.brokers]!r}); add a "
+            "'brokers' entry for that venue, or keep the strategy on paper"
         )
     testnet = mode == "testnet"
-    brokers = [b.model_copy(update={"testnet": testnet}) for b in base_slice.brokers]
+    brokers = [b.model_copy(update={"testnet": testnet}) for b in matching]
     return base_slice.model_copy(
         update={
             "mode": "live",

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -442,6 +442,7 @@ def _status_dict(status: StrategyStatus) -> dict[str, Any]:
     return {
         "name": status.name,
         "kind": status.kind,
+        "exchange": status.exchange,
         "mode": status.mode,
         "running": status.running,
         "realised_pnl": (

--- a/trading_bot/interfaces/api/app.py
+++ b/trading_bot/interfaces/api/app.py
@@ -425,6 +425,15 @@ def create_app(engine: Engine) -> FastAPI:
 #: Valid deployment modes the control API accepts.
 _CONTROL_MODES = ("paper", "testnet", "live")
 
+#: Browser session cookie set on a successful /login (opaque, HttpOnly).
+_SESSION_COOKIE = "tb_session"
+#: How long a control session stays valid (seconds).
+_SESSION_TTL_SECONDS = 12 * 3600
+#: Login attempts per minute per client (brute-force throttle).
+_LOGIN_RATE_PER_MIN = 10
+#: Path prefixes reachable without a session (the login flow + assets).
+_OPEN_PREFIXES = ("/login", "/logout", "/static")
+
 
 class _ModeBody(BaseModel):
     """Request body for ``POST /api/strategies/{name}/mode``.
@@ -452,13 +461,15 @@ def _status_dict(status: StrategyStatus) -> dict[str, Any]:
     }
 
 
-def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
+def create_control_app(
+    supervisor: StrategySupervisor, *, auth_token: str | None = None
+) -> FastAPI:
     """Build the daemon's **control** FastAPI over a :class:`StrategySupervisor`.
 
     Unlike :func:`create_app` (a *read-only* view of one engine), this app is the
     **control plane**: it lists the managed strategies and lets a client **start /
-    stop** them and **switch mode** (paper / testnet / live). It is meant to be
-    served **loopback-only** by the daemon, since it can change what trades.
+    stop** them and **switch mode** (paper / testnet / live). It binds **loopback**
+    by default; to reach it remotely, either tunnel (SSH) or set ``auth_token``.
 
     **Real money is gated.** Switching a strategy to ``live`` requires
     ``confirm: true`` in the request body — the deliberate acknowledgement the UI
@@ -466,10 +477,21 @@ def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
     nothing changes. The factory's credential + risk-limit gates still apply when a
     live unit is actually started.
 
+    **Authentication (for remote exposure).** With ``auth_token`` set, the app gates
+    every route behind a token login: ``/login`` exchanges the token for an
+    HttpOnly session cookie, an auth-guard middleware then refuses unauthenticated
+    requests (``401`` for ``/api/*``; redirect to ``/login`` for pages), and login
+    attempts are rate-limited. ``/api/*`` also accepts a ``Bearer <token>`` header
+    or ``?token=`` query (for non-browser clients). With ``auth_token`` ``None`` (the
+    default) there is **no** auth — only safe behind loopback / an SSH tunnel.
+
     Parameters
     ----------
     supervisor : StrategySupervisor
         The supervisor to expose, read+controlled through ``app.state.supervisor``.
+    auth_token : str or None, optional
+        When set, require this token to log in (enables the auth guard). ``None``
+        (default) leaves the app unauthenticated — loopback / tunnel only.
 
     Returns
     -------
@@ -487,10 +509,11 @@ def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
 
     app = FastAPI(
         title="trading_bot control",
-        summary="Supervise + control the declared strategies (loopback-only).",
+        summary="Supervise + control the declared strategies.",
         default_response_class=_DecimalJSONResponse,
     )
     app.state.supervisor = supervisor
+    app.state.auth_enabled = bool(auth_token)
 
     def _sup(request: Request) -> StrategySupervisor:
         return request.app.state.supervisor  # type: ignore[no-any-return]
@@ -509,7 +532,12 @@ def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
         async def control_dashboard(request: Request) -> Any:
             """Render the control dashboard shell (data fetched client-side)."""
             return templates.TemplateResponse(
-                request, "control.html", {"version": trading_bot.__version__}
+                request,
+                "control.html",
+                {
+                    "version": trading_bot.__version__,
+                    "auth": request.app.state.auth_enabled,
+                },
             )
 
     @app.get("/api/health")
@@ -565,4 +593,140 @@ def create_control_app(supervisor: StrategySupervisor) -> FastAPI:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {"ok": True, "status": _status_dict(_sup(request).status(name)[0])}
 
+    if auth_token:
+        _install_control_auth(app, auth_token=auth_token, templates=templates)
+
     return app
+
+
+def _install_control_auth(
+    app: FastAPI, *, auth_token: str, templates: Jinja2Templates | None
+) -> None:
+    """Gate ``app`` behind a token login — for remote exposure (dccd-style).
+
+    Adds an in-memory session store, an auth-guard middleware (``401`` for
+    ``/api/*``, redirect to ``/login`` for pages — except the open prefixes), a
+    rate-limited ``/login`` (token → HttpOnly session cookie) and ``/logout``.
+    ``/api/*`` also accepts a ``Bearer <token>`` header or ``?token=`` query for
+    non-browser clients. Constant-time token comparison; ``Secure`` cookie behind
+    HTTPS. Sessions are in-process (reset on restart — fine for a single daemon).
+    """
+    import secrets
+    import time
+
+    from fastapi.responses import RedirectResponse
+
+    app.state.sessions = {}  # sid -> created_ns
+    app.state.login_buckets = {}  # client -> (tokens, last monotonic)
+
+    def _prune() -> None:
+        cutoff = time.time_ns() - _SESSION_TTL_SECONDS * 1_000_000_000
+        for sid in [s for s, ts in app.state.sessions.items() if ts < cutoff]:
+            app.state.sessions.pop(sid, None)
+
+    def _new_session() -> str:
+        sid = secrets.token_urlsafe(32)
+        app.state.sessions[sid] = time.time_ns()
+        return sid
+
+    def _valid_session(request: Request) -> bool:
+        sid = request.cookies.get(_SESSION_COOKIE)
+        if not sid:
+            return False
+        _prune()
+        return sid in app.state.sessions
+
+    def _is_https(request: Request) -> bool:
+        if request.url.scheme == "https":
+            return True
+        fwd = request.headers.get("x-forwarded-proto", "")
+        return fwd.split(",", 1)[0].strip() == "https"
+
+    def _safe_next(nxt: str | None) -> str:
+        if nxt and nxt.startswith("/") and not nxt.startswith("//") and "\\" not in nxt:
+            return nxt
+        return "/"
+
+    def _rate_allow(key: str) -> bool:
+        buckets = app.state.login_buckets
+        now = time.monotonic()
+        rate = _LOGIN_RATE_PER_MIN / 60.0
+        tokens, last = buckets.get(key, (float(_LOGIN_RATE_PER_MIN), now))
+        tokens = min(float(_LOGIN_RATE_PER_MIN), tokens + (now - last) * rate)
+        if tokens < 1.0:
+            buckets[key] = (tokens, now)
+            return False
+        buckets[key] = (tokens - 1.0, now)
+        return True
+
+    @app.middleware("http")
+    async def _auth_guard(request: Request, call_next: Any) -> Any:
+        path = request.url.path
+        if request.method == "OPTIONS" or path.startswith(_OPEN_PREFIXES):
+            return await call_next(request)
+        if path.startswith("/api/"):
+            bearer = request.headers.get("Authorization") == f"Bearer {auth_token}"
+            query = request.query_params.get("token") == auth_token
+            if not (bearer or query or _valid_session(request)):
+                return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+        elif not _valid_session(request):
+            return RedirectResponse(f"/login?next={path}", status_code=303)
+        return await call_next(request)
+
+    def _login_page(request: Request, *, error: str = "", status: int = 200) -> Any:
+        nxt = _safe_next(request.query_params.get("next"))
+        if templates is not None:
+            return templates.TemplateResponse(
+                request,
+                "login.html",
+                {"version": trading_bot.__version__, "next": nxt, "error": error},
+                status_code=status,
+            )
+        return HTMLResponse(
+            '<form method="post" action="/login">'
+            f'<input type="hidden" name="next" value="{nxt}">'
+            '<input name="token" type="password" placeholder="token">'
+            "<button>Sign in</button></form>",
+            status_code=status,
+        )
+
+    @app.get("/login", response_class=HTMLResponse)
+    async def login_form(request: Request) -> Any:
+        return _login_page(request)
+
+    @app.post("/login")
+    async def login_submit(request: Request) -> Any:
+        client = request.client
+        if not _rate_allow(client.host if client else "unknown"):
+            return JSONResponse(
+                {"detail": "too many attempts"},
+                status_code=429,
+                headers={"Retry-After": "5"},
+            )
+        # Parse the urlencoded login form directly (no python-multipart dep).
+        from urllib.parse import parse_qs
+
+        form = parse_qs((await request.body()).decode("utf-8", "replace"))
+        token = (form.get("token") or [""])[0]
+        nxt = _safe_next((form.get("next") or ["/"])[0])
+        if not secrets.compare_digest(token, auth_token):
+            return _login_page(request, error="Invalid token.", status=401)
+        resp = RedirectResponse(nxt, status_code=303)
+        resp.set_cookie(
+            _SESSION_COOKIE,
+            _new_session(),
+            httponly=True,
+            samesite="lax",
+            secure=_is_https(request),
+            max_age=_SESSION_TTL_SECONDS,
+        )
+        return resp
+
+    @app.post("/logout")
+    async def logout(request: Request) -> Any:
+        sid = request.cookies.get(_SESSION_COOKIE)
+        if sid:
+            app.state.sessions.pop(sid, None)
+        resp = RedirectResponse("/login", status_code=303)
+        resp.delete_cookie(_SESSION_COOKIE)
+        return resp

--- a/trading_bot/interfaces/cli/main.py
+++ b/trading_bot/interfaces/cli/main.py
@@ -723,6 +723,7 @@ async def _run_daemon(
     serve: bool = False,
     host: str = "127.0.0.1",
     port: int = 8000,
+    auth_token: str | None = None,
     dccd_client: object | None = None,
 ) -> None:
     """Supervise the declared strategies and step them on a schedule until stopped.
@@ -774,7 +775,16 @@ async def _run_daemon(
 
             from trading_bot.interfaces.api import create_control_app
 
-            api = create_control_app(supervisor)
+            if host not in ("127.0.0.1", "localhost", "::1") and not auth_token:
+                _console.print(
+                    "[red]refusing to bind a non-loopback control dashboard with no "
+                    "auth token[/red] — set --serve-token / TRADING_BOT_UI_TOKEN, or "
+                    "bind 127.0.0.1 and tunnel (the control plane can trade)."
+                )
+                raise typer.Exit(code=1)
+            api = create_control_app(supervisor, auth_token=auth_token)
+            if auth_token:
+                _console.print("[dim]control dashboard auth: token login enabled[/dim]")
             server = uvicorn.Server(
                 uvicorn.Config(api, host=host, port=port, log_level="warning")
             )
@@ -824,6 +834,13 @@ def start(
     serve_port: int = typer.Option(
         8000, "--serve-port", help="Control dashboard TCP port."
     ),
+    serve_token: str | None = typer.Option(
+        None,
+        "--serve-token",
+        envvar="TRADING_BOT_UI_TOKEN",
+        help="Require this token to log in to the control dashboard (enables auth). "
+        "Mandatory to bind a non-loopback --serve-host. Reads TRADING_BOT_UI_TOKEN.",
+    ),
 ) -> None:
     """Run the trading **daemon**: supervise the declared strategies, step on a schedule.
 
@@ -849,6 +866,7 @@ def start(
                 serve=serve,
                 host=serve_host,
                 port=serve_port,
+                auth_token=serve_token,
             )
         )
     except Exception as exc:  # noqa: BLE001 - surface any build/config failure cleanly

--- a/trading_bot/interfaces/ui/static/control.js
+++ b/trading_bot/interfaces/ui/static/control.js
@@ -72,15 +72,32 @@ function row(s) {
   </tr>`;
 }
 
+function groupHeader(exchange, count) {
+  return `<tr class="group"><td colspan="7">
+    <span class="group-name">${escapeHtml(exchange)}</span>
+    <span class="group-count">${count}</span>
+  </td></tr>`;
+}
+
 async function refresh() {
   try {
     const list = await api("/api/strategies");
     setConn(true);
     sumTotal.textContent = list.length;
     sumRunning.textContent = list.filter((s) => s.running).length;
-    body.innerHTML = list.length
-      ? list.map(row).join("")
-      : '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
+    if (!list.length) {
+      body.innerHTML = '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
+      return;
+    }
+    // Group strategies by exchange (alphabetical), each under a header row.
+    const byEx = {};
+    for (const s of list) (byEx[s.exchange] = byEx[s.exchange] || []).push(s);
+    let html = "";
+    for (const ex of Object.keys(byEx).sort()) {
+      html += groupHeader(ex, byEx[ex].length);
+      html += byEx[ex].map(row).join("");
+    }
+    body.innerHTML = html;
   } catch (e) {
     setConn(false);
   }

--- a/trading_bot/interfaces/ui/static/control.js
+++ b/trading_bot/interfaces/ui/static/control.js
@@ -1,13 +1,25 @@
 // trading_bot control plane — list strategies, start/stop, switch mode.
-// Pure HTTP client of /api/strategies; switching to LIVE asks for a typed
-// confirmation that maps to {confirm:true} on the mode endpoint (the server
-// also refuses live without it).
+// Pure HTTP client of /api/strategies. Switching to LIVE opens a typed-confirmation
+// modal that maps to {confirm:true} on the mode endpoint (the server also refuses
+// live without it).
 "use strict";
 
 const MODES = ["paper", "testnet", "live"];
+const PHRASE = "I UNDERSTAND";
+
 const body = document.getElementById("strategies-body");
 const conn = document.getElementById("conn");
 const msg = document.getElementById("msg");
+const sumTotal = document.getElementById("sum-total");
+const sumRunning = document.getElementById("sum-running");
+
+const modal = document.getElementById("live-modal");
+const modalName = document.getElementById("live-modal-name");
+const modalInput = document.getElementById("live-modal-input");
+const modalConfirm = document.getElementById("live-modal-confirm");
+const modalCancel = document.getElementById("live-modal-cancel");
+
+let pendingLive = null; // {name} awaiting confirmation
 
 function setConn(ok) {
   conn.className = "conn " + (ok ? "ok" : "down");
@@ -24,32 +36,36 @@ async function api(path, opts) {
   let data = null;
   try { data = await resp.json(); } catch (e) { /* no body */ }
   if (!resp.ok) {
-    const detail = (data && data.detail) || resp.statusText;
-    throw new Error(detail);
+    throw new Error((data && data.detail) || resp.statusText);
   }
   return data;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
 }
 
 function modeSelect(s) {
   const opts = MODES.map(
     (m) => `<option value="${m}"${m === s.mode ? " selected" : ""}>${m}</option>`
   ).join("");
-  return `<select data-name="${s.name}" class="mode-select">${opts}</select>`;
+  return `<select data-name="${escapeHtml(s.name)}" class="mode-select" aria-label="mode">${opts}</select>`;
 }
 
 function row(s) {
-  const statusBadge = s.running
-    ? '<span class="side-buy">running</span>'
-    : '<span class="conn">stopped</span>';
+  const status = s.running
+    ? '<span class="run-pill is-running"><span class="dot"></span>running</span>'
+    : '<span class="run-pill is-stopped"><span class="dot"></span>stopped</span>';
   const action = s.running
-    ? `<button data-name="${s.name}" data-act="stop">Stop</button>`
-    : `<button data-name="${s.name}" data-act="start">Start</button>`;
-  const pnl = s.realised_pnl === null ? "—" : s.realised_pnl;
+    ? `<button data-name="${escapeHtml(s.name)}" data-act="stop" class="btn-stop">Stop</button>`
+    : `<button data-name="${escapeHtml(s.name)}" data-act="start" class="btn-start">Start</button>`;
+  const pnl = s.realised_pnl === null ? '<span class="conn">—</span>' : escapeHtml(s.realised_pnl);
   return `<tr>
-    <td>${s.name}</td>
-    <td>${s.kind}</td>
-    <td>${modeSelect(s)}</td>
-    <td>${statusBadge}</td>
+    <td>${escapeHtml(s.name)}</td>
+    <td>${escapeHtml(s.kind)}</td>
+    <td><span class="badge badge-${s.mode}">${s.mode}</span> ${modeSelect(s)}</td>
+    <td>${status}</td>
     <td class="num">${pnl}</td>
     <td class="num">${s.open_orders}</td>
     <td>${action}</td>
@@ -60,13 +76,28 @@ async function refresh() {
   try {
     const list = await api("/api/strategies");
     setConn(true);
-    if (!list.length) {
-      body.innerHTML = '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
-      return;
-    }
-    body.innerHTML = list.map(row).join("");
+    sumTotal.textContent = list.length;
+    sumRunning.textContent = list.filter((s) => s.running).length;
+    body.innerHTML = list.length
+      ? list.map(row).join("")
+      : '<tr class="empty"><td colspan="7">No strategies declared.</td></tr>';
   } catch (e) {
     setConn(false);
+  }
+}
+
+async function setMode(name, mode, confirm) {
+  try {
+    await api(`/api/strategies/${encodeURIComponent(name)}/mode`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mode, confirm: !!confirm }),
+    });
+    flash(`${name}: mode → ${mode}`, false);
+  } catch (e) {
+    flash(`${name}: ${e.message}`, true);
+  } finally {
+    await refresh();
   }
 }
 
@@ -85,37 +116,53 @@ async function onClick(ev) {
   }
 }
 
-async function onModeChange(ev) {
+function onModeChange(ev) {
   const sel = ev.target.closest("select.mode-select");
   if (!sel) return;
   const name = sel.dataset.name;
   const mode = sel.value;
-  let confirm = false;
   if (mode === "live") {
-    // Real money — deliberate, typed acknowledgement (the server also enforces it).
-    const typed = window.prompt(
-      `Switch "${name}" to LIVE (REAL MONEY)?\nType I UNDERSTAND to confirm:`
-    );
-    if (typed !== "I UNDERSTAND") {
-      flash(`${name}: live switch cancelled`, true);
-      await refresh();
-      return;
-    }
-    confirm = true;
+    openLiveModal(name); // deliberate, typed acknowledgement
+    return;
   }
-  try {
-    await api(`/api/strategies/${encodeURIComponent(name)}/mode`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ mode, confirm }),
-    });
-    flash(`${name}: mode → ${mode}`, false);
-  } catch (e) {
-    flash(`${name}: ${e.message}`, true);
-  } finally {
-    await refresh();
-  }
+  setMode(name, mode, false); // paper / testnet — no confirmation
 }
+
+// --- live confirmation modal ---------------------------------------------- //
+
+function openLiveModal(name) {
+  pendingLive = { name };
+  modalName.textContent = name;
+  modalInput.value = "";
+  modalConfirm.disabled = true;
+  modal.classList.add("open");
+  modalInput.focus();
+}
+
+function closeLiveModal() {
+  modal.classList.remove("open");
+  pendingLive = null;
+  refresh(); // re-render so a cancelled select reverts to the server's mode
+}
+
+modalInput.addEventListener("input", () => {
+  modalConfirm.disabled = modalInput.value.trim() !== PHRASE;
+});
+modalInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" && !modalConfirm.disabled) modalConfirm.click();
+  if (e.key === "Escape") closeLiveModal();
+});
+modalConfirm.addEventListener("click", async () => {
+  const name = pendingLive && pendingLive.name;
+  modal.classList.remove("open");
+  if (name) await setMode(name, "live", true);
+  pendingLive = null;
+});
+modalCancel.addEventListener("click", () => {
+  flash(`${pendingLive ? pendingLive.name : ""}: live switch cancelled`, true);
+  closeLiveModal();
+});
+modal.addEventListener("click", (e) => { if (e.target === modal) closeLiveModal(); });
 
 body.addEventListener("click", onClick);
 body.addEventListener("change", onModeChange);

--- a/trading_bot/interfaces/ui/static/style.css
+++ b/trading_bot/interfaces/ui/static/style.css
@@ -139,6 +139,30 @@ footer a { color: var(--muted); }
 }
 .chip b { color: var(--fg); font-weight: 600; }
 
+/* Sign-out in the control header. */
+.logout-form { margin: 0; }
+.logout-btn {
+  font-size: .76rem; color: var(--muted); background: transparent;
+  border: 1px solid var(--border); border-radius: 7px; padding: .28rem .65rem;
+}
+.logout-btn:hover { color: var(--err); border-color: rgba(248,81,73,.45); background: var(--err-soft); }
+
+/* Login page — centred card. */
+.login-body { display: flex; min-height: 100vh; align-items: center; justify-content: center; }
+.login-card { width: min(92vw, 360px); }
+.login-card h2 {
+  margin: 0 0 1rem; font-size: .82rem; font-weight: 700; letter-spacing: .12em;
+  text-transform: uppercase; color: var(--muted);
+}
+.login-card label { display: block; font-size: .82rem; color: var(--muted); margin-bottom: .35rem; }
+.login-card input[type="password"] {
+  width: 100%; font: inherit; color: var(--fg); font-family: ui-monospace, monospace;
+  background: var(--bg); border: 1px solid var(--border); border-radius: 8px;
+  padding: .6rem .7rem;
+}
+.login-card input[type="password"]:focus { outline: none; border-color: var(--accent); }
+.login-err { margin: .9rem 0 0; color: var(--err); font-size: .85rem; }
+
 /* Exchange group-header row in the strategies table. */
 tr.group td {
   background: var(--accent-soft);

--- a/trading_bot/interfaces/ui/static/style.css
+++ b/trading_bot/interfaces/ui/static/style.css
@@ -114,3 +114,97 @@ footer a { color: var(--muted); }
   .topbar { padding: .55rem .8rem; }
   main { padding: .9rem .7rem; }
 }
+
+/* ===========================================================================
+   Control plane — summary, mode badges, buttons, the live-confirm modal.
+   (Aligned with dccd's palette + pill/badge language; fonts fall back to the
+   system stack, no shipped assets.)
+   =========================================================================== */
+
+:root {
+  --font-display: "Martian Mono", ui-monospace, "SF Mono", monospace;
+  --accent-soft: rgba(94, 162, 255, .12);
+  --warn-soft: rgba(214, 161, 50, .14);
+  --err-soft: rgba(248, 81, 73, .12);
+  --ok-soft: rgba(63, 185, 80, .14);
+}
+.brand { font-family: var(--font-display); }
+
+/* A small summary chip set in the header (N strategies · M running). */
+.summary { display: inline-flex; gap: .4rem; align-items: center; margin-right: auto; }
+.chip {
+  font-size: .76rem; color: var(--muted);
+  border: 1px solid var(--border); border-radius: 999px;
+  padding: .2rem .6rem; font-variant-numeric: tabular-nums;
+}
+.chip b { color: var(--fg); font-weight: 600; }
+
+/* Mode badge — paper (calm), testnet (amber), live (red, emphasised). */
+.badge {
+  display: inline-block; font-size: .68rem; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .09em;
+  padding: .18rem .5rem; border-radius: 999px; border: 1px solid var(--border);
+}
+.badge-paper   { color: var(--accent); border-color: rgba(94,162,255,.4); background: var(--accent-soft); }
+.badge-testnet { color: var(--warn);   border-color: rgba(214,161,50,.45); background: var(--warn-soft); }
+.badge-live    { color: var(--err);    border-color: rgba(248,81,73,.5);   background: var(--err-soft); }
+
+/* Running / stopped pill with a status dot. */
+.run-pill { display: inline-flex; align-items: center; gap: .4rem; font-size: .8rem; }
+.run-pill .dot { width: .5rem; height: .5rem; border-radius: 50%; background: var(--muted); }
+.run-pill.is-running { color: var(--ok); }
+.run-pill.is-running .dot { background: var(--ok); box-shadow: 0 0 5px var(--ok); }
+.run-pill.is-stopped { color: var(--muted); }
+
+/* Buttons + the mode <select>. */
+button, .btn {
+  font: inherit; font-size: .82rem; cursor: pointer; color: var(--fg);
+  background: var(--card); border: 1px solid var(--border); border-radius: 7px;
+  padding: .32rem .8rem; transition: background .12s, border-color .12s, color .12s;
+}
+button:hover { background: var(--border); }
+button:disabled { opacity: .5; cursor: not-allowed; }
+button.btn-start { color: var(--ok); border-color: rgba(63,185,80,.45); }
+button.btn-start:hover { background: var(--ok-soft); }
+button.btn-stop { color: var(--err); border-color: rgba(248,81,73,.45); }
+button.btn-stop:hover { background: var(--err-soft); }
+button.btn-primary { color: #08110a; background: var(--ok); border-color: var(--ok); font-weight: 700; }
+button.btn-primary:hover { filter: brightness(1.08); background: var(--ok); }
+
+select.mode-select {
+  font: inherit; font-size: .8rem; color: var(--fg);
+  background: var(--bg); border: 1px solid var(--border); border-radius: 7px;
+  padding: .28rem 1.6rem .28rem .55rem; cursor: pointer;
+  appearance: none;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--muted) 50%),
+    linear-gradient(135deg, var(--muted) 50%, transparent 50%);
+  background-position: right .85rem center, right .6rem center;
+  background-size: 5px 5px, 5px 5px; background-repeat: no-repeat;
+}
+select.mode-select:focus { outline: none; border-color: var(--accent); }
+
+/* Modal — the deliberate "go live" confirmation. */
+.modal {
+  position: fixed; inset: 0; display: none; z-index: 50;
+  align-items: center; justify-content: center;
+  background: rgba(4, 7, 12, .68); backdrop-filter: blur(2px);
+}
+.modal.open { display: flex; }
+.modal-card {
+  background: var(--card); border: 1px solid var(--border);
+  border-top: 3px solid var(--err);
+  border-radius: 12px; padding: 1.3rem 1.4rem; max-width: 420px; width: calc(100% - 2rem);
+  box-shadow: 0 18px 50px rgba(0, 0, 0, .55);
+}
+.modal-card h3 { margin: 0 0 .5rem; font-size: 1rem; }
+.modal-card h3 .warn-mark { color: var(--err); }
+.modal-card p { color: var(--muted); margin: .35rem 0 .9rem; }
+.modal-card code { color: var(--fg); background: var(--err-soft); padding: 0 .3rem; border-radius: 4px; }
+.modal-card input {
+  width: 100%; font: inherit; color: var(--fg);
+  background: var(--bg); border: 1px solid var(--border); border-radius: 7px;
+  padding: .5rem .6rem; margin-bottom: 1rem; font-family: ui-monospace, monospace;
+}
+.modal-card input:focus { outline: none; border-color: var(--err); }
+.modal-actions { display: flex; gap: .6rem; justify-content: flex-end; }

--- a/trading_bot/interfaces/ui/static/style.css
+++ b/trading_bot/interfaces/ui/static/style.css
@@ -139,6 +139,21 @@ footer a { color: var(--muted); }
 }
 .chip b { color: var(--fg); font-weight: 600; }
 
+/* Exchange group-header row in the strategies table. */
+tr.group td {
+  background: var(--accent-soft);
+  border-bottom: 1px solid var(--border);
+  padding: .4rem .6rem;
+}
+tr.group .group-name {
+  font-family: var(--font-display); font-weight: 700; font-size: .74rem;
+  text-transform: uppercase; letter-spacing: .1em; color: var(--accent);
+}
+tr.group .group-count {
+  margin-left: .5rem; color: var(--muted); font-size: .72rem;
+  font-variant-numeric: tabular-nums;
+}
+
 /* Mode badge — paper (calm), testnet (amber), live (red, emphasised). */
 .badge {
   display: inline-block; font-size: .68rem; font-weight: 700;

--- a/trading_bot/interfaces/ui/templates/control.html
+++ b/trading_bot/interfaces/ui/templates/control.html
@@ -8,13 +8,17 @@
 </head>
 <body>
   <!-- Control plane: lists the daemon's managed strategies and lets you start /
-       stop them and switch mode (paper / testnet / live). Switching to LIVE asks
-       for a typed confirmation; all state is fetched/changed via /api/strategies. -->
+       stop them and switch mode (paper / testnet / live). Switching to LIVE opens
+       a typed confirmation; all state is fetched/changed via /api/strategies. -->
   <header class="topbar">
     <div class="brand-group">
       <span class="brand">trading_bot</span>
       <span class="ver">v{{ version }}</span>
     </div>
+    <span class="summary">
+      <span class="chip"><b id="sum-total">—</b> strategies</span>
+      <span class="chip"><b id="sum-running">—</b> running</span>
+    </span>
     <span class="mode-badge mode-paper">control</span>
     <span id="conn" class="conn"><span class="dot"></span>connecting…</span>
   </header>
@@ -48,6 +52,22 @@
     trading_bot v{{ version }} — control plane (loopback). Switching to <b>live</b>
     trades real money and requires a typed confirmation.
   </footer>
+
+  <!-- Live confirmation modal: the deliberate "go real money" acknowledgement. -->
+  <div id="live-modal" class="modal" role="dialog" aria-modal="true" aria-labelledby="live-modal-title">
+    <div class="modal-card">
+      <h3 id="live-modal-title"><span class="warn-mark">⚠</span> Switch to LIVE — real money</h3>
+      <p>
+        You are about to switch <b id="live-modal-name">—</b> to <b>live</b>. This
+        trades <b>real money</b> on the venue. Type <code>I UNDERSTAND</code> to confirm.
+      </p>
+      <input id="live-modal-input" type="text" placeholder="I UNDERSTAND" autocomplete="off" spellcheck="false">
+      <div class="modal-actions">
+        <button id="live-modal-cancel" type="button">Cancel</button>
+        <button id="live-modal-confirm" class="btn-primary" type="button" disabled>Go live</button>
+      </div>
+    </div>
+  </div>
 
   <script src="/static/control.js"></script>
 </body>

--- a/trading_bot/interfaces/ui/templates/control.html
+++ b/trading_bot/interfaces/ui/templates/control.html
@@ -21,6 +21,11 @@
     </span>
     <span class="mode-badge mode-paper">control</span>
     <span id="conn" class="conn"><span class="dot"></span>connecting…</span>
+    {% if auth %}
+    <form method="post" action="/logout" class="logout-form">
+      <button type="submit" class="logout-btn">sign out</button>
+    </form>
+    {% endif %}
   </header>
 
   <main>

--- a/trading_bot/interfaces/ui/templates/login.html
+++ b/trading_bot/interfaces/ui/templates/login.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>trading_bot — sign in</title>
+  <link rel="stylesheet" href="/static/style.css">
+</head>
+<body class="login-body">
+  <form class="login-card card" method="post" action="/login" autocomplete="off">
+    <div class="brand-group" style="margin-bottom: 1rem;">
+      <span class="brand">trading_bot</span>
+      <span class="ver">v{{ version }}</span>
+    </div>
+    <h2>Control — sign in</h2>
+    <input type="hidden" name="next" value="{{ next }}">
+    <label for="token">Access token</label>
+    <input id="token" name="token" type="password" autocomplete="current-password" autofocus spellcheck="false">
+    <button class="btn-primary" type="submit" style="width: 100%; margin-top: .9rem;">Sign in</button>
+    {% if error %}<p class="login-err">{{ error }}</p>{% endif %}
+  </form>
+</body>
+</html>

--- a/trading_bot/tests/application/test_supervisor.py
+++ b/trading_bot/tests/application/test_supervisor.py
@@ -136,7 +136,43 @@ async def test_testnet_without_a_broker_is_refused() -> None:
         _config(with_broker=False),
         dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(_trend())}),
     )
-    with pytest.raises(ConfigError, match="without a configured broker"):
+    with pytest.raises(ConfigError, match="no matching broker"):
+        await sup.set_mode("btc-ma", "testnet")
+
+
+def test_status_includes_the_strategys_exchange() -> None:
+    """Each unit reports the exchange it's for (a strategy's ``data.exchange``)."""
+    sup = _supervisor()
+    assert sup.status("btc-ma")[0].exchange == "kraken"
+
+
+async def test_set_mode_refused_when_no_broker_for_that_exchange() -> None:
+    """testnet/live needs a broker **matching the unit's exchange**, not just any broker.
+
+    The strategy is on Kraken (`data.exchange`), but only a Binance broker is
+    configured — switching it to testnet must be refused (per-exchange routing).
+    """
+    cfg = AppConfig.model_validate(
+        {
+            "mode": "paper",
+            "brokers": [{"name": "bn", "exchange": "binance"}],  # no kraken broker
+            "strategies": [
+                {
+                    "name": "btc-ma",
+                    "symbol": "BTC/USD",
+                    "data": {"exchange": "kraken", "span": 60},
+                    "signal": {"ref": "ma_crossover", "params": {"fast": 3, "slow": 6}},
+                    "reference_qty": "2",
+                    "lookback": 6,
+                }
+            ],
+        }
+    )
+    sup = StrategySupervisor(
+        cfg, dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(_trend())})
+    )
+    assert sup.status("btc-ma")[0].exchange == "kraken"
+    with pytest.raises(ConfigError, match="no matching broker"):
         await sup.set_mode("btc-ma", "testnet")
 
 

--- a/trading_bot/tests/interfaces/test_control_api.py
+++ b/trading_bot/tests/interfaces/test_control_api.py
@@ -78,6 +78,7 @@ def test_list_strategies() -> None:
     assert resp.status_code == 200
     [s] = resp.json()
     assert s["name"] == "btc-ma"
+    assert s["exchange"] == "kraken"  # grouped/displayed by exchange
     assert s["mode"] == "paper"
     assert s["running"] is False
     assert s["realised_pnl"] is None

--- a/trading_bot/tests/interfaces/test_control_api.py
+++ b/trading_bot/tests/interfaces/test_control_api.py
@@ -152,3 +152,75 @@ def test_start_then_stop() -> None:
     r = client.post("/api/strategies/btc-ma/stop")
     assert r.status_code == 200
     assert r.json()["status"]["running"] is False
+
+
+# --- auth (token login, for remote exposure) ------------------------------- #
+
+
+def _auth_client(token: str = "secret-token") -> tuple[TestClient, str]:
+    trend = [100.0 + i for i in range(20)] + [119.0 - i for i in range(1, 21)]
+    sup = StrategySupervisor(
+        _config(), dccd_client=_FakeDccdClient({"BTC/USD": _dccd_ohlc(trend)})
+    )
+    return TestClient(create_control_app(sup, auth_token=token)), token
+
+
+def test_no_token_means_no_auth() -> None:
+    """Default (no `auth_token`) — the app is open (loopback/tunnel use)."""
+    assert _client().get("/api/strategies").status_code == 200
+
+
+def test_auth_api_requires_a_token() -> None:
+    """With auth on, an unauthenticated `/api/*` call is 401."""
+    client, _ = _auth_client()
+    assert client.get("/api/strategies").status_code == 401
+
+
+def test_auth_bearer_and_query_token_work() -> None:
+    """`/api/*` accepts a Bearer header or `?token=` (non-browser clients)."""
+    client, token = _auth_client()
+    assert client.get(
+        "/api/strategies", headers={"Authorization": f"Bearer {token}"}
+    ).status_code == 200
+    assert client.get(f"/api/strategies?token={token}").status_code == 200
+
+
+def test_auth_page_redirects_to_login() -> None:
+    """An unauthenticated page request redirects to /login."""
+    client, _ = _auth_client()
+    r = client.get("/", follow_redirects=False)
+    assert r.status_code == 303
+    assert "/login" in r.headers["location"]
+
+
+def test_auth_login_flow_sets_session_cookie() -> None:
+    """A correct token at /login mints a session cookie that authenticates; logout clears it."""
+    client, token = _auth_client()
+    assert client.get("/login").status_code == 200  # the form is open
+
+    bad = client.post(
+        "/login", data={"token": "nope", "next": "/"}, follow_redirects=False
+    )
+    assert bad.status_code == 401
+    assert client.get("/api/strategies").status_code == 401  # still no session
+
+    ok = client.post(
+        "/login", data={"token": token, "next": "/"}, follow_redirects=False
+    )
+    assert ok.status_code == 303
+    assert client.get("/api/strategies").status_code == 200  # session cookie works
+
+    client.post("/logout", follow_redirects=False)
+    assert client.get("/api/strategies").status_code == 401  # cleared
+
+
+def test_auth_login_is_rate_limited() -> None:
+    """Repeated login attempts are throttled (429) — brute-force guard."""
+    client, _ = _auth_client()
+    statuses = [
+        client.post(
+            "/login", data={"token": "x", "next": "/"}, follow_redirects=False
+        ).status_code
+        for _ in range(20)
+    ]
+    assert 429 in statuses

--- a/trading_bot/tests/interfaces/test_control_api.py
+++ b/trading_bot/tests/interfaces/test_control_api.py
@@ -122,6 +122,23 @@ def test_unknown_mode_is_400() -> None:
     assert r.status_code == 400
 
 
+def test_control_dashboard_renders() -> None:
+    """`GET /` returns the control dashboard shell (brand + table + live modal)."""
+    resp = _client().get("/")
+    assert resp.status_code == 200
+    html = resp.text
+    assert "trading_bot" in html
+    assert 'id="strategies-body"' in html  # the table control.js fills
+    assert 'id="live-modal"' in html  # the deliberate go-live confirmation
+
+
+def test_control_js_is_served() -> None:
+    """The control dashboard's script is served and carries the confirm phrase."""
+    resp = _client().get("/static/control.js")
+    assert resp.status_code == 200
+    assert "I UNDERSTAND" in resp.text
+
+
 def test_start_then_stop() -> None:
     """`POST start` runs the strategy in its own engine; `POST stop` tears it down."""
     pytest.importorskip("fynance")  # ma_crossover evaluates fynance.sma


### PR DESCRIPTION
> This PR will be merged into `master` **after** `chore/release-0.7.0` (#104) lands in `develop`. Tagged `v0.7.0` on merge.


### Added

- **Control dashboard authentication (for remote access).** `create_control_app(...,
  auth_token=…)` gates the dashboard behind a **token login** (dccd-style): `/login`
  exchanges the token for an HttpOnly, `Secure`-over-HTTPS session cookie; an auth-guard
  middleware refuses unauthenticated requests (`401` for `/api/*`, redirect to `/login`
  for pages); login is **rate-limited**; `/api/*` also accepts `Bearer <token>` / `?token=`
  for scripts; constant-time token check; a **sign-out** in the header. `trading-bot start
  --serve --serve-token …` (or `TRADING_BOT_UI_TOKEN`) enables it and **refuses a
  non-loopback bind without a token**. With no token (default) the app stays open —
  loopback / SSH-tunnel only. `doc/dev/10-deploy.md` covers the token + HTTPS reverse
  proxy. (#102)

### Changed

- **Control dashboard groups strategies by exchange**, and each strategy now uses the
  **broker matching its own venue** on testnet/live (`StrategyStatus.exchange`; a
  strategy's `data.exchange` / a portfolio's `venue`). Switching to testnet/live is
  refused if no broker is configured for that exchange. (#101)

- **Control dashboard visual pass** — mode **badges** (paper/testnet/live, colour-coded),
  a running/stopped status pill, start/stop buttons styled by action, a header summary
  (N strategies · M running), and a proper **typed-confirmation modal** for going live
  (replaces the browser `prompt`). Aligned with dccd's dark palette/pill language; no
  shipped font assets. (#100)

### Fixed

- **CI was red since the daemon landed** — `apscheduler` was in the `daemon` extra but
  missing from `dev`, while the daemon test (`test_daemon_starts_ticks_and_stops_cleanly`)
  drives `_run_daemon`, which imports it. CI installs `.[dev]`, so it hit
  `ModuleNotFoundError: No module named 'apscheduler'` (masked locally by a dev env that
  also had `[daemon]`). Added `apscheduler` to the `dev` extra, like the other daemon
  runtime deps the suite already exercises. (#103)

### Deprecated

### Removed