### PR TITLE
feat: ALLOC1 portfolio config (Binance)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ALLOC1 portfolio config (Binance)** — wires the research allocator ALLOC1
+  (`../fynance-research/DEPLOY_ALLOC1.md`: a dynamic regime-aware blend of LS2 / MN1 /
+  BEAR1 over a 14-coin Binance USDT universe) by config + a thin generic adapter, exactly
+  like LS1. Adds `strategies/alloc1/{binance.yaml, signal.py, test_e2e.py}`: the signal
+  wrapper adapts `fynance_research.strategies.alloc1_live.target_weights("binance")` to the
+  `PortfolioSignalFn` contract (research imported lazily), the paper config declares the
+  14-coin portfolio, and the wiring test proves the config validates + the signal ref
+  resolves offline. Paper-only; no engine code changed. Kraken is deliberately omitted (an
+  open research+data task — MN1 needs SOL/ADA/LINK-USD on Kraken + a 0.26% re-validation).
+
 ### Changed
 
 - **Private read-only endpoints validated live on mainnet for both venues** — the


### PR DESCRIPTION
Wires the research allocator **ALLOC1** (`../fynance-research/DEPLOY_ALLOC1.md` — a dynamic regime-aware blend of LS2 / MN1 / BEAR1 over a 14-coin Binance USDT universe) into `trading_bot` by **config + a thin generic adapter**, exactly like LS1. No engine code changed.

- `strategies/alloc1/signal.py` — adapts `fynance_research.strategies.alloc1_live.target_weights("binance")` to the `PortfolioSignalFn` contract via the generic `as_portfolio_signal`; `fynance_research` imported **lazily** (config resolution stays research-free).
- `strategies/alloc1/binance.yaml` — paper portfolio over the 14 `*-USDT` coins. `gross_cap` is reference-only (ALLOC1's signal, unlike LS1, does not hard-cap gross).
- `strategies/alloc1/test_e2e.py` — offline wiring test: the config validates and the signal ref resolves without the research package.

Verified end-to-end: the adapted signal evaluates to the 14-coin `Symbol→Money` weight vector, matching the research oracle (gross 0.50, net −0.26 in the current bear regime). Paper-only.

**Kraken deliberately omitted** — an open research+data task (MN1 needs SOL/ADA/LINK-USD on Kraken + a 0.26% re-validation); filed on the dccd + fynance-research roadmaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)