### PR TITLE
fix: Binance testnet reads BINANCE_TESTNET_* credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Binance testnet now authenticates with testnet credentials.** The engine's
+  testnet path (`testnet: true` on a Binance broker) hard-pinned the testnet URL
+  but still read the default `BINANCE_API_KEY` / `BINANCE_API_SECRET` — which, once
+  separate mainnet + testnet keys coexist in `.env`, is the **mainnet** key and is
+  rejected by `testnet.binance.vision` (`-2015`). It now reads
+  `BINANCE_TESTNET_API_KEY` / `BINANCE_TESTNET_API_SECRET` (falling back to the
+  generic pair for the older single-key setup). Verified read-only against real
+  Binance testnet via `build_engine` (balances). (#108)
+
 ### Deprecated
 
 ### Removed

--- a/doc/dev/03-decisions.md
+++ b/doc/dev/03-decisions.md
@@ -6,6 +6,21 @@ rejected approaches as tombstones.
 
 ---
 
+### 2026-07-01 Binance testnet reads `BINANCE_TESTNET_*` credentials (PR #108)  [accepted]
+- **Choice**: the testnet adapter built by `_build_testnet_venue("binance")` now
+  reads `BINANCE_TESTNET_API_KEY` / `BINANCE_TESTNET_API_SECRET`, falling back to
+  the generic `BINANCE_API_KEY` / `BINANCE_API_SECRET`. The URL was already
+  hard-pinned to `testnet.binance.vision`; only the credential source changed.
+- **Why**: mainnet and testnet are **distinct** Binance credentials — a mainnet
+  key is rejected by the testnet endpoint with `-2015`. Once mainnet + testnet keys
+  coexist in `.env`, the testnet path must pick the testnet pair, not the default
+  `BINANCE_API_KEY` (which is now mainnet). The fallback preserves the older
+  single-key setup where the only Binance key *was* the testnet one.
+- **Rejected alternatives**: (a) a per-broker `credentials_env` config field —
+  more config surface for a convention that can be derived; (b) requiring the user
+  to overwrite `BINANCE_API_KEY` with the testnet key when testing — brittle and
+  makes mainnet reads (validated read-only) impossible at the same time.
+
 ### 2026-06-30 Control dashboard auth — token login + sessions (dccd-style) (PR #102)  [accepted]
 
 **Choice.** The control dashboard gains an **optional** token auth (off by default):

--- a/trading_bot/application/service_factory.py
+++ b/trading_bot/application/service_factory.py
@@ -48,6 +48,7 @@ name the simulator explicitly.
 
 from __future__ import annotations
 
+import os
 import pathlib
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
@@ -368,20 +369,45 @@ def _build_live_venue(venue: str) -> _LiveBroker:
     raise BrokerError(f"no live adapter for venue {venue!r}")
 
 
+def _binance_testnet_credentials() -> tuple[str, str]:
+    """The Binance **testnet** key/secret, from the environment.
+
+    Testnet and mainnet are distinct credentials (a mainnet key is rejected by
+    ``testnet.binance.vision`` with ``-2015``), so the testnet adapter reads the
+    **testnet-specific** ``BINANCE_TESTNET_API_KEY`` / ``BINANCE_TESTNET_API_SECRET``
+    first, falling back to the generic ``BINANCE_API_KEY`` / ``BINANCE_API_SECRET``
+    for the older single-key setup where the only Binance key *was* the testnet one.
+    Returns ``("", "")`` when absent (the caller's ``has_credentials`` gate refuses).
+    """
+    key = os.environ.get("BINANCE_TESTNET_API_KEY") or os.environ.get(
+        "BINANCE_API_KEY", ""
+    )
+    secret = os.environ.get("BINANCE_TESTNET_API_SECRET") or os.environ.get(
+        "BINANCE_API_SECRET", ""
+    )
+    return key, secret
+
+
 def _build_testnet_venue(venue: str) -> _LiveBroker:
     """Construct a venue's **testnet** adapter, hard-pinned to its sandbox URL.
 
     Only venues in :data:`_TESTNET_VENUES` have a testnet. The base URL is forced
     to the venue's testnet endpoint (passed explicitly, so any ``BINANCE_API_BASE``
     env value is overridden) — the adapter can therefore never reach mainnet, which
-    is why the caller skips the ``live_enabled`` opt-in for it. Credentials are
-    still read from the environment (testnet keys). A venue with no testnet (e.g.
-    Kraken, which has no public spot sandbox) raises.
+    is why the caller skips the ``live_enabled`` opt-in for it. Credentials are the
+    venue's **testnet** keys (``BINANCE_TESTNET_*``, falling back to ``BINANCE_*``);
+    see :func:`_binance_testnet_credentials`. A venue with no testnet (e.g. Kraken,
+    which has no public spot sandbox) raises.
     """
     if venue == "binance":
         # Hard-pin the testnet base URL (explicit arg overrides the env default),
-        # so this adapter is structurally incapable of hitting api.binance.com.
-        return BinanceBroker(base_url=TESTNET_API_BASE)
+        # so this adapter is structurally incapable of hitting api.binance.com, and
+        # feed it the *testnet* credentials (not the mainnet key, which testnet
+        # rejects with -2015).
+        key, secret = _binance_testnet_credentials()
+        return BinanceBroker(
+            api_key=key, api_secret=secret, base_url=TESTNET_API_BASE
+        )
     raise BrokerError(
         f"venue {venue!r} has no testnet/sandbox; testnet is available for "
         f"{sorted(_TESTNET_VENUES)!r} only (Kraken has no public spot testnet — "

--- a/trading_bot/tests/application/test_service_factory.py
+++ b/trading_bot/tests/application/test_service_factory.py
@@ -419,14 +419,41 @@ def test_testnet_hard_pins_url_ignoring_mainnet_env(monkeypatch) -> None:
 
 def test_testnet_without_credentials_refuses(monkeypatch) -> None:
     """Testnet still needs (testnet) credentials → ``BrokerError`` without them."""
-    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
-    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    for var in (
+        "BINANCE_API_KEY",
+        "BINANCE_API_SECRET",
+        "BINANCE_TESTNET_API_KEY",
+        "BINANCE_TESTNET_API_SECRET",
+    ):
+        monkeypatch.delenv(var, raising=False)
     cfg = AppConfig(
         mode="live",
         brokers=[BrokerConfig(name="bn", exchange="binance", testnet=True)],
     )
     with pytest.raises(BrokerError, match="credentials"):
         build_engine(cfg)
+
+
+def test_testnet_uses_testnet_specific_credentials(monkeypatch) -> None:
+    """The testnet adapter reads ``BINANCE_TESTNET_*`` — not the mainnet key.
+
+    Mainnet and testnet are distinct credentials (a mainnet key is rejected by
+    ``testnet.binance.vision``). With **only** the ``BINANCE_TESTNET_*`` pair set
+    (mainnet vars absent), the testnet broker must still report credentials — proof
+    it read the testnet-specific env vars, not ``BINANCE_API_KEY``.
+    """
+    monkeypatch.delenv("BINANCE_API_KEY", raising=False)
+    monkeypatch.delenv("BINANCE_API_SECRET", raising=False)
+    monkeypatch.setenv("BINANCE_TESTNET_API_KEY", "tk")
+    monkeypatch.setenv("BINANCE_TESTNET_API_SECRET", "ts")
+    cfg = AppConfig(
+        mode="live",
+        brokers=[BrokerConfig(name="bn", exchange="binance", testnet=True)],
+    )
+    engine = build_engine(cfg)
+    assert isinstance(engine.broker, BinanceBroker)
+    assert engine.broker.is_testnet
+    assert engine.broker.has_credentials  # read from BINANCE_TESTNET_*
 
 
 def test_testnet_kraken_refuses() -> None:

--- a/trading_bot/tests/brokers/test_binance_rest.py
+++ b/trading_bot/tests/brokers/test_binance_rest.py
@@ -786,21 +786,29 @@ async def test_real_binance_testnet_round_trip(
 ) -> None:
     """Place → read back → cancel a far-from-market LIMIT on the Binance testnet.
 
-    Skips unless ``BINANCE_API_KEY`` / ``BINANCE_API_SECRET`` are present
-    (testnet keys from https://testnet.binance.vision). Points ``base_url`` at
-    the testnet, places a tiny LIMIT order far below market (so it never fills),
-    reads it back via ``open_orders`` (asserting the broker-reported state
-    matches what was requested), then cancels it via the composite id.
+    Skips unless testnet credentials are present — ``BINANCE_TESTNET_API_KEY`` /
+    ``BINANCE_TESTNET_API_SECRET`` (falling back to ``BINANCE_API_KEY`` /
+    ``BINANCE_API_SECRET`` for the older single-key setup), from
+    https://testnet.binance.vision. Points ``base_url`` at the testnet, places a
+    tiny LIMIT order far below market (so it never fills), reads it back via
+    ``open_orders`` (asserting the broker-reported state matches what was
+    requested), then cancels it via the composite id.
     """
     import os
 
-    key = os.environ.get("BINANCE_API_KEY")
-    secret = os.environ.get("BINANCE_API_SECRET")
+    key = os.environ.get("BINANCE_TESTNET_API_KEY") or os.environ.get(
+        "BINANCE_API_KEY"
+    )
+    secret = os.environ.get("BINANCE_TESTNET_API_SECRET") or os.environ.get(
+        "BINANCE_API_SECRET"
+    )
     if not key or not secret:
         pytest.skip("no Binance testnet credentials in the environment")
 
     symbol = Symbol("BTC", "USDT")
-    broker = BinanceBroker(base_url=TESTNET_API_BASE, symbols=[symbol])
+    broker = BinanceBroker(
+        api_key=key, api_secret=secret, base_url=TESTNET_API_BASE, symbols=[symbol]
+    )
     inst = await broker.instrument(symbol)
     mark = await broker.ticker(inst)
 


### PR DESCRIPTION
## Summary
- The engine's **testnet** path (`testnet: true` on a Binance broker) hard-pinned the testnet URL but still read the default `BINANCE_API_KEY` / `BINANCE_API_SECRET`. Once **separate** mainnet + testnet keys coexist in `.env`, that default is the **mainnet** key — rejected by `testnet.binance.vision` with `-2015`.
- `_build_testnet_venue("binance")` now reads `BINANCE_TESTNET_API_KEY` / `BINANCE_TESTNET_API_SECRET` (falling back to the generic pair for the older single-key setup).

## Why
- Needed to run any strategy in **testnet ("live test")** mode now that mainnet keys are also present (mainnet reads were validated read-only in #106). See the ADR entry.

## Changes
- `application/service_factory.py`: `_binance_testnet_credentials()` helper + wire it into `_build_testnet_venue`.
- Tests: `test_testnet_uses_testnet_specific_credentials` (only `BINANCE_TESTNET_*` set → broker still has credentials); `test_testnet_without_credentials_refuses` now clears the testnet vars too; the `-m network` testnet round-trip reads the testnet keys.

## Verification on real data
- `build_engine(mode=live, testnet=true)` → `BinanceBroker` pinned to `testnet.binance.vision`, `balances()` returned **444 assets** (USDT 10000, BTC 1, BNB 1…). **Read-only; no order placed.**

## Test plan
- [x] `pytest` — 762 passed; `ruff` + `mypy` clean
- [ ] CI green